### PR TITLE
fix: link interview records by WOID

### DIFF
--- a/lib/sync/interview-record-transformer.test.ts
+++ b/lib/sync/interview-record-transformer.test.ts
@@ -57,6 +57,7 @@ test('transformInterviewRecord maps regular interview fields to interview_record
       $id: { value: '9559' },
       $revision: { value: '3' },
       HRID: { value: '3505' },
+      WOID: { value: '2447' },
       COID: { value: '3222' },
       companyName: { value: '株式会社ABC製造' },
       interview: { value: '定期面談' },
@@ -83,10 +84,10 @@ test('transformInterviewRecord maps regular interview fields to interview_record
 
   assert.equal(row.tenant_id, 'tenant-1')
   assert.equal(row.person_id, 'person-1')
-  assert.equal(row.source_person_id, '3505')
   assert.equal(row.source_system, 'kintone')
   assert.equal(row.source_app_id, '98')
   assert.equal(row.source_record_id, '9559')
+  assert.equal(row.source_person_id, '2447')
   assert.equal(row.record_type, 'regular_interview')
   assert.equal(row.source_status, '完了')
   assert.equal(row.interview_date, '2026-05-14')
@@ -94,6 +95,27 @@ test('transformInterviewRecord maps regular interview fields to interview_record
   assert.equal(row.external_confirmation_status, DEFAULT_EXTERNAL_CONFIRMATION_STATUS)
   assert.equal(row.external_report_body, '本人の勤務状況は良好です。')
   assert.deepEqual(row.activity_entries, [])
+})
+
+test('transformInterviewRecord falls back to HRID when WOID is missing', () => {
+  const row = transformInterviewRecord(
+    {
+      $id: { value: '9562' },
+      $revision: { value: '1' },
+      HRID: { value: '3505' },
+      WOID: { value: '' },
+      interview: { value: '定期面談' },
+      Status: { value: '完了' },
+      interviewDate: { value: '2026-05-15' },
+    },
+    {
+      tenantId: 'tenant-1',
+      personId: 'person-1',
+      sourceAppId: '98',
+    }
+  )
+
+  assert.equal(row.source_person_id, '3505')
 })
 
 test('parseActivityEntries normalizes Kintone subtable rows for daily support', () => {

--- a/lib/sync/interview-record-transformer.ts
+++ b/lib/sync/interview-record-transformer.ts
@@ -125,8 +125,16 @@ export function isImportableInterviewRecord(record: KintoneRecord): boolean {
   )
 }
 
-export function getInterviewRecordSourcePersonId(record: KintoneRecord): string | null {
+export function getInterviewRecordSourceWorkId(record: KintoneRecord): string | null {
+  return toStringOrNull(fieldValue(record, 'WOID'))
+}
+
+export function getInterviewRecordSourceHumanResourceId(record: KintoneRecord): string | null {
   return toStringOrNull(fieldValue(record, 'HRID'))
+}
+
+export function getInterviewRecordSourcePersonId(record: KintoneRecord): string | null {
+  return getInterviewRecordSourceWorkId(record) ?? getInterviewRecordSourceHumanResourceId(record)
 }
 
 export function getInterviewRecordSourceRecordId(record: KintoneRecord): string | null {
@@ -162,7 +170,7 @@ export function parseActivityEntries(tableStorageDaily: any): ActivityEntry[] {
         ...(notes ? { notes } : {}),
       }
     })
-    .filter((entry): entry is ActivityEntry => entry !== null)
+    .filter((entry: ActivityEntry | null): entry is ActivityEntry => entry !== null)
 }
 
 function toRawRecordJson(record: KintoneRecord): Record<string, unknown> {
@@ -194,7 +202,7 @@ export function transformInterviewRecord(
   return {
     tenant_id: context.tenantId,
     person_id: context.personId,
-    source_person_id: toStringOrNull(fieldValue(record, 'HRID')),
+    source_person_id: getInterviewRecordSourcePersonId(record),
     source_system: KINTONE_INTERVIEW_SOURCE_SYSTEM,
     source_app_id: context.sourceAppId,
     source_record_id: sourceRecordId,

--- a/lib/sync/kintone-sync.ts
+++ b/lib/sync/kintone-sync.ts
@@ -15,8 +15,9 @@ import { uploadFileToStorage } from '@/lib/storage/file-uploader'
 import { getDataMappings, mapFieldValues, type DataMapping } from '@/lib/mappings/value-mapper'
 import {
   buildInterviewRecordsQuery,
-  getInterviewRecordSourcePersonId,
+  getInterviewRecordSourceHumanResourceId,
   getInterviewRecordSourceRecordId,
+  getInterviewRecordSourceWorkId,
   isImportableInterviewRecord,
   transformInterviewRecord,
 } from './interview-record-transformer'
@@ -967,32 +968,60 @@ export class KintoneDataSync {
             return
           }
 
-          const sourcePersonId = getInterviewRecordSourcePersonId(record)
-          if (!sourcePersonId) {
+          const sourceWorkId = getInterviewRecordSourceWorkId(record)
+          const sourceHumanResourceId = getInterviewRecordSourceHumanResourceId(record)
+          if (!sourceWorkId && !sourceHumanResourceId) {
             skippedUnlinked++
             console.warn('[sync] interview-records:skip', {
               sourceRecordId,
-              reason: 'missing-source-person-id',
+              reason: 'missing-source-person-link-id',
             })
             return
           }
 
-          const { data: people, error: personError } = await this.supabase
-            .from('people')
-            .select('id')
-            .eq('tenant_id', this.tenantId)
-            .eq('external_id', sourcePersonId)
-            .limit(2)
+          let personId: string | null = null
+          if (sourceWorkId) {
+            const { data: workIdPeople, error: workIdPersonError } = await this.supabase
+              .from('people')
+              .select('id')
+              .eq('tenant_id', this.tenantId)
+              .eq('id', sourceWorkId)
+              .limit(1)
 
-          if (personError) {
-            console.error('[sync] interview-records:person-lookup-error', {
-              sourceRecordId,
-              error: personError.message,
-            })
-            throw personError
+            if (workIdPersonError) {
+              console.error('[sync] interview-records:person-lookup-error', {
+                sourceRecordId,
+                lookup: 'WOID',
+                error: workIdPersonError.message,
+              })
+              throw workIdPersonError
+            }
+
+            personId = workIdPeople?.[0]?.id ?? null
           }
 
-          if (!people || people.length === 0) {
+          let fallbackPeople: Array<{ id: string }> | null = null
+          if (!personId && sourceHumanResourceId) {
+            const { data: people, error: personError } = await this.supabase
+              .from('people')
+              .select('id')
+              .eq('tenant_id', this.tenantId)
+              .eq('external_id', sourceHumanResourceId)
+              .limit(2)
+
+            if (personError) {
+              console.error('[sync] interview-records:person-lookup-error', {
+                sourceRecordId,
+                lookup: 'HRID',
+                error: personError.message,
+              })
+              throw personError
+            }
+
+            fallbackPeople = people
+          }
+
+          if (!personId && (!fallbackPeople || fallbackPeople.length === 0)) {
             skippedUnlinked++
             console.warn('[sync] interview-records:skip', {
               sourceRecordId,
@@ -1001,7 +1030,7 @@ export class KintoneDataSync {
             return
           }
 
-          if (people.length > 1) {
+          if (!personId && fallbackPeople && fallbackPeople.length > 1) {
             skippedAmbiguousPerson++
             console.warn('[sync] interview-records:skip', {
               sourceRecordId,
@@ -1010,10 +1039,20 @@ export class KintoneDataSync {
             return
           }
 
+          personId = personId ?? fallbackPeople?.[0]?.id ?? null
+          if (!personId) {
+            skippedUnlinked++
+            console.warn('[sync] interview-records:skip', {
+              sourceRecordId,
+              reason: 'person-not-found',
+            })
+            return
+          }
+
           const now = new Date().toISOString()
           const payload = transformInterviewRecord(record, {
             tenantId: this.tenantId,
-            personId: people[0].id,
+            personId,
             sourceAppId: appMapping.source_app_id,
           })
 


### PR DESCRIPTION
## Summary
- Use App 98 `WOID` as the primary link to `people.id` for interview record sync
- Keep `HRID` as fallback via `people.external_id` for records where `WOID` is missing
- Store `source_person_id` as `WOID || HRID` so imported rows follow the same identity rule

## Why
The production pilot sync reached Kintone successfully but synced `0` rows. The endpoint was valid; the remaining issue is that App 98 records should link to FunBase people by `WOID` (work management id), not primarily by `HRID`. `HRID/external_id` remains useful for person-master/photo-style linking.

## Verification
- `npm test -- lib/sync/interview-record-transformer.test.ts`
- `git diff --check`
- `npm run typecheck` still fails on existing baseline errors outside this PR; no `lib/sync/interview-record-transformer.ts` or `lib/sync/kintone-sync.ts` errors after filtering the output.

Related: funtoco/fun-docs#766

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced interview record synchronization with improved identifier resolution and fallback logic
  * Strengthened data matching accuracy by implementing hierarchical source field handling
  * Updated validation to ensure proper fallback behavior when primary identifier sources are unavailable

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/funtoco/fun-base/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->