### PR TITLE
feat: add Kintone App 98 interview records sync

### DIFF
--- a/.github/workflows/cron-sync.yml
+++ b/.github/workflows/cron-sync.yml
@@ -14,6 +14,7 @@ on:
         options:
           - people
           - visas
+          - interview_records
           - both
 
 jobs:
@@ -72,3 +73,31 @@ jobs:
         run: |
           echo "🕐 Starting visas sync at $(date)"
           pnpm dlx tsx@4.20.3 scripts/sync-by-type.ts --type visas
+
+  sync-interview-records:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.sync_type == 'interview_records'
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    environment: Production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Sync Interview Records
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          echo "🕐 Starting interview_records sync at $(date)"
+          pnpm dlx tsx@4.20.3 scripts/sync-by-type.ts --type interview_records

--- a/app/api/cron/sync-by-type/route.ts
+++ b/app/api/cron/sync-by-type/route.ts
@@ -1,6 +1,6 @@
 /**
  * Scheduled data synchronization endpoint by target app type
- * POST /api/cron/sync-by-type?type=people|people_image|visas
+ * POST /api/cron/sync-by-type?type=people|people_image|visas|interview_records
  * This endpoint is called by Vercel Cron Jobs for scheduled syncs by type
  */
 
@@ -51,9 +51,9 @@ async function handleSyncByType(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const targetAppType = searchParams.get('type')
     
-    if (!targetAppType || !['people', 'people_image', 'visas'].includes(targetAppType)) {
+    if (!targetAppType || !['people', 'people_image', 'visas', 'interview_records'].includes(targetAppType)) {
       return NextResponse.json(
-        { error: 'Invalid or missing type parameter. Must be "people", "people_image", or "visas"' },
+        { error: 'Invalid or missing type parameter. Must be "people", "people_image", "visas", or "interview_records"' },
         { status: 400 }
       )
     }

--- a/app/api/schema/[app]/route.ts
+++ b/app/api/schema/[app]/route.ts
@@ -15,7 +15,7 @@ export async function GET(
 ) {
   try {
     const appKey = params.app
-    const allow = new Set(['people', 'people_image', 'visas', 'meetings'])
+    const allow = new Set(['people', 'people_image', 'visas', 'meetings', 'interview_records'])
     if (!allow.has(appKey)) {
       return NextResponse.json({ error: 'Table not allowed' }, { status: 400 })
     }
@@ -53,4 +53,3 @@ export async function GET(
     return NextResponse.json({ error: 'Failed to fetch schema' }, { status: 500 })
   }
 }
-

--- a/lib/sync/interview-record-transformer.test.ts
+++ b/lib/sync/interview-record-transformer.test.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+
+import {
+  DEFAULT_EXTERNAL_CONFIRMATION_STATUS,
+  buildInterviewRecordsQuery,
+  isImportableInterviewRecord,
+  parseActivityEntries,
+  transformInterviewRecord,
+} from './interview-record-transformer'
+
+test('isImportableInterviewRecord only accepts completed regular or daily interview records', () => {
+  assert.equal(
+    isImportableInterviewRecord({
+      $id: { value: '9559' },
+      $revision: { value: '1' },
+      Status: { value: '完了' },
+      interview: { value: '定期面談' },
+    }),
+    true
+  )
+  assert.equal(
+    isImportableInterviewRecord({
+      $id: { value: '9560' },
+      $revision: { value: '1' },
+      Status: { value: '確認中' },
+      interview: { value: '定期面談' },
+    }),
+    false
+  )
+  assert.equal(
+    isImportableInterviewRecord({
+      $id: { value: '9561' },
+      $revision: { value: '1' },
+      Status: { value: '完了' },
+      interview: { value: '家族面談' },
+    }),
+    false
+  )
+})
+
+test('buildInterviewRecordsQuery keeps connector filters and enforces completed status', () => {
+  assert.equal(
+    buildInterviewRecordsQuery('COID = "3222"'),
+    'COID = "3222" and Status = "完了"'
+  )
+
+  assert.equal(
+    buildInterviewRecordsQuery('COID = "3222" and Status = "完了"'),
+    'COID = "3222" and Status = "完了"'
+  )
+})
+
+test('transformInterviewRecord maps regular interview fields to interview_records row', () => {
+  const row = transformInterviewRecord(
+    {
+      $id: { value: '9559' },
+      $revision: { value: '3' },
+      HRID: { value: '3505' },
+      COID: { value: '3222' },
+      companyName: { value: '株式会社ABC製造' },
+      interview: { value: '定期面談' },
+      Status: { value: '完了' },
+      interviewDate: { value: '2026-05-14' },
+      Time: { value: '14:00' },
+      Time_0: { value: '15:00' },
+      targetQuarter: { value: '2026年第2四半期' },
+      timeInterview: { value: '60' },
+      interviewMethod: { value: '対面' },
+      interviewPlace: { value: '本社会議室' },
+      supportName: { value: [{ name: '田中' }] },
+      salesName: { value: [{ name: '佐藤' }] },
+      funtocoStaff: { value: [{ name: '山田' }] },
+      確認期限: { value: '2026-05-22T18:00:00Z' },
+      企業提出用レポート: { value: '本人の勤務状況は良好です。' },
+    },
+    {
+      tenantId: 'tenant-1',
+      personId: 'person-1',
+      sourceAppId: '98',
+    }
+  )
+
+  assert.equal(row.tenant_id, 'tenant-1')
+  assert.equal(row.person_id, 'person-1')
+  assert.equal(row.source_person_id, '3505')
+  assert.equal(row.source_system, 'kintone')
+  assert.equal(row.source_app_id, '98')
+  assert.equal(row.source_record_id, '9559')
+  assert.equal(row.record_type, 'regular_interview')
+  assert.equal(row.source_status, '完了')
+  assert.equal(row.interview_date, '2026-05-14')
+  assert.equal(row.interview_duration_minutes, 60)
+  assert.equal(row.external_confirmation_status, DEFAULT_EXTERNAL_CONFIRMATION_STATUS)
+  assert.equal(row.external_report_body, '本人の勤務状況は良好です。')
+  assert.deepEqual(row.activity_entries, [])
+})
+
+test('parseActivityEntries normalizes Kintone subtable rows for daily support', () => {
+  const entries = parseActivityEntries({
+    value: [
+      {
+        id: 'row-1',
+        value: {
+          dai: { value: '生活支援' },
+          chu: { value: '銀行・送金' },
+          shou: { value: ['口座開設', '海外送金'] },
+          notes: { value: '本人へ案内済み' },
+        },
+      },
+    ],
+  })
+
+  assert.deepEqual(entries, [
+    {
+      dai: '生活支援',
+      chu: '銀行・送金',
+      shou: '口座開設, 海外送金',
+      notes: '本人へ案内済み',
+    },
+  ])
+})

--- a/lib/sync/interview-record-transformer.ts
+++ b/lib/sync/interview-record-transformer.ts
@@ -1,0 +1,218 @@
+import type { KintoneRecord } from '@/lib/kintone/api-client'
+
+export const DEFAULT_EXTERNAL_CONFIRMATION_STATUS = '確認待ち'
+export const IMPORTABLE_INTERVIEW_STATUS = '完了'
+export const KINTONE_INTERVIEW_SOURCE_SYSTEM = 'kintone'
+
+type RecordType = 'regular_interview' | 'daily_support'
+
+export interface InterviewRecordTransformContext {
+  tenantId: string
+  personId: string
+  sourceAppId: string
+}
+
+export interface ActivityEntry {
+  dai: string
+  chu: string
+  shou: string
+  notes?: string
+}
+
+export interface InterviewRecordPayload {
+  tenant_id: string
+  person_id: string
+  source_person_id: string | null
+  source_system: typeof KINTONE_INTERVIEW_SOURCE_SYSTEM
+  source_app_id: string
+  source_record_id: string
+  record_type: RecordType
+  source_status: string
+  interview_date: string
+  start_time: string | null
+  end_time: string | null
+  target_quarter: string | null
+  interview_method: string | null
+  interview_place: string | null
+  interview_duration_minutes: number | null
+  company_id: string | null
+  company_name: string | null
+  support_staff_name: string | null
+  sales_staff_name: string | null
+  internal_staff_name: string | null
+  external_report_body: string | null
+  activity_entries: ActivityEntry[]
+  internal_notes: string | null
+  external_confirmation_status: typeof DEFAULT_EXTERNAL_CONFIRMATION_STATUS
+  confirmation_due_at: string | null
+  raw_record_json: Record<string, unknown>
+}
+
+function fieldValue(record: Record<string, any>, fieldCode: string): any {
+  if (fieldCode === '$id') return record.$id?.value
+  if (fieldCode === '$revision') return record.$revision?.value
+  return record[fieldCode]?.value
+}
+
+function toStringOrNull(value: any): string | null {
+  if (value === undefined || value === null) return null
+
+  if (Array.isArray(value)) {
+    const joined = value
+      .map((item) => {
+        if (item && typeof item === 'object') {
+          return item.name ?? item.code ?? item.value
+        }
+        return item
+      })
+      .filter((item) => item !== undefined && item !== null && String(item).trim() !== '')
+      .map(String)
+      .join(', ')
+
+    return joined || null
+  }
+
+  if (typeof value === 'object') {
+    const label = value.name ?? value.code ?? value.value
+    return label === undefined || label === null || String(label).trim() === '' ? null : String(label)
+  }
+
+  const text = String(value).trim()
+  return text || null
+}
+
+function toNumberOrNull(value: any): number | null {
+  if (value === undefined || value === null || value === '') return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function toDateOrNull(value: any): string | null {
+  const text = toStringOrNull(value)
+  if (!text) return null
+  return text.slice(0, 10)
+}
+
+function normalizeRecordType(value: any): RecordType | null {
+  const text = toStringOrNull(value)
+  if (text === '定期面談') return 'regular_interview'
+  if (text === '日々の面談') return 'daily_support'
+  return null
+}
+
+function hasCompletedStatusFilter(query: string): boolean {
+  return /\bStatus\s*=\s*"完了"/.test(query)
+}
+
+export function buildInterviewRecordsQuery(baseQuery = ''): string {
+  const trimmed = baseQuery.trim()
+  const statusFilter = 'Status = "完了"'
+
+  if (!trimmed) return statusFilter
+  if (hasCompletedStatusFilter(trimmed)) return trimmed
+
+  return `${trimmed} and ${statusFilter}`
+}
+
+export function isImportableInterviewRecord(record: KintoneRecord): boolean {
+  return (
+    toStringOrNull(fieldValue(record, 'Status')) === IMPORTABLE_INTERVIEW_STATUS &&
+    normalizeRecordType(fieldValue(record, 'interview')) !== null
+  )
+}
+
+export function getInterviewRecordSourcePersonId(record: KintoneRecord): string | null {
+  return toStringOrNull(fieldValue(record, 'HRID'))
+}
+
+export function getInterviewRecordSourceRecordId(record: KintoneRecord): string | null {
+  return toStringOrNull(fieldValue(record, '$id'))
+}
+
+function pickSubtableValue(row: Record<string, any>, fieldCodes: string[]): any {
+  for (const fieldCode of fieldCodes) {
+    if (row[fieldCode]?.value !== undefined) {
+      return row[fieldCode].value
+    }
+  }
+  return undefined
+}
+
+export function parseActivityEntries(tableStorageDaily: any): ActivityEntry[] {
+  const rows = Array.isArray(tableStorageDaily?.value) ? tableStorageDaily.value : []
+
+  return rows
+    .map((row: any) => {
+      const values = row?.value || {}
+      const dai = toStringOrNull(pickSubtableValue(values, ['dai', '大分類']))
+      const chu = toStringOrNull(pickSubtableValue(values, ['chu', '中分類']))
+      const shou = toStringOrNull(pickSubtableValue(values, ['shou', '小分類']))
+      const notes = toStringOrNull(pickSubtableValue(values, ['notes', 'note', '備考', '対応内容']))
+
+      if (!dai && !chu && !shou && !notes) return null
+
+      return {
+        dai: dai || '',
+        chu: chu || '',
+        shou: shou || '',
+        ...(notes ? { notes } : {}),
+      }
+    })
+    .filter((entry): entry is ActivityEntry => entry !== null)
+}
+
+function toRawRecordJson(record: KintoneRecord): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(record)) as Record<string, unknown>
+}
+
+export function transformInterviewRecord(
+  record: KintoneRecord,
+  context: InterviewRecordTransformContext
+): InterviewRecordPayload {
+  if (!isImportableInterviewRecord(record)) {
+    throw new Error('Interview record is not importable')
+  }
+
+  const recordType = normalizeRecordType(fieldValue(record, 'interview'))
+  const interviewDate = toDateOrNull(fieldValue(record, 'interviewDate'))
+  const sourceRecordId = toStringOrNull(fieldValue(record, '$id'))
+
+  if (!recordType) {
+    throw new Error('Unsupported interview record type')
+  }
+  if (!interviewDate) {
+    throw new Error('Missing interviewDate')
+  }
+  if (!sourceRecordId) {
+    throw new Error('Missing Kintone record id')
+  }
+
+  return {
+    tenant_id: context.tenantId,
+    person_id: context.personId,
+    source_person_id: toStringOrNull(fieldValue(record, 'HRID')),
+    source_system: KINTONE_INTERVIEW_SOURCE_SYSTEM,
+    source_app_id: context.sourceAppId,
+    source_record_id: sourceRecordId,
+    record_type: recordType,
+    source_status: toStringOrNull(fieldValue(record, 'Status')) || IMPORTABLE_INTERVIEW_STATUS,
+    interview_date: interviewDate,
+    start_time: toStringOrNull(fieldValue(record, 'Time')),
+    end_time: toStringOrNull(fieldValue(record, 'Time_0')),
+    target_quarter: toStringOrNull(fieldValue(record, 'targetQuarter')),
+    interview_method: toStringOrNull(fieldValue(record, 'interviewMethod')),
+    interview_place: toStringOrNull(fieldValue(record, 'interviewPlace')),
+    interview_duration_minutes: toNumberOrNull(fieldValue(record, 'timeInterview')),
+    company_id: toStringOrNull(fieldValue(record, 'COID')),
+    company_name: toStringOrNull(fieldValue(record, 'companyName')),
+    support_staff_name: toStringOrNull(fieldValue(record, 'supportName')),
+    sales_staff_name: toStringOrNull(fieldValue(record, 'salesName')),
+    internal_staff_name: toStringOrNull(fieldValue(record, 'funtocoStaff')),
+    external_report_body: toStringOrNull(fieldValue(record, '企業提出用レポート')),
+    activity_entries: recordType === 'daily_support' ? parseActivityEntries(record.tableStorageDaily) : [],
+    internal_notes: toStringOrNull(fieldValue(record, 'interviewContent')) || toStringOrNull(fieldValue(record, 'memo')),
+    external_confirmation_status: DEFAULT_EXTERNAL_CONFIRMATION_STATUS,
+    confirmation_due_at: toStringOrNull(fieldValue(record, '確認期限')),
+    raw_record_json: toRawRecordJson(record),
+  }
+}

--- a/lib/sync/interview-record-transformer.ts
+++ b/lib/sync/interview-record-transformer.ts
@@ -54,31 +54,35 @@ function fieldValue(record: Record<string, any>, fieldCode: string): any {
   return record[fieldCode]?.value
 }
 
+function labelValue(value: any): any {
+  if (value && typeof value === 'object') {
+    return value.name ?? value.code ?? value.value
+  }
+
+  return value
+}
+
+function nonEmptyStringOrNull(value: any): string | null {
+  if (value === undefined || value === null) return null
+
+  const text = String(value).trim()
+  return text || null
+}
+
 function toStringOrNull(value: any): string | null {
   if (value === undefined || value === null) return null
 
   if (Array.isArray(value)) {
     const joined = value
-      .map((item) => {
-        if (item && typeof item === 'object') {
-          return item.name ?? item.code ?? item.value
-        }
-        return item
-      })
-      .filter((item) => item !== undefined && item !== null && String(item).trim() !== '')
-      .map(String)
+      .map(labelValue)
+      .map(nonEmptyStringOrNull)
+      .filter((item): item is string => item !== null)
       .join(', ')
 
     return joined || null
   }
 
-  if (typeof value === 'object') {
-    const label = value.name ?? value.code ?? value.value
-    return label === undefined || label === null || String(label).trim() === '' ? null : String(label)
-  }
-
-  const text = String(value).trim()
-  return text || null
+  return nonEmptyStringOrNull(labelValue(value))
 }
 
 function toNumberOrNull(value: any): number | null {

--- a/lib/sync/kintone-sync.ts
+++ b/lib/sync/kintone-sync.ts
@@ -22,6 +22,8 @@ import {
 } from './interview-record-transformer'
 // import { getKintoneMapping, type KintoneMapping } from './mapping-loader'
 
+const DEFAULT_SYNC_CONCURRENCY = 6
+
 // Types for field mappings
 interface FieldMapping {
   source_field_code: string
@@ -185,6 +187,32 @@ export function combineKintoneQueries(...queries: Array<string | null | undefine
     .join(' and ')
 }
 
+function getSyncConcurrencyLimit(): number {
+  const rawValue = process.env.SYNC_CONCURRENCY
+  if (!rawValue) {
+    return DEFAULT_SYNC_CONCURRENCY
+  }
+
+  const parsedValue = Number.parseInt(rawValue, 10)
+  if (!Number.isFinite(parsedValue) || parsedValue < 1) {
+    console.warn('[sync] invalid SYNC_CONCURRENCY; using default', {
+      value: rawValue,
+      defaultValue: DEFAULT_SYNC_CONCURRENCY,
+    })
+    return DEFAULT_SYNC_CONCURRENCY
+  }
+
+  return parsedValue
+}
+
+function assertConcurrencyLimit(limit: number): number {
+  if (!Number.isFinite(limit) || !Number.isInteger(limit) || limit < 1) {
+    throw new Error(`Invalid concurrency limit: ${limit}. Expected an integer >= 1.`)
+  }
+
+  return limit
+}
+
 async function runWithConcurrency<T, R>(
   items: T[],
   limit: number,
@@ -193,6 +221,7 @@ async function runWithConcurrency<T, R>(
   const results: any[] = []
   let index = 0
   const runners: Promise<void>[] = []
+  const concurrencyLimit = assertConcurrencyLimit(limit)
   const runNext = async (): Promise<void> => {
     if (index >= items.length) return
     const current = index++
@@ -203,7 +232,7 @@ async function runWithConcurrency<T, R>(
       await runNext()
     }
   }
-  const size = Math.min(limit, items.length)
+  const size = Math.min(concurrencyLimit, items.length)
   for (let i = 0; i < size; i++) runners.push(runNext())
   await Promise.all(runners)
   return results as R[]
@@ -722,7 +751,7 @@ export class KintoneDataSync {
       // Process each mapping
       for (const appMapping of appMappings) {
         // Build query using only database filter conditions
-        const filterQuery = await this.buildFilterQuery(targetAppType, appMappingId)
+        const filterQuery = await this.buildFilterQuery(targetAppType, appMapping.id)
         const recordIdQuery = buildRecordIdQuery(options)
         const query = combineKintoneQueries(filterQuery, recordIdQuery)
         console.log('[sync] kintone-query', {
@@ -749,7 +778,7 @@ export class KintoneDataSync {
         }
 
         // Process records with limited concurrency to speed up while avoiding timeouts
-        const CONCURRENCY_LIMIT = Number(process.env.SYNC_CONCURRENCY || 6)
+        const CONCURRENCY_LIMIT = getSyncConcurrencyLimit()
         await runWithConcurrency(records, CONCURRENCY_LIMIT, async (record) => {
           try {
             // Transform Kintone record to our format using database field mappings
@@ -916,94 +945,105 @@ export class KintoneDataSync {
       })
 
       const records = await this.kintoneClient.getRecords(appMapping.source_app_id, query, [])
-      const CONCURRENCY_LIMIT = Number(process.env.SYNC_CONCURRENCY || 6)
+      const CONCURRENCY_LIMIT = getSyncConcurrencyLimit()
       let syncedCount = 0
       let skippedNotImportable = 0
       let skippedUnlinked = 0
       let skippedAmbiguousPerson = 0
+      let failedRecords = 0
 
       await runWithConcurrency(records, CONCURRENCY_LIMIT, async (record) => {
-        const sourceRecordId = getInterviewRecordSourceRecordId(record) || 'unknown'
+        let sourceRecordId = 'unknown'
 
-        if (!isImportableInterviewRecord(record)) {
-          skippedNotImportable++
-          console.log('[sync] interview-records:skip', {
-            sourceRecordId,
-            reason: 'not-importable',
+        try {
+          sourceRecordId = getInterviewRecordSourceRecordId(record) || 'unknown'
+
+          if (!isImportableInterviewRecord(record)) {
+            skippedNotImportable++
+            console.log('[sync] interview-records:skip', {
+              sourceRecordId,
+              reason: 'not-importable',
+            })
+            return
+          }
+
+          const sourcePersonId = getInterviewRecordSourcePersonId(record)
+          if (!sourcePersonId) {
+            skippedUnlinked++
+            console.warn('[sync] interview-records:skip', {
+              sourceRecordId,
+              reason: 'missing-source-person-id',
+            })
+            return
+          }
+
+          const { data: people, error: personError } = await this.supabase
+            .from('people')
+            .select('id')
+            .eq('tenant_id', this.tenantId)
+            .eq('external_id', sourcePersonId)
+            .limit(2)
+
+          if (personError) {
+            console.error('[sync] interview-records:person-lookup-error', {
+              sourceRecordId,
+              error: personError.message,
+            })
+            throw personError
+          }
+
+          if (!people || people.length === 0) {
+            skippedUnlinked++
+            console.warn('[sync] interview-records:skip', {
+              sourceRecordId,
+              reason: 'person-not-found',
+            })
+            return
+          }
+
+          if (people.length > 1) {
+            skippedAmbiguousPerson++
+            console.warn('[sync] interview-records:skip', {
+              sourceRecordId,
+              reason: 'ambiguous-person',
+            })
+            return
+          }
+
+          const now = new Date().toISOString()
+          const payload = transformInterviewRecord(record, {
+            tenantId: this.tenantId,
+            personId: people[0].id,
+            sourceAppId: appMapping.source_app_id,
           })
-          return
-        }
 
-        const sourcePersonId = getInterviewRecordSourcePersonId(record)
-        if (!sourcePersonId) {
-          skippedUnlinked++
-          console.warn('[sync] interview-records:skip', {
+          const { error: upsertError } = await this.supabase
+            .from('interview_records')
+            .upsert(
+              {
+                ...payload,
+                synced_at: now,
+                updated_at: now,
+              },
+              { onConflict: 'tenant_id,source_system,source_app_id,source_record_id' }
+            )
+
+          if (upsertError) {
+            console.error('[sync] interview-records:db-error', {
+              sourceRecordId,
+              error: upsertError.message,
+            })
+            throw upsertError
+          }
+
+          syncedCount++
+        } catch (err) {
+          failedRecords++
+          console.error('[sync] interview-records:record-failure', {
             sourceRecordId,
-            reason: 'missing-source-person-id',
+            error: err instanceof Error ? err.message : err,
           })
-          return
         }
-
-        const { data: people, error: personError } = await this.supabase
-          .from('people')
-          .select('id')
-          .eq('tenant_id', this.tenantId)
-          .eq('external_id', sourcePersonId)
-          .limit(2)
-
-        if (personError) {
-          console.error('[sync] interview-records:person-lookup-error', {
-            sourceRecordId,
-            error: personError.message,
-          })
-          throw personError
-        }
-
-        if (!people || people.length === 0) {
-          skippedUnlinked++
-          console.warn('[sync] interview-records:skip', {
-            sourceRecordId,
-            reason: 'person-not-found',
-          })
-          return
-        }
-
-        if (people.length > 1) {
-          skippedAmbiguousPerson++
-          console.warn('[sync] interview-records:skip', {
-            sourceRecordId,
-            reason: 'ambiguous-person',
-          })
-          return
-        }
-
-        const now = new Date().toISOString()
-        const payload = transformInterviewRecord(record, {
-          tenantId: this.tenantId,
-          personId: people[0].id,
-          sourceAppId: appMapping.source_app_id,
-        })
-
-        const { error: upsertError } = await this.supabase
-          .from('interview_records')
-          .upsert(
-            {
-              ...payload,
-              synced_at: now,
-              updated_at: now,
-            },
-            { onConflict: 'tenant_id,source_system,source_app_id,source_record_id' }
-          )
-
-        if (upsertError) {
-          console.error('[sync] interview-records:db-error', {
-            sourceRecordId,
-            error: upsertError.message,
-          })
-          throw upsertError
-        }
-
-        syncedCount++
       })
 
       console.log('[sync] interview-records:summary', {
@@ -1013,6 +1053,7 @@ export class KintoneDataSync {
         skippedNotImportable,
         skippedUnlinked,
         skippedAmbiguousPerson,
+        failedRecords,
       })
 
       totalSyncedCount += syncedCount

--- a/lib/sync/kintone-sync.ts
+++ b/lib/sync/kintone-sync.ts
@@ -13,6 +13,13 @@ import { SyncLogger, createSyncLogger } from './sync-logger'
 import { getUpdateKeysByConnector, buildConflictColumns, buildUpdateCondition, getKintoneRecordValue } from './update-key-utils'
 import { uploadFileToStorage } from '@/lib/storage/file-uploader'
 import { getDataMappings, mapFieldValues, type DataMapping } from '@/lib/mappings/value-mapper'
+import {
+  buildInterviewRecordsQuery,
+  getInterviewRecordSourcePersonId,
+  getInterviewRecordSourceRecordId,
+  isImportableInterviewRecord,
+  transformInterviewRecord,
+} from './interview-record-transformer'
 // import { getKintoneMapping, type KintoneMapping } from './mapping-loader'
 
 // Types for field mappings
@@ -176,6 +183,30 @@ export function combineKintoneQueries(...queries: Array<string | null | undefine
     .map((query) => query?.trim())
     .filter((query): query is string => !!query)
     .join(' and ')
+}
+
+async function runWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: any[] = []
+  let index = 0
+  const runners: Promise<void>[] = []
+  const runNext = async (): Promise<void> => {
+    if (index >= items.length) return
+    const current = index++
+    try {
+      const res = await worker(items[current])
+      results[current] = res
+    } finally {
+      await runNext()
+    }
+  }
+  const size = Math.min(limit, items.length)
+  for (let i = 0; i < size; i++) runners.push(runNext())
+  await Promise.all(runners)
+  return results as R[]
 }
 
 /**
@@ -444,7 +475,7 @@ export class KintoneDataSync {
   /**
    * Build Kintone query from filter conditions
    */
-  private async buildFilterQuery(appType: 'people' | 'visas', appMappingId?: string): Promise<string> {
+  private async buildFilterQuery(appType: string, appMappingId?: string): Promise<string> {
     try {
       let mappingId: string
 
@@ -684,31 +715,14 @@ export class KintoneDataSync {
       
       let totalSyncedCount = 0
 
-      // Simple concurrency limiter (promise pool)
-      const runWithConcurrency = async <T, R>(items: T[], limit: number, worker: (item: T) => Promise<R>): Promise<R[]> => {
-        const results: any[] = []
-        let index = 0
-        const runners: Promise<void>[] = []
-        const runNext = async (): Promise<void> => {
-          if (index >= items.length) return
-          const current = index++
-          try {
-            const res = await worker(items[current])
-            results[current] = res
-          } finally {
-            await runNext()
-          }
-        }
-        const size = Math.min(limit, items.length)
-        for (let i = 0; i < size; i++) runners.push(runNext())
-        await Promise.all(runners)
-        return results as R[]
+      if (targetAppType === 'interview_records') {
+        return this.syncInterviewRecords(appMappings, options)
       }
       
       // Process each mapping
       for (const appMapping of appMappings) {
         // Build query using only database filter conditions
-        const filterQuery = await this.buildFilterQuery(targetAppType as 'people' | 'visas', appMappingId)
+        const filterQuery = await this.buildFilterQuery(targetAppType, appMappingId)
         const recordIdQuery = buildRecordIdQuery(options)
         const query = combineKintoneQueries(filterQuery, recordIdQuery)
         console.log('[sync] kintone-query', {
@@ -882,6 +896,131 @@ export class KintoneDataSync {
     }
   }
 
+  private async syncInterviewRecords(
+    appMappings: AppMapping[],
+    options: KintoneSyncOptions = {}
+  ): Promise<number> {
+    let totalSyncedCount = 0
+
+    for (const appMapping of appMappings) {
+      const filterQuery = buildInterviewRecordsQuery(
+        await this.buildFilterQuery('interview_records', appMapping.id)
+      )
+      const recordIdQuery = buildRecordIdQuery(options)
+      const query = combineKintoneQueries(filterQuery, recordIdQuery)
+
+      console.log('[sync] interview-records:kintone-query', {
+        sourceAppId: appMapping.source_app_id,
+        appMappingId: appMapping.id,
+        query,
+      })
+
+      const records = await this.kintoneClient.getRecords(appMapping.source_app_id, query, [])
+      const CONCURRENCY_LIMIT = Number(process.env.SYNC_CONCURRENCY || 6)
+      let syncedCount = 0
+      let skippedNotImportable = 0
+      let skippedUnlinked = 0
+      let skippedAmbiguousPerson = 0
+
+      await runWithConcurrency(records, CONCURRENCY_LIMIT, async (record) => {
+        const sourceRecordId = getInterviewRecordSourceRecordId(record) || 'unknown'
+
+        if (!isImportableInterviewRecord(record)) {
+          skippedNotImportable++
+          console.log('[sync] interview-records:skip', {
+            sourceRecordId,
+            reason: 'not-importable',
+          })
+          return
+        }
+
+        const sourcePersonId = getInterviewRecordSourcePersonId(record)
+        if (!sourcePersonId) {
+          skippedUnlinked++
+          console.warn('[sync] interview-records:skip', {
+            sourceRecordId,
+            reason: 'missing-source-person-id',
+          })
+          return
+        }
+
+        const { data: people, error: personError } = await this.supabase
+          .from('people')
+          .select('id')
+          .eq('tenant_id', this.tenantId)
+          .eq('external_id', sourcePersonId)
+          .limit(2)
+
+        if (personError) {
+          console.error('[sync] interview-records:person-lookup-error', {
+            sourceRecordId,
+            error: personError.message,
+          })
+          throw personError
+        }
+
+        if (!people || people.length === 0) {
+          skippedUnlinked++
+          console.warn('[sync] interview-records:skip', {
+            sourceRecordId,
+            reason: 'person-not-found',
+          })
+          return
+        }
+
+        if (people.length > 1) {
+          skippedAmbiguousPerson++
+          console.warn('[sync] interview-records:skip', {
+            sourceRecordId,
+            reason: 'ambiguous-person',
+          })
+          return
+        }
+
+        const now = new Date().toISOString()
+        const payload = transformInterviewRecord(record, {
+          tenantId: this.tenantId,
+          personId: people[0].id,
+          sourceAppId: appMapping.source_app_id,
+        })
+
+        const { error: upsertError } = await this.supabase
+          .from('interview_records')
+          .upsert(
+            {
+              ...payload,
+              synced_at: now,
+              updated_at: now,
+            },
+            { onConflict: 'tenant_id,source_system,source_app_id,source_record_id' }
+          )
+
+        if (upsertError) {
+          console.error('[sync] interview-records:db-error', {
+            sourceRecordId,
+            error: upsertError.message,
+          })
+          throw upsertError
+        }
+
+        syncedCount++
+      })
+
+      console.log('[sync] interview-records:summary', {
+        appMappingId: appMapping.id,
+        fetched: records.length,
+        synced: syncedCount,
+        skippedNotImportable,
+        skippedUnlinked,
+        skippedAmbiguousPerson,
+      })
+
+      totalSyncedCount += syncedCount
+    }
+
+    return totalSyncedCount
+  }
+
   /**
    * Get target table name for app type
    */
@@ -890,7 +1029,8 @@ export class KintoneDataSync {
       'people': 'people',
       'people_image': 'people',
       'visas': 'visas',
-      'meetings': 'meetings'
+      'meetings': 'meetings',
+      'interview_records': 'interview_records'
     }
     return tableMap[targetAppType] || null
   }

--- a/scripts/sync-by-type.ts
+++ b/scripts/sync-by-type.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 import { createSyncService } from '@/lib/sync/kintone-sync'
 
-type SyncTargetType = 'people' | 'visas'
+type SyncTargetType = 'people' | 'visas' | 'interview_records'
 type CliSyncType = SyncTargetType | 'both'
 
 function getArgValue(flag: string): string | undefined {
@@ -17,11 +17,11 @@ function parseSyncType(): CliSyncType {
   const rawType = getArgValue('--type') || process.env.SYNC_TYPE
 
   if (!rawType) {
-    throw new Error('Missing sync type. Use --type people|visas|both')
+    throw new Error('Missing sync type. Use --type people|visas|interview_records|both')
   }
 
-  if (rawType !== 'people' && rawType !== 'visas' && rawType !== 'both') {
-    throw new Error(`Invalid sync type "${rawType}". Use people, visas, or both`)
+  if (rawType !== 'people' && rawType !== 'visas' && rawType !== 'interview_records' && rawType !== 'both') {
+    throw new Error(`Invalid sync type "${rawType}". Use people, visas, interview_records, or both`)
   }
 
   return rawType


### PR DESCRIPTION
## Summary
- Add a dedicated `interview_records` sync path for Kintone App 98 records.
- Import only completed App 98 records and normalize `定期面談` / `日々の面談` into `regular_interview` / `daily_support`.
- Resolve records through `HRID -> people.external_id` within the connector tenant, and skip unresolved/ambiguous records with safe summary logs.
- Add explicit manual `interview_records` sync support without changing the existing scheduled people/visas sync behavior.

## Verification
- `pnpm exec vitest run lib/sync/interview-record-transformer.test.ts`
- `pnpm dlx tsx@4.20.3 -e "import('./lib/sync/kintone-sync.ts').then(() => console.log('kintone-sync import ok'))"`
- `pnpm dlx tsx@4.20.3 -e "Promise.all([import('./app/api/cron/sync-by-type/route.ts'), import('./app/api/schema/[app]/route.ts')]).then(() => console.log('api route imports ok'))"`
- `git diff --check`

## Production note
Draft until production DB deploy baseline is repaired. Current DB deploy is blocked by the pre-existing migration history mismatch from fun-base-infra #41, so this PR should not be treated as production-ready yet.

Closes funtoco/fun-docs#758

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for syncing interview records from Kintone, enabling automated data synchronization with validation and transformation of interview information.

* **Tests**
  * Added comprehensive test coverage for interview record transformation and processing logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/funtoco/fun-base/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->