### PR TITLE
[codex] Fix and batch people image sync

### DIFF
--- a/app/admin/connectors/[id]/connector-app-mapping-tab.tsx
+++ b/app/admin/connectors/[id]/connector-app-mapping-tab.tsx
@@ -21,8 +21,16 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Label } from "@/components/ui/label"
 import { Database, Settings, ExternalLink, RefreshCw, Loader2, Plus, Edit, Trash2, Search, X, GitBranch, AlertCircle, ToggleLeft, ToggleRight } from "lucide-react"
 import { type Connector } from "@/lib/types/connector"
+import { buildRecordIdBatches } from "@/lib/sync/batch-utils"
 import { toast } from "sonner"
 import { StatusToggleDialog } from "@/components/ui/status-toggle-dialog"
+
+const PEOPLE_IMAGE_BATCH_SIZE = 100
+const PEOPLE_IMAGE_BATCH_DELAY_MS = 500
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
 
 interface AppMapping {
   id: string
@@ -171,6 +179,11 @@ export function ConnectorAppMappingTab({ connector, tenantId, connectionStatus, 
   const [savingMappings, setSavingMappings] = useState(false)
   const [loadingFields, setLoadingFields] = useState(false)
   const [syncingMapping, setSyncingMapping] = useState<string | null>(null)
+  const [syncProgress, setSyncProgress] = useState<Record<string, {
+    current: number
+    total: number
+    range: string
+  }>>({})
   
   const debouncedSearch = useDebounce(searchTerm, 300)
 
@@ -516,33 +529,104 @@ export function ConnectorAppMappingTab({ connector, tenantId, connectionStatus, 
     }
   }
 
-  const handleStartSync = async (mappingId: string) => {
-    try {
-      setSyncingMapping(mappingId)
-      
-      const response = await fetch(`/api/connectors/${connector.id}/sync`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          tenantId,
-          force: true,
-          appMappingId: mappingId
-        })
+  const fetchMaxRecordId = async (appMappingId: string): Promise<number> => {
+    const response = await fetch(`/api/connectors/${connector.id}/sync?appMappingId=${encodeURIComponent(appMappingId)}&metric=maxRecordId`)
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      throw new Error(errorData.error || 'Failed to fetch max Kintone record id')
+    }
+
+    const data = await response.json()
+    const maxRecordId = Number(data.maxRecordId)
+
+    if (!Number.isInteger(maxRecordId) || maxRecordId < 1) {
+      throw new Error('Kintone app has no syncable records')
+    }
+
+    return maxRecordId
+  }
+
+  const runSyncRequest = async (
+    mappingId: string,
+    range?: { from: number; to: number }
+  ) => {
+    const response = await fetch(`/api/connectors/${connector.id}/sync`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        tenantId,
+        force: true,
+        appMappingId: mappingId,
+        ...(range ? {
+          recordIdFrom: String(range.from),
+          recordIdTo: String(range.to)
+        } : {})
       })
-      
-      if (!response.ok) {
-        const errorData = await response.json()
-        throw new Error(errorData.error || 'Failed to start sync')
+    })
+
+    const result = await response.json().catch(() => ({}))
+
+    if (!response.ok) {
+      throw new Error(result.error || 'Failed to start sync')
+    }
+
+    if (result.success === false) {
+      const detail = Array.isArray(result.errors) && result.errors.length > 0
+        ? result.errors.join('; ')
+        : 'Sync completed with errors'
+      throw new Error(detail)
+    }
+
+    return result
+  }
+
+  const handlePeopleImageBatchSync = async (mapping: AppMapping) => {
+    const maxRecordId = await fetchMaxRecordId(mapping.id)
+    const batches = buildRecordIdBatches(1, maxRecordId, PEOPLE_IMAGE_BATCH_SIZE)
+    let totalSynced = 0
+
+    for (let index = 0; index < batches.length; index++) {
+      const batch = batches[index]
+      setSyncProgress(prev => ({
+        ...prev,
+        [mapping.id]: {
+          current: index + 1,
+          total: batches.length,
+          range: `${batch.from}-${batch.to}`
+        }
+      }))
+
+      const result = await runSyncRequest(mapping.id, batch)
+      totalSynced += Number(result.synced?.people_image || 0)
+
+      if (index < batches.length - 1) {
+        await sleep(PEOPLE_IMAGE_BATCH_DELAY_MS)
       }
-      
-      const result = await response.json()
+    }
+
+    toast.success('画像連携が完了しました', {
+      description: `${batches.length} batch / ${totalSynced}件を更新しました`
+    })
+  }
+
+  const handleStartSync = async (mapping: AppMapping) => {
+    try {
+      setSyncingMapping(mapping.id)
+
+      if (mapping.target_app_type === 'people_image') {
+        await handlePeopleImageBatchSync(mapping)
+        return
+      }
+
+      const result = await runSyncRequest(mapping.id)
       toast.success('連携を開始しました', {
-        description: 'データの同期処理が開始されました'
+        description: 'データの同期処理が完了しました'
       })
-      
-      console.log('Sync started:', result)
+
+      console.log('Sync completed:', result)
     } catch (error) {
       console.error('Error starting sync:', error)
       toast.error('連携の開始に失敗しました', {
@@ -550,6 +634,11 @@ export function ConnectorAppMappingTab({ connector, tenantId, connectionStatus, 
       })
     } finally {
       setSyncingMapping(null)
+      setSyncProgress(prev => {
+        const next = { ...prev }
+        delete next[mapping.id]
+        return next
+      })
     }
   }
 
@@ -1159,7 +1248,7 @@ export function ConnectorAppMappingTab({ connector, tenantId, connectionStatus, 
                           size="sm"
                           onClick={(e) => {
                             e.stopPropagation()
-                            handleStartSync(mapping.id)
+                            handleStartSync(mapping)
                           }}
                           disabled={syncingMapping === mapping.id}
                         >
@@ -1168,7 +1257,11 @@ export function ConnectorAppMappingTab({ connector, tenantId, connectionStatus, 
                           ) : (
                             <RefreshCw className="h-4 w-4 mr-1" />
                           )}
-                          {syncingMapping === mapping.id ? '連携中...' : '連携開始'}
+                          {syncingMapping === mapping.id
+                            ? (syncProgress[mapping.id]
+                              ? `連携中 ${syncProgress[mapping.id].current}/${syncProgress[mapping.id].total}`
+                              : '連携中...')
+                            : '連携開始'}
                         </Button>
                       )}
                       <Button

--- a/app/admin/connectors/[id]/connector-app-mapping-tab.tsx
+++ b/app/admin/connectors/[id]/connector-app-mapping-tab.tsx
@@ -573,7 +573,8 @@ export function ConnectorAppMappingTab({ connector, tenantId, connectionStatus, 
       throw new Error(result.error || 'Failed to start sync')
     }
 
-    if (result.success === false) {
+    const syncFailed = !result.success
+    if (syncFailed) {
       const detail = Array.isArray(result.errors) && result.errors.length > 0
         ? result.errors.join('; ')
         : 'Sync completed with errors'
@@ -622,7 +623,7 @@ export function ConnectorAppMappingTab({ connector, tenantId, connectionStatus, 
       }
 
       const result = await runSyncRequest(mapping.id)
-      toast.success('連携を開始しました', {
+      toast.success('連携が完了しました', {
         description: 'データの同期処理が完了しました'
       })
 

--- a/app/api/connectors/[id]/sync/route.ts
+++ b/app/api/connectors/[id]/sync/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { createSyncService } from '@/lib/sync/kintone-sync'
 import { getConnector, setConnectorStatus } from '@/lib/db/connectors'
 import { revalidatePath } from 'next/cache'
+import { createClient } from '@supabase/supabase-js'
 
 // Use Node.js runtime for crypto operations
 export const runtime = 'nodejs'
@@ -11,6 +12,11 @@ export const maxDuration = 300
 // Validation schema
 const kintoneRecordIdSchema = z.string().trim().regex(/^\d+$/, {
   message: 'Kintone record id must be numeric'
+})
+
+const syncMetadataQuerySchema = z.object({
+  appMappingId: z.string().min(1),
+  metric: z.literal('maxRecordId').default('maxRecordId')
 })
 
 const syncRequestSchema = z.object({
@@ -44,6 +50,92 @@ const syncRequestSchema = z.object({
     path: ['recordIdFrom']
   }
 )
+
+function getServerClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceKey) {
+    throw new Error('Missing Supabase configuration')
+  }
+
+  return createClient(supabaseUrl, serviceKey)
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const connectorId = params.id
+    const { searchParams } = new URL(request.url)
+    const { appMappingId } = syncMetadataQuerySchema.parse({
+      appMappingId: searchParams.get('appMappingId'),
+      metric: searchParams.get('metric') || 'maxRecordId'
+    })
+
+    const connector = await getConnector(connectorId)
+
+    if (!connector) {
+      return NextResponse.json(
+        { error: 'Connector not found' },
+        { status: 404 }
+      )
+    }
+
+    if (connector.provider !== 'kintone') {
+      return NextResponse.json(
+        { error: 'Only Kintone connectors support data sync' },
+        { status: 400 }
+      )
+    }
+
+    const supabase = getServerClient()
+    const { data: appMapping, error: appMappingError } = await supabase
+      .from('connector_app_mappings')
+      .select('source_app_id')
+      .eq('id', appMappingId)
+      .eq('connector_id', connectorId)
+      .eq('is_active', true)
+      .single()
+
+    if (appMappingError || !appMapping) {
+      return NextResponse.json(
+        { error: 'Active app mapping not found' },
+        { status: 404 }
+      )
+    }
+
+    const effectiveTenantId = connector.tenant_id || ''
+    const syncService = await createSyncService(connectorId, effectiveTenantId, 'manual')
+    const maxRecordId = await syncService.getMaxRecordId(appMapping.source_app_id)
+
+    return NextResponse.json({
+      success: true,
+      appMappingId,
+      sourceAppId: appMapping.source_app_id,
+      maxRecordId
+    })
+  } catch (error) {
+    console.error('Sync metadata request error:', error)
+
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        {
+          error: 'Validation failed',
+          details: error.errors
+        },
+        { status: 400 }
+      )
+    }
+
+    const errorMessage = error instanceof Error ? error.message : 'Internal server error'
+    return NextResponse.json(
+      { error: errorMessage },
+      { status: 500 }
+    )
+  }
+}
 
 export async function POST(
   request: NextRequest,

--- a/app/api/connectors/[id]/sync/route.ts
+++ b/app/api/connectors/[id]/sync/route.ts
@@ -9,10 +9,41 @@ export const runtime = 'nodejs'
 export const maxDuration = 300
 
 // Validation schema
+const kintoneRecordIdSchema = z.string().trim().regex(/^\d+$/, {
+  message: 'Kintone record id must be numeric'
+})
+
 const syncRequestSchema = z.object({
   force: z.boolean().optional(),
-  appMappingId: z.string().optional()
-})
+  appMappingId: z.string().optional(),
+  recordId: kintoneRecordIdSchema.optional(),
+  recordIdFrom: kintoneRecordIdSchema.optional(),
+  recordIdTo: kintoneRecordIdSchema.optional()
+}).refine(
+  (body) => {
+    const hasRecordFilter = !!body.recordId || !!body.recordIdFrom || !!body.recordIdTo
+    return !hasRecordFilter || !!body.appMappingId
+  },
+  {
+    message: 'appMappingId is required when syncing a specific Kintone record id',
+    path: ['appMappingId']
+  }
+).refine(
+  (body) => !body.recordId || (!body.recordIdFrom && !body.recordIdTo),
+  {
+    message: 'recordId cannot be combined with recordIdFrom or recordIdTo',
+    path: ['recordId']
+  }
+).refine(
+  (body) => {
+    if (!body.recordIdFrom || !body.recordIdTo) return true
+    return Number(body.recordIdFrom) <= Number(body.recordIdTo)
+  },
+  {
+    message: 'recordIdFrom must be less than or equal to recordIdTo',
+    path: ['recordIdFrom']
+  }
+)
 
 export async function POST(
   request: NextRequest,
@@ -23,7 +54,7 @@ export async function POST(
     const body = await request.json()
     
     // Validate input
-    const { force, appMappingId } = syncRequestSchema.parse(body)
+    const { force, appMappingId, recordId, recordIdFrom, recordIdTo } = syncRequestSchema.parse(body)
     
     // Get and validate connector
     const connector = await getConnector(connectorId)
@@ -57,14 +88,23 @@ export async function POST(
     try {
       // If tenantId is not provided, fall back to connector.tenant_id for tenantless/global connectors
       const effectiveTenantId = tenantId || connector.tenant_id || ''
-      console.log('[sync-api] start manual sync', { connectorId, tenantId, connectorTenant: connector.tenant_id, effectiveTenantId, appMappingId })
+      const syncOptions = { recordId, recordIdFrom, recordIdTo }
+      console.log('[sync-api] start manual sync', {
+        connectorId,
+        tenantId,
+        connectorTenant: connector.tenant_id,
+        effectiveTenantId,
+        appMappingId,
+        force,
+        ...syncOptions
+      })
       const syncService = await createSyncService(
         connectorId,
         effectiveTenantId,
         'manual',
         request.headers.get('x-user-id') || undefined
       )
-      const result = await syncService.syncAll(appMappingId)
+      const result = await syncService.syncAll(appMappingId, undefined, syncOptions)
       console.log('[sync-api] result', result)
       
       // Update connector status if there were errors

--- a/app/api/connectors/[id]/sync/route.ts
+++ b/app/api/connectors/[id]/sync/route.ts
@@ -6,6 +6,7 @@ import { revalidatePath } from 'next/cache'
 
 // Use Node.js runtime for crypto operations
 export const runtime = 'nodejs'
+export const maxDuration = 300
 
 // Validation schema
 const syncRequestSchema = z.object({

--- a/app/api/connectors/[id]/sync/route.ts
+++ b/app/api/connectors/[id]/sync/route.ts
@@ -7,7 +7,8 @@ import { createClient } from '@supabase/supabase-js'
 
 // Use Node.js runtime for crypto operations
 export const runtime = 'nodejs'
-export const maxDuration = 300
+const MAX_DURATION_SECONDS = 300
+export const maxDuration = MAX_DURATION_SECONDS
 
 // Validation schema
 const kintoneRecordIdSchema = z.string().trim().regex(/^\d+$/, {
@@ -25,31 +26,33 @@ const syncRequestSchema = z.object({
   recordId: kintoneRecordIdSchema.optional(),
   recordIdFrom: kintoneRecordIdSchema.optional(),
   recordIdTo: kintoneRecordIdSchema.optional()
-}).refine(
-  (body) => {
-    const hasRecordFilter = !!body.recordId || !!body.recordIdFrom || !!body.recordIdTo
-    return !hasRecordFilter || !!body.appMappingId
-  },
-  {
-    message: 'appMappingId is required when syncing a specific Kintone record id',
-    path: ['appMappingId']
+}).superRefine((body, ctx) => {
+  const hasRecordFilter = Boolean(body.recordId || body.recordIdFrom || body.recordIdTo)
+
+  if (hasRecordFilter && !body.appMappingId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'appMappingId is required when syncing a specific Kintone record id',
+      path: ['appMappingId']
+    })
   }
-).refine(
-  (body) => !body.recordId || (!body.recordIdFrom && !body.recordIdTo),
-  {
-    message: 'recordId cannot be combined with recordIdFrom or recordIdTo',
-    path: ['recordId']
+
+  if (body.recordId && (body.recordIdFrom || body.recordIdTo)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'recordId cannot be combined with recordIdFrom or recordIdTo',
+      path: ['recordId']
+    })
   }
-).refine(
-  (body) => {
-    if (!body.recordIdFrom || !body.recordIdTo) return true
-    return Number(body.recordIdFrom) <= Number(body.recordIdTo)
-  },
-  {
-    message: 'recordIdFrom must be less than or equal to recordIdTo',
-    path: ['recordIdFrom']
+
+  if (body.recordIdFrom && body.recordIdTo && Number(body.recordIdFrom) > Number(body.recordIdTo)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'recordIdFrom must be less than or equal to recordIdTo',
+      path: ['recordIdFrom']
+    })
   }
-)
+})
 
 function getServerClient() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL

--- a/app/api/cron/sync-by-type/route.ts
+++ b/app/api/cron/sync-by-type/route.ts
@@ -11,6 +11,7 @@ import { createClient } from '@supabase/supabase-js'
 
 // Use Node.js runtime for crypto operations
 export const runtime = 'nodejs'
+export const maxDuration = 300
 
 // Server-side Supabase client
 function getServerClient() {

--- a/app/api/cron/sync-by-type/route.ts
+++ b/app/api/cron/sync-by-type/route.ts
@@ -1,6 +1,6 @@
 /**
  * Scheduled data synchronization endpoint by target app type
- * POST /api/cron/sync-by-type?type=people|visas
+ * POST /api/cron/sync-by-type?type=people|people_image|visas
  * This endpoint is called by Vercel Cron Jobs for scheduled syncs by type
  */
 
@@ -50,9 +50,9 @@ async function handleSyncByType(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const targetAppType = searchParams.get('type')
     
-    if (!targetAppType || !['people', 'visas'].includes(targetAppType)) {
+    if (!targetAppType || !['people', 'people_image', 'visas'].includes(targetAppType)) {
       return NextResponse.json(
-        { error: 'Invalid or missing type parameter. Must be "people" or "visas"' },
+        { error: 'Invalid or missing type parameter. Must be "people", "people_image", or "visas"' },
         { status: 400 }
       )
     }

--- a/lib/kintone/api-client.test.ts
+++ b/lib/kintone/api-client.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildKintoneRecordsQuery } from './api-client'
+
+test('buildKintoneRecordsQuery adds default ordering and pagination to filter queries', () => {
+  assert.equal(
+    buildKintoneRecordsQuery('$id >= 1 and $id <= 100', 500, 0),
+    '$id >= 1 and $id <= 100 order by $id asc limit 500 offset 0'
+  )
+})
+
+test('buildKintoneRecordsQuery preserves explicit order and limit queries', () => {
+  assert.equal(
+    buildKintoneRecordsQuery('order by $id desc limit 1', 500, 0),
+    'order by $id desc limit 1'
+  )
+})
+
+test('buildKintoneRecordsQuery adds pagination after explicit ordering without limit', () => {
+  assert.equal(
+    buildKintoneRecordsQuery('status = "active" order by $id desc', 100, 200),
+    'status = "active" order by $id desc limit 100 offset 200'
+  )
+})

--- a/lib/kintone/api-client.ts
+++ b/lib/kintone/api-client.ts
@@ -33,6 +33,24 @@ export interface KintoneApiConfig {
   accessToken: string
 }
 
+export function buildKintoneRecordsQuery(query: string | undefined, limit: number, offset: number): string {
+  const trimmedQuery = query?.trim()
+  const hasLimit = !!trimmedQuery && /\blimit\s+\d+\b/i.test(trimmedQuery)
+
+  if (!trimmedQuery) {
+    return `order by $id asc limit ${limit} offset ${offset}`
+  }
+
+  if (hasLimit) {
+    return trimmedQuery
+  }
+
+  const hasOrderBy = /\border\s+by\b/i.test(trimmedQuery)
+  const orderClause = hasOrderBy ? '' : ' order by $id asc'
+
+  return `${trimmedQuery}${orderClause} limit ${limit} offset ${offset}`
+}
+
 export class KintoneApiClient {
   private domain: string
   private accessToken: string
@@ -169,14 +187,11 @@ export class KintoneApiClient {
     const limit = 500
     let offset = 0
     let allRecords: KintoneRecord[] = []
+    const isExplicitlyLimited = !!query?.trim() && /\blimit\s+\d+\b/i.test(query)
 
     while (true) {
-      let endpoint = `/k/v1/records.json?app=${appId}&query=order by $id asc limit ${limit} offset ${offset}`
-      
-      // Override query if provided
-      if (query) {
-        endpoint = `/k/v1/records.json?app=${appId}&query=${encodeURIComponent(query + ' order by $id asc')} limit ${limit} offset ${offset}`
-      }
+      const recordsQuery = buildKintoneRecordsQuery(query, limit, offset)
+      let endpoint = `/k/v1/records.json?app=${appId}&query=${encodeURIComponent(recordsQuery)}`
       
       if (fields && fields.length > 0) {
         const fieldsParam = fields.map(field => `fields[]=${encodeURIComponent(field)}`).join('&')
@@ -189,7 +204,7 @@ export class KintoneApiClient {
       allRecords = allRecords.concat(records)
       
       // If we got fewer records than the limit, we've reached the end
-      if (records.length < limit) {
+      if (isExplicitlyLimited || records.length < limit) {
         break
       }
       

--- a/lib/sync/batch-utils.test.ts
+++ b/lib/sync/batch-utils.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildRecordIdBatches } from './batch-utils'
+
+test('buildRecordIdBatches splits a record id span into inclusive ranges', () => {
+  assert.deepEqual(buildRecordIdBatches(1, 250, 100), [
+    { from: 1, to: 100 },
+    { from: 101, to: 200 },
+    { from: 201, to: 250 },
+  ])
+})
+
+test('buildRecordIdBatches starts from a later record id', () => {
+  assert.deepEqual(buildRecordIdBatches(2401, 2555, 50), [
+    { from: 2401, to: 2450 },
+    { from: 2451, to: 2500 },
+    { from: 2501, to: 2550 },
+    { from: 2551, to: 2555 },
+  ])
+})
+
+test('buildRecordIdBatches rejects invalid bounds', () => {
+  assert.throws(() => buildRecordIdBatches(0, 100, 50), /from must be greater than 0/)
+  assert.throws(() => buildRecordIdBatches(1, 100, 0), /batchSize must be greater than 0/)
+  assert.throws(() => buildRecordIdBatches(100, 1, 50), /to must be greater than or equal to from/)
+})

--- a/lib/sync/batch-utils.ts
+++ b/lib/sync/batch-utils.ts
@@ -1,0 +1,26 @@
+export interface RecordIdBatch {
+  from: number
+  to: number
+}
+
+export function buildRecordIdBatches(from: number, to: number, batchSize: number): RecordIdBatch[] {
+  if (!Number.isInteger(from) || from < 1) {
+    throw new Error('from must be greater than 0')
+  }
+  if (!Number.isInteger(to) || to < from) {
+    throw new Error('to must be greater than or equal to from')
+  }
+  if (!Number.isInteger(batchSize) || batchSize < 1) {
+    throw new Error('batchSize must be greater than 0')
+  }
+
+  const batches: RecordIdBatch[] = []
+  for (let current = from; current <= to; current += batchSize) {
+    batches.push({
+      from: current,
+      to: Math.min(current + batchSize - 1, to),
+    })
+  }
+
+  return batches
+}

--- a/lib/sync/kintone-sync.test.ts
+++ b/lib/sync/kintone-sync.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test'
 import {
   applyFileFieldProcessResult,
   buildPeopleImageStoragePath,
+  shouldSkipMissingUpdateTarget,
 } from './kintone-sync'
 import { buildUpdateCondition } from './update-key-utils'
 
@@ -79,4 +80,11 @@ test('buildUpdateCondition treats __ID__ mapping as Kintone record id', () => {
   )
 
   assert.deepEqual(condition, { external_id: '2447' })
+})
+
+test('people_image sync always skips records without an existing target person', () => {
+  assert.equal(shouldSkipMissingUpdateTarget('people_image', false), true)
+  assert.equal(shouldSkipMissingUpdateTarget('people_image', true), true)
+  assert.equal(shouldSkipMissingUpdateTarget('people', false), false)
+  assert.equal(shouldSkipMissingUpdateTarget('people', true), true)
 })

--- a/lib/sync/kintone-sync.test.ts
+++ b/lib/sync/kintone-sync.test.ts
@@ -8,7 +8,7 @@ import {
   buildPeopleImageStoragePath,
   shouldSkipMissingUpdateTarget,
 } from './kintone-sync'
-import { buildUpdateCondition } from './update-key-utils'
+import { buildUpdateCondition, getKintoneRecordValue } from './update-key-utils'
 
 test('buildPeopleImageStoragePath keeps same filenames isolated per Kintone record', () => {
   const first = buildPeopleImageStoragePath({
@@ -82,6 +82,11 @@ test('buildUpdateCondition treats __ID__ mapping as Kintone record id', () => {
   )
 
   assert.deepEqual(condition, { external_id: '2447' })
+})
+
+test('getKintoneRecordValue resolves Kintone record id aliases consistently', () => {
+  assert.equal(getKintoneRecordValue({ $id: { value: '2447' } }, '$id'), '2447')
+  assert.equal(getKintoneRecordValue({ __ID__: { value: '2447' } }, '__ID__'), '2447')
 })
 
 test('people_image sync always skips records without an existing target person', () => {

--- a/lib/sync/kintone-sync.test.ts
+++ b/lib/sync/kintone-sync.test.ts
@@ -5,6 +5,7 @@ import {
   applyFileFieldProcessResult,
   buildPeopleImageStoragePath,
 } from './kintone-sync'
+import { buildUpdateCondition } from './update-key-utils'
 
 test('buildPeopleImageStoragePath keeps same filenames isolated per Kintone record', () => {
   const first = buildPeopleImageStoragePath({
@@ -56,4 +57,26 @@ test('applyFileFieldProcessResult clears image when Kintone FILE field is intent
   })
 
   assert.equal(data.image_path, null)
+})
+
+test('buildUpdateCondition treats __ID__ mapping as Kintone record id', () => {
+  const condition = buildUpdateCondition(
+    {
+      $id: { value: '2447' },
+      image: { value: [{ fileKey: 'file-key' }] },
+    },
+    [
+      {
+        source_field_code: '__ID__',
+        target_field_id: 'external_id',
+        is_required: true,
+        sort_order: 0,
+        is_update_key: true,
+      },
+    ],
+    '',
+    false
+  )
+
+  assert.deepEqual(condition, { external_id: '2447' })
 })

--- a/lib/sync/kintone-sync.test.ts
+++ b/lib/sync/kintone-sync.test.ts
@@ -3,6 +3,8 @@ import test from 'node:test'
 
 import {
   applyFileFieldProcessResult,
+  buildRecordIdQuery,
+  combineKintoneQueries,
   buildPeopleImageStoragePath,
   shouldSkipMissingUpdateTarget,
 } from './kintone-sync'
@@ -87,4 +89,29 @@ test('people_image sync always skips records without an existing target person',
   assert.equal(shouldSkipMissingUpdateTarget('people_image', true), true)
   assert.equal(shouldSkipMissingUpdateTarget('people', false), false)
   assert.equal(shouldSkipMissingUpdateTarget('people', true), true)
+})
+
+test('buildRecordIdQuery targets one Kintone record by numeric id', () => {
+  assert.equal(buildRecordIdQuery({ recordId: '2447' }), '$id = 2447')
+})
+
+test('buildRecordIdQuery supports bounded Kintone record id ranges', () => {
+  assert.equal(
+    buildRecordIdQuery({ recordIdFrom: '2400', recordIdTo: '2500' }),
+    '$id >= 2400 and $id <= 2500'
+  )
+})
+
+test('buildRecordIdQuery rejects non-numeric record ids', () => {
+  assert.throws(
+    () => buildRecordIdQuery({ recordId: '2447 or status = "x"' }),
+    /Kintone record id must be numeric/
+  )
+})
+
+test('combineKintoneQueries preserves existing filters and adds record id filter', () => {
+  assert.equal(
+    combineKintoneQueries('status = "在籍中"', buildRecordIdQuery({ recordId: '2447' })),
+    'status = "在籍中" and $id = 2447'
+  )
 })

--- a/lib/sync/kintone-sync.test.ts
+++ b/lib/sync/kintone-sync.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  applyFileFieldProcessResult,
+  buildPeopleImageStoragePath,
+} from './kintone-sync'
+
+test('buildPeopleImageStoragePath keeps same filenames isolated per Kintone record', () => {
+  const first = buildPeopleImageStoragePath({
+    tenantId: '',
+    recordId: '1382',
+    fieldCode: 'image',
+    fileName: '2.png',
+  })
+  const second = buildPeopleImageStoragePath({
+    tenantId: '',
+    recordId: '1729',
+    fieldCode: 'image',
+    fileName: '2.png',
+  })
+
+  assert.equal(first, 'global/people_image/1382/image/Mg.png')
+  assert.equal(second, 'global/people_image/1729/image/Mg.png')
+  assert.notEqual(first, second)
+})
+
+test('buildPeopleImageStoragePath includes tenant scope when connector is tenant-bound', () => {
+  const path = buildPeopleImageStoragePath({
+    tenantId: 'tenant-123',
+    recordId: '1382',
+    fieldCode: 'image',
+    fileName: '2.png',
+  })
+
+  assert.equal(path, 'tenant-123/people_image/1382/image/Mg.png')
+})
+
+test('applyFileFieldProcessResult does not clear existing image when file processing failed', () => {
+  const data: Record<string, unknown> = { image_path: 'old/path.png' }
+
+  applyFileFieldProcessResult(data, 'image_path', {
+    shouldUpdate: false,
+    path: null,
+  })
+
+  assert.equal(data.image_path, 'old/path.png')
+})
+
+test('applyFileFieldProcessResult clears image when Kintone FILE field is intentionally empty', () => {
+  const data: Record<string, unknown> = { image_path: 'old/path.png' }
+
+  applyFileFieldProcessResult(data, 'image_path', {
+    shouldUpdate: true,
+    path: null,
+  })
+
+  assert.equal(data.image_path, null)
+})

--- a/lib/sync/kintone-sync.ts
+++ b/lib/sync/kintone-sync.ts
@@ -677,7 +677,15 @@ export class KintoneDataSync {
             const includeTenant = !!this.tenantId
             const whereCondition = buildUpdateCondition(record, updateKeys, this.tenantId, includeTenant)
             console.log(`[sync] where=${JSON.stringify(whereCondition)}`)
-            
+
+            const missingUpdateKeys = updateKeys.filter((fieldMapping) => {
+              return whereCondition[fieldMapping.target_field_id] === undefined || whereCondition[fieldMapping.target_field_id] === null
+            })
+            if (missingUpdateKeys.length > 0) {
+              console.log(`[sync] skip-missing-update-key rec=${record.$id?.value} keys=%s`, missingUpdateKeys.map((key) => `${key.source_field_code}->${key.target_field_id}`).join(','))
+              return
+            }
+
             // Check if we should skip this record when there is no update target
             // We need to know existence cheaply; perform a minimal select when skip flag is on
             let exists: boolean | undefined

--- a/lib/sync/kintone-sync.ts
+++ b/lib/sync/kintone-sync.ts
@@ -11,7 +11,7 @@ import { decryptJson } from '@/lib/security/crypto'
 // import { loadKintoneClientConfig } from '@/lib/db/credential-loader'
 import { SyncLogger, createSyncLogger } from './sync-logger'
 import { getUpdateKeysByConnector, buildConflictColumns, buildUpdateCondition } from './update-key-utils'
-import { uploadFileToStorage, generateFilePath } from '@/lib/storage/file-uploader'
+import { uploadFileToStorage } from '@/lib/storage/file-uploader'
 import { getDataMappings, mapFieldValues, type DataMapping } from '@/lib/mappings/value-mapper'
 // import { getKintoneMapping, type KintoneMapping } from './mapping-loader'
 
@@ -89,6 +89,25 @@ function encodeFilenameBase64Url(filename: string): string {
   return `${b64url}${ext}`
 }
 
+export function buildPeopleImageStoragePath({
+  tenantId,
+  recordId,
+  fieldCode,
+  fileName
+}: {
+  tenantId?: string | null
+  recordId: string
+  fieldCode: string
+  fileName: string
+}): string {
+  const tenantScope = sanitizeStorageKey(tenantId || 'global')
+  const safeRecordId = sanitizeStorageKey(recordId)
+  const safeFieldCode = sanitizeStorageKey(fieldCode)
+  const safeFileName = sanitizeStorageKey(encodeFilenameBase64Url(fileName))
+
+  return `${tenantScope}/people_image/${safeRecordId}/${safeFieldCode}/${safeFileName}`
+}
+
 interface AppMapping {
   id: string
   source_app_id: string
@@ -100,6 +119,21 @@ interface AppMapping {
   field_mappings: FieldMapping[]
 }
 
+interface FileFieldProcessResult {
+  shouldUpdate: boolean
+  path: string | null
+}
+
+export function applyFileFieldProcessResult(
+  data: Record<string, any>,
+  targetFieldId: string,
+  result: FileFieldProcessResult
+): void {
+  if (result.shouldUpdate) {
+    data[targetFieldId] = result.path
+  }
+}
+
 /**
  * Process FILE type field - download from Kintone and upload to Supabase Storage
  */
@@ -108,20 +142,20 @@ async function processFileField(
   record: KintoneRecord,
   fieldMapping: FieldMapping,
   tenantId: string
-): Promise<string | null> {
+): Promise<FileFieldProcessResult> {
   try {
     const sourceValue = record[fieldMapping.source_field_code]?.value
     
     if (!sourceValue || !Array.isArray(sourceValue) || sourceValue.length === 0) {
       console.log(`[file] no-data field=%s`, fieldMapping.source_field_code)
-      return null
+      return { shouldUpdate: true, path: null }
     }
 
     // Get the first file (Kintone FILE fields can have multiple files)
     const fileInfo = sourceValue[0]
     if (!fileInfo || !fileInfo.fileKey) {
       console.log(`[file] no-key field=%s`, fieldMapping.source_field_code)
-      return null
+      return { shouldUpdate: false, path: null }
     }
 
     // Download file from Kintone
@@ -129,10 +163,12 @@ async function processFileField(
     
     // Use the original filename (decode MIME Encoded-Word if necessary)
     const decodedName = decodeMimeEncodedWord(fileData.fileName) || fileData.fileName
-    // Encode basename to URL-safe Base64 to avoid storage key issues, keep extension
-    const encodedName = encodeFilenameBase64Url(decodedName)
-    // Use URL-safe Base64-encoded basename + original extension as the storage key
-    const filePath = encodedName
+    const filePath = buildPeopleImageStoragePath({
+      tenantId,
+      recordId: String(record.$id.value),
+      fieldCode: fieldMapping.source_field_code,
+      fileName: decodedName
+    })
 
     // Upload to Supabase Storage
     const uploadResult = await uploadFileToStorage(
@@ -145,15 +181,15 @@ async function processFileField(
 
     if (!uploadResult.success) {
       console.error(`[file] upload-failed field=%s path=%s err=%s`, fieldMapping.source_field_code, filePath, uploadResult.error)
-      return null
+      return { shouldUpdate: false, path: null }
     }
 
     console.log(`[file] uploaded field=%s path=%s`, fieldMapping.source_field_code, uploadResult.path || filePath)
-    return uploadResult.path || null
+    return { shouldUpdate: true, path: uploadResult.path || null }
 
   } catch (error) {
     console.error(`[file] error field=%s err=%o`, fieldMapping.source_field_code, error)
-    return null
+    return { shouldUpdate: false, path: null }
   }
 }
 
@@ -669,9 +705,9 @@ export class KintoneDataSync {
             // Map fields using database configuration
             for (const fieldMapping of appMapping.field_mappings) {
               if (fieldMapping.source_field_type === 'FILE') {
-                const filePath = await processFileField(this.kintoneClient, record, fieldMapping, this.tenantId)
-                data[fieldMapping.target_field_id] = filePath
-                console.log(`[sync] file-mapped target_field=%s path=%s`, fieldMapping.target_field_id, filePath)
+                const fileResult = await processFileField(this.kintoneClient, record, fieldMapping, this.tenantId)
+                applyFileFieldProcessResult(data, fieldMapping.target_field_id, fileResult)
+                console.log(`[sync] file-mapped target_field=%s path=%s shouldUpdate=%s`, fieldMapping.target_field_id, fileResult.path, fileResult.shouldUpdate)
               } else {
                 // Regular field mapping
                 const sourceValue = record[fieldMapping.source_field_code]?.value
@@ -759,6 +795,7 @@ export class KintoneDataSync {
   private getTargetTable(targetAppType: string): string | null {
     const tableMap: Record<string, string> = {
       'people': 'people',
+      'people_image': 'people',
       'visas': 'visas',
       'meetings': 'meetings'
     }

--- a/lib/sync/kintone-sync.ts
+++ b/lib/sync/kintone-sync.ts
@@ -10,7 +10,7 @@ import { getCredential } from '@/lib/db/connectors'
 import { decryptJson } from '@/lib/security/crypto'
 // import { loadKintoneClientConfig } from '@/lib/db/credential-loader'
 import { SyncLogger, createSyncLogger } from './sync-logger'
-import { getUpdateKeysByConnector, buildConflictColumns, buildUpdateCondition } from './update-key-utils'
+import { getUpdateKeysByConnector, buildConflictColumns, buildUpdateCondition, getKintoneRecordValue } from './update-key-utils'
 import { uploadFileToStorage } from '@/lib/storage/file-uploader'
 import { getDataMappings, mapFieldValues, type DataMapping } from '@/lib/mappings/value-mapper'
 // import { getKintoneMapping, type KintoneMapping } from './mapping-loader'
@@ -207,7 +207,7 @@ async function processFileField(
     
     // Use the original filename (decode MIME Encoded-Word if necessary)
     const decodedName = decodeMimeEncodedWord(fileData.fileName) || fileData.fileName
-    const recordIdValue = record.$id?.value
+    const recordIdValue = getKintoneRecordValue(record, '$id')
     if (recordIdValue === undefined || recordIdValue === null) {
       console.log(`[file] no-record-id field=%s`, fieldMapping.source_field_code)
       return { shouldUpdate: false, path: null }

--- a/lib/sync/kintone-sync.ts
+++ b/lib/sync/kintone-sync.ts
@@ -163,9 +163,15 @@ async function processFileField(
     
     // Use the original filename (decode MIME Encoded-Word if necessary)
     const decodedName = decodeMimeEncodedWord(fileData.fileName) || fileData.fileName
+    const recordIdValue = record.$id?.value
+    if (recordIdValue === undefined || recordIdValue === null) {
+      console.log(`[file] no-record-id field=%s`, fieldMapping.source_field_code)
+      return { shouldUpdate: false, path: null }
+    }
+
     const filePath = buildPeopleImageStoragePath({
       tenantId,
-      recordId: String(record.$id.value),
+      recordId: String(recordIdValue),
       fieldCode: fieldMapping.source_field_code,
       fileName: decodedName
     })

--- a/lib/sync/kintone-sync.ts
+++ b/lib/sync/kintone-sync.ts
@@ -430,6 +430,17 @@ export class KintoneDataSync {
     
   }
 
+  async getMaxRecordId(sourceAppId: string): Promise<number> {
+    const records = await this.kintoneClient.getRecords(sourceAppId, 'order by $id desc limit 1')
+    const maxRecordId = Number(records[0]?.$id?.value || 0)
+
+    if (!Number.isFinite(maxRecordId) || maxRecordId < 0) {
+      throw new Error(`Invalid max Kintone record id for app ${sourceAppId}`)
+    }
+
+    return maxRecordId
+  }
+
   /**
    * Build Kintone query from filter conditions
    */

--- a/lib/sync/kintone-sync.ts
+++ b/lib/sync/kintone-sync.ts
@@ -134,6 +134,13 @@ export function applyFileFieldProcessResult(
   }
 }
 
+export function shouldSkipMissingUpdateTarget(
+  targetAppType: string,
+  skipIfNoUpdateTarget: boolean
+): boolean {
+  return skipIfNoUpdateTarget || targetAppType === 'people_image'
+}
+
 /**
  * Process FILE type field - download from Kintone and upload to Supabase Storage
  */
@@ -689,7 +696,7 @@ export class KintoneDataSync {
             // Check if we should skip this record when there is no update target
             // We need to know existence cheaply; perform a minimal select when skip flag is on
             let exists: boolean | undefined
-            if (appMapping.skip_if_no_update_target) {
+            if (shouldSkipMissingUpdateTarget(targetAppType, appMapping.skip_if_no_update_target)) {
               const { data: headCheck, error: headErr } = await this.supabase
                 .from(targetTable)
                 .select('id')
@@ -768,6 +775,11 @@ export class KintoneDataSync {
               error = updateError
             }
             if (!error && (!updatedRows || updatedRows.length === 0)) {
+              if (targetAppType === 'people_image') {
+                console.log(`[sync] skip-no-target-after-update rec=${record.$id?.value}`)
+                return
+              }
+
               // No rows updated -> insert new
               const { error: insertError } = await this.supabase
                 .from(targetTable)

--- a/lib/sync/kintone-sync.ts
+++ b/lib/sync/kintone-sync.ts
@@ -141,6 +141,43 @@ export function shouldSkipMissingUpdateTarget(
   return skipIfNoUpdateTarget || targetAppType === 'people_image'
 }
 
+export interface KintoneSyncOptions {
+  recordId?: string
+  recordIdFrom?: string
+  recordIdTo?: string
+}
+
+function assertKintoneRecordId(value: string, label: string): string {
+  const trimmed = value.trim()
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(`Invalid ${label}: Kintone record id must be numeric`)
+  }
+  return trimmed
+}
+
+export function buildRecordIdQuery(options: KintoneSyncOptions = {}): string {
+  if (options.recordId) {
+    return `$id = ${assertKintoneRecordId(options.recordId, 'recordId')}`
+  }
+
+  const conditions: string[] = []
+  if (options.recordIdFrom) {
+    conditions.push(`$id >= ${assertKintoneRecordId(options.recordIdFrom, 'recordIdFrom')}`)
+  }
+  if (options.recordIdTo) {
+    conditions.push(`$id <= ${assertKintoneRecordId(options.recordIdTo, 'recordIdTo')}`)
+  }
+
+  return conditions.join(' and ')
+}
+
+export function combineKintoneQueries(...queries: Array<string | null | undefined>): string {
+  return queries
+    .map((query) => query?.trim())
+    .filter((query): query is string => !!query)
+    .join(' and ')
+}
+
 /**
  * Process FILE type field - download from Kintone and upload to Supabase Storage
  */
@@ -461,7 +498,11 @@ export class KintoneDataSync {
    * @param appMappingId Optional specific app mapping ID to sync. If not provided, syncs all active mappings.
    * @param targetAppType Optional target app type to filter mappings. If not provided, syncs all target app types.
    */
-  async syncAll(appMappingId?: string, targetAppType?: string): Promise<SyncResult> {
+  async syncAll(
+    appMappingId?: string,
+    targetAppType?: string,
+    options: KintoneSyncOptions = {}
+  ): Promise<SyncResult> {
     if (process.env.ALLOW_LEGACY_IMPORTS === 'false' || process.env.IMPORTS_DISABLED_UNTIL_MAPPING_ACTIVE === 'true') {
       // Check active mapping exists for this connector
       const { data: activeMappings } = await this.supabase
@@ -486,7 +527,10 @@ export class KintoneDataSync {
         connectorId: this.connectorId,
         tenantId: this.tenantId,
         targetAppType,
-        appMappingId
+        appMappingId,
+        recordId: options.recordId,
+        recordIdFrom: options.recordIdFrom,
+        recordIdTo: options.recordIdTo
       })
       // Start sync session
       sessionId = await this.syncLogger.startSession(
@@ -533,7 +577,7 @@ export class KintoneDataSync {
       console.log('[sync] syncAll:mappings', appMappings.map(m => ({ id: m.id, target_app_type: m.target_app_type, source_app_id: m.source_app_id })))
       for (const appMapping of appMappings) {
         try {
-          const syncedCount = await this.syncAppData(appMapping.target_app_type, appMapping.source_app_id, appMapping.id)
+          const syncedCount = await this.syncAppData(appMapping.target_app_type, appMapping.source_app_id, appMapping.id, options)
           synced[appMapping.target_app_type] = syncedCount
         } catch (err) {
           const error = `${appMapping.target_app_type} sync failed: ${err instanceof Error ? err.message : 'Unknown error'}`
@@ -589,7 +633,12 @@ export class KintoneDataSync {
   /**
    * Sync app data from Kintone based on app mapping configuration
    */
-  private async syncAppData(targetAppType: string, sourceAppId: string, appMappingId?: string): Promise<number> {
+  private async syncAppData(
+    targetAppType: string,
+    sourceAppId: string,
+    appMappingId?: string,
+    options: KintoneSyncOptions = {}
+  ): Promise<number> {
     if (process.env.ALLOW_LEGACY_IMPORTS === 'false' || process.env.IMPORTS_DISABLED_UNTIL_MAPPING_ACTIVE === 'true') {
       const { data: active } = await this.supabase
         .from('connector_app_mappings')
@@ -649,7 +698,14 @@ export class KintoneDataSync {
       for (const appMapping of appMappings) {
         // Build query using only database filter conditions
         const filterQuery = await this.buildFilterQuery(targetAppType as 'people' | 'visas', appMappingId)
-        const query = filterQuery || ''
+        const recordIdQuery = buildRecordIdQuery(options)
+        const query = combineKintoneQueries(filterQuery, recordIdQuery)
+        console.log('[sync] kintone-query', {
+          targetAppType,
+          sourceAppId,
+          appMappingId: appMapping.id,
+          query
+        })
         
         // Get records from Kintone
         const records = await this.kintoneClient.getRecords(appMapping.source_app_id, query, [])

--- a/lib/sync/update-key-utils.ts
+++ b/lib/sync/update-key-utils.ts
@@ -129,7 +129,7 @@ export function buildUpdateCondition(
   }
   
   for (const fieldMapping of updateKeys) {
-    const sourceValue = record[fieldMapping.source_field_code]?.value
+    const sourceValue = getKintoneRecordValue(record, fieldMapping.source_field_code)
     const targetKey = fieldMapping.target_field_id
     
     if (sourceValue !== undefined && sourceValue !== null) {
@@ -138,4 +138,16 @@ export function buildUpdateCondition(
   }
   
   return condition
+}
+
+function getKintoneRecordValue(record: Record<string, any>, sourceFieldCode: string): any {
+  if (sourceFieldCode === '$id' || sourceFieldCode === '__ID__') {
+    return record.$id?.value ?? record.__ID__?.value
+  }
+
+  if (sourceFieldCode === '$revision' || sourceFieldCode === '__REVISION__') {
+    return record.$revision?.value ?? record.__REVISION__?.value
+  }
+
+  return record[sourceFieldCode]?.value
 }

--- a/lib/sync/update-key-utils.ts
+++ b/lib/sync/update-key-utils.ts
@@ -140,7 +140,7 @@ export function buildUpdateCondition(
   return condition
 }
 
-function getKintoneRecordValue(record: Record<string, any>, sourceFieldCode: string): any {
+export function getKintoneRecordValue(record: Record<string, any>, sourceFieldCode: string): any {
   if (sourceFieldCode === '$id' || sourceFieldCode === '__ID__') {
     return record.$id?.value ?? record.__ID__?.value
   }


### PR DESCRIPTION
## Summary

Fixes FunBase `people_image` sync so Kintone app 30 photos no longer collide by filename, image-only records cannot create sparse `people` rows, and manual image sync can run in Vercel by processing app 30 in batches instead of one long request.

Refs funtoco/fun-docs#743.

## Root Cause

- Photo mismatch: `processFileField()` stored files with filename-only paths such as `Mg.png`. With `upsert: true`, multiple people with the same source filename overwrote the same Supabase Storage object.
- Blank photos: app30 image records were sometimes not reflected because the full manual sync timed out before reaching later app30 record ids, and earlier code could fall into insert/error paths for image-only records.
- Mapping key: sample checks confirmed app30 `$id` / `__ID__` should map to `people.external_id`, not `people.id`.

## Changes

- Store people images under unique paths: tenant scope / app30 record id / field code / encoded filename.
- Resolve `$id` and `__ID__` update keys consistently via `getKintoneRecordValue()`.
- Skip records when update keys cannot be resolved.
- Make `people_image` update-only. Missing target `people` rows are skipped and never inserted from image-only data.
- Preserve existing `image_path` when file download/upload fails; clear only when Kintone FILE field is actually empty.
- Add targeted/range sync request support: `recordId`, `recordIdFrom`, `recordIdTo`.
- Change the manual `people_image` UI sync button to browser-driven batches of 100 app30 ids, with progress like `連携中 1/40`.
- Add server-side max record id metadata lookup by `appMappingId`; browser cannot pass arbitrary `sourceAppId`.
- Allow scheduled `type=people_image` and set sync API max duration to 300s.

## Validation

- Preview verification:
  - Wrong-photo sample matched Kintone after sync.
  - EKA DIANINGSIH (`people.id=3302`, `external_id=2447`, app30 `$id=2447`) filled `image_path` after targeted sync.
  - Batch UI sync was run successfully by the requester.
- `pnpm dlx tsx --test lib/kintone/api-client.test.ts lib/sync/batch-utils.test.ts lib/sync/kintone-sync.test.ts`
  - `tests 17`
  - `pass 17`
  - `fail 0`
- Vercel preview deployment passes.
- CodeRabbit status passes.
- All addressed review threads are resolved.

## Known Non-Blocker

- `npm run typecheck` is not clean on the current repo baseline. It stops first on `constants/meeting-taxonomy.ts` (`TS1127: Invalid character`); after confirming that local parse issue, broader existing type debt remains in connector/tenant-management areas. Those files are outside this PR scope and Vercel/CodeRabbit pass for this PR.
- Current batch sync is browser-driven. If the tab is closed, the manual batch stops. This is acceptable for the current MVP; durable background/cron sync should be a follow-up if operations need unattended full sync.

## Post-Merge Operation

After merge/deploy, do not bulk-delete `people.image_path`. Re-run `people_image` sync from the app mapping screen. The new sync updates matched rows to unique paths and skips unmatched app30 rows safely.
