### PR TITLE
fix: テナント作成時の RLS 違反を回避

### DIFF
--- a/lib/actions/tenant-actions.ts
+++ b/lib/actions/tenant-actions.ts
@@ -67,19 +67,25 @@ export async function createTenantAction(data: CreateTenantData) {
   }
 
   try {
-    // Create tenant
-    const { data: tenant, error: tenantError } = await supabase
+    // Pre-generate the tenant id so we can insert without RETURNING.
+    // tenants has RLS enabled; the creator is not yet a member, so an implicit
+    // SELECT (via .select() / RETURNING) would fail the SELECT policy and
+    // surface as "new row violates row-level security policy". Inserting
+    // without RETURNING relies only on the INSERT WITH CHECK policy.
+    const tenantId = crypto.randomUUID()
+
+    const { error: tenantError } = await supabase
       .from('tenants')
       .insert({
+        id: tenantId,
         name: data.name,
         slug: data.slug,
         description: data.description,
         max_members: 50
       })
-      .select()
-      .single()
 
     if (tenantError) {
+      console.error('Insert tenant error:', tenantError)
       if (tenantError.code === '23505') {
         throw new Error('このスラッグは既に使用されています')
       }
@@ -91,7 +97,7 @@ export async function createTenantAction(data: CreateTenantData) {
       .from('user_tenants')
       .insert({
         user_id: user.id,
-        tenant_id: tenant.id,
+        tenant_id: tenantId,
         email: user.email,
         role: 'owner',
         status: 'active',
@@ -101,7 +107,7 @@ export async function createTenantAction(data: CreateTenantData) {
     if (userTenantError) {
       console.error('Error adding user to tenant:', userTenantError)
       // If user_tenants insertion fails, we should clean up the tenant
-      await supabase.from('tenants').delete().eq('id', tenant.id)
+      await supabase.from('tenants').delete().eq('id', tenantId)
       throw new Error('ユーザーをテナントに追加できませんでした')
     }
 
@@ -109,7 +115,7 @@ export async function createTenantAction(data: CreateTenantData) {
     const { error: updateError } = await supabase.auth.updateUser({
       data: {
         tenant_name: data.name,
-        tenant_id: tenant.id
+        tenant_id: tenantId
       }
     })
 


### PR DESCRIPTION
## Summary
- production の `public.tenants` は RLS 有効で INSERT ポリシー無しの状態となっており、テナント作成が `new row violates row-level security policy for table "tenants"` で失敗していた
- さらに supabase クライアントの `.insert().select().single()` が暗黙の `RETURNING` を発生させ、作成直後の新規行に対する SELECT ポリシー違反として弾かれていた

## 修正内容
- `crypto.randomUUID()` で tenant id を事前生成
- `.select()` を外して `INSERT ... RETURNING` を発生させない
- 以降の参照(user_tenants insert / cleanup / auth metadata)は事前生成した `tenantId` を使用
- `tenantError` を `console.error` で詳細出力(再発時の調査用)
- 併せて submodule (`fun-base-infra` PR #40)で INSERT ポリシーを追加

## 動作確認
ローカル DB に `ALTER TABLE tenants ENABLE ROW LEVEL SECURITY;` を当てて production を再現:
- before: owner が新規テナント作成 → RLS 違反で失敗
- after: owner は作成可、非 owner は引き続き拒否

## 関連
- fun-base-infra: https://github.com/funtoco/fun-base-infra/pull/40

## Test plan
- [ ] fun-base-infra #40 を本番に適用後、管理者ユーザーで新規テナント作成
- [ ] 非 owner ユーザーには「テナントを作成する権限がありません」が出ること
- [ ] スラッグ重複時に「このスラッグは既に使用されています」が出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced tenant creation workflow for improved reliability.

* **Chores**
  * Updated backend dependencies to latest versions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/funtoco/fun-base/pull/70)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related issue
- funtoco/fun-docs#747
