### PR TITLE
fix: read App 98 interview category field

### DIFF
--- a/lib/sync/interview-record-transformer.test.ts
+++ b/lib/sync/interview-record-transformer.test.ts
@@ -15,7 +15,8 @@ test('isImportableInterviewRecord only accepts completed regular or daily interv
       $id: { value: '9559' },
       $revision: { value: '1' },
       Status: { value: '完了' },
-      interview: { value: '定期面談' },
+      interview: { value: '<div><br /></div>' },
+      timeInterview: { value: '定期面談' },
     }),
     true
   )
@@ -24,7 +25,7 @@ test('isImportableInterviewRecord only accepts completed regular or daily interv
       $id: { value: '9560' },
       $revision: { value: '1' },
       Status: { value: '確認中' },
-      interview: { value: '定期面談' },
+      timeInterview: { value: '定期面談' },
     }),
     false
   )
@@ -33,7 +34,7 @@ test('isImportableInterviewRecord only accepts completed regular or daily interv
       $id: { value: '9561' },
       $revision: { value: '1' },
       Status: { value: '完了' },
-      interview: { value: '家族面談' },
+      timeInterview: { value: '家族面談' },
     }),
     false
   )
@@ -60,13 +61,13 @@ test('transformInterviewRecord maps regular interview fields to interview_record
       WOID: { value: '2447' },
       COID: { value: '3222' },
       companyName: { value: '株式会社ABC製造' },
-      interview: { value: '定期面談' },
+      interview: { value: '<div><br /></div>' },
       Status: { value: '完了' },
       interviewDate: { value: '2026-05-14' },
       Time: { value: '14:00' },
       Time_0: { value: '15:00' },
       targetQuarter: { value: '2026年第2四半期' },
-      timeInterview: { value: '60' },
+      timeInterview: { value: '定期面談' },
       interviewMethod: { value: '対面' },
       interviewPlace: { value: '本社会議室' },
       supportName: { value: [{ name: '田中' }] },
@@ -104,7 +105,7 @@ test('transformInterviewRecord falls back to HRID when WOID is missing', () => {
       $revision: { value: '1' },
       HRID: { value: '3505' },
       WOID: { value: '' },
-      interview: { value: '定期面談' },
+      timeInterview: { value: '定期面談' },
       Status: { value: '完了' },
       interviewDate: { value: '2026-05-15' },
     },

--- a/lib/sync/interview-record-transformer.test.ts
+++ b/lib/sync/interview-record-transformer.test.ts
@@ -38,6 +38,16 @@ test('isImportableInterviewRecord only accepts completed regular or daily interv
     }),
     false
   )
+  assert.equal(
+    isImportableInterviewRecord({
+      $id: { value: '9562' },
+      $revision: { value: '1' },
+      Status: { value: '完了' },
+      interview: { value: '定期面談' },
+      timeInterview: { value: ' ' },
+    }),
+    true
+  )
 })
 
 test('buildInterviewRecordsQuery keeps connector filters and enforces completed status', () => {
@@ -96,6 +106,29 @@ test('transformInterviewRecord maps regular interview fields to interview_record
   assert.equal(row.external_confirmation_status, DEFAULT_EXTERNAL_CONFIRMATION_STATUS)
   assert.equal(row.external_report_body, '本人の勤務状況は良好です。')
   assert.deepEqual(row.activity_entries, [])
+})
+
+test('transformInterviewRecord ignores invalid clock values for duration', () => {
+  const row = transformInterviewRecord(
+    {
+      $id: { value: '9563' },
+      $revision: { value: '1' },
+      HRID: { value: '3505' },
+      WOID: { value: '2447' },
+      timeInterview: { value: '定期面談' },
+      Status: { value: '完了' },
+      interviewDate: { value: '2026-05-15' },
+      Time: { value: '14:99' },
+      Time_0: { value: '15:00' },
+    },
+    {
+      tenantId: 'tenant-1',
+      personId: 'person-1',
+      sourceAppId: '98',
+    }
+  )
+
+  assert.equal(row.interview_duration_minutes, null)
 })
 
 test('transformInterviewRecord falls back to HRID when WOID is missing', () => {

--- a/lib/sync/interview-record-transformer.ts
+++ b/lib/sync/interview-record-transformer.ts
@@ -92,8 +92,16 @@ function toMinutesOrNull(startTime: string | null, endTime: string | null): numb
   const endMatch = /^(\d{1,2}):(\d{2})$/.exec(endTime)
   if (!startMatch || !endMatch) return null
 
-  const startMinutes = Number(startMatch[1]) * 60 + Number(startMatch[2])
-  const endMinutes = Number(endMatch[1]) * 60 + Number(endMatch[2])
+  const startHour = Number(startMatch[1])
+  const startMinute = Number(startMatch[2])
+  const endHour = Number(endMatch[1])
+  const endMinute = Number(endMatch[2])
+  if (startHour > 23 || endHour > 23 || startMinute > 59 || endMinute > 59) {
+    return null
+  }
+
+  const startMinutes = startHour * 60 + startMinute
+  const endMinutes = endHour * 60 + endMinute
   const duration = endMinutes - startMinutes
 
   return duration >= 0 ? duration : null
@@ -113,7 +121,7 @@ function normalizeRecordType(value: any): RecordType | null {
 }
 
 function recordTypeValue(record: KintoneRecord): any {
-  return fieldValue(record, 'timeInterview') ?? fieldValue(record, 'interview')
+  return toStringOrNull(fieldValue(record, 'timeInterview')) ?? fieldValue(record, 'interview')
 }
 
 function hasCompletedStatusFilter(query: string): boolean {

--- a/lib/sync/interview-record-transformer.ts
+++ b/lib/sync/interview-record-transformer.ts
@@ -85,10 +85,18 @@ function toStringOrNull(value: any): string | null {
   return nonEmptyStringOrNull(labelValue(value))
 }
 
-function toNumberOrNull(value: any): number | null {
-  if (value === undefined || value === null || value === '') return null
-  const parsed = Number(value)
-  return Number.isFinite(parsed) ? parsed : null
+function toMinutesOrNull(startTime: string | null, endTime: string | null): number | null {
+  if (!startTime || !endTime) return null
+
+  const startMatch = /^(\d{1,2}):(\d{2})$/.exec(startTime)
+  const endMatch = /^(\d{1,2}):(\d{2})$/.exec(endTime)
+  if (!startMatch || !endMatch) return null
+
+  const startMinutes = Number(startMatch[1]) * 60 + Number(startMatch[2])
+  const endMinutes = Number(endMatch[1]) * 60 + Number(endMatch[2])
+  const duration = endMinutes - startMinutes
+
+  return duration >= 0 ? duration : null
 }
 
 function toDateOrNull(value: any): string | null {
@@ -102,6 +110,10 @@ function normalizeRecordType(value: any): RecordType | null {
   if (text === '定期面談') return 'regular_interview'
   if (text === '日々の面談') return 'daily_support'
   return null
+}
+
+function recordTypeValue(record: KintoneRecord): any {
+  return fieldValue(record, 'timeInterview') ?? fieldValue(record, 'interview')
 }
 
 function hasCompletedStatusFilter(query: string): boolean {
@@ -121,7 +133,7 @@ export function buildInterviewRecordsQuery(baseQuery = ''): string {
 export function isImportableInterviewRecord(record: KintoneRecord): boolean {
   return (
     toStringOrNull(fieldValue(record, 'Status')) === IMPORTABLE_INTERVIEW_STATUS &&
-    normalizeRecordType(fieldValue(record, 'interview')) !== null
+    normalizeRecordType(recordTypeValue(record)) !== null
   )
 }
 
@@ -185,9 +197,11 @@ export function transformInterviewRecord(
     throw new Error('Interview record is not importable')
   }
 
-  const recordType = normalizeRecordType(fieldValue(record, 'interview'))
+  const recordType = normalizeRecordType(recordTypeValue(record))
   const interviewDate = toDateOrNull(fieldValue(record, 'interviewDate'))
   const sourceRecordId = toStringOrNull(fieldValue(record, '$id'))
+  const startTime = toStringOrNull(fieldValue(record, 'Time'))
+  const endTime = toStringOrNull(fieldValue(record, 'Time_0'))
 
   if (!recordType) {
     throw new Error('Unsupported interview record type')
@@ -209,12 +223,12 @@ export function transformInterviewRecord(
     record_type: recordType,
     source_status: toStringOrNull(fieldValue(record, 'Status')) || IMPORTABLE_INTERVIEW_STATUS,
     interview_date: interviewDate,
-    start_time: toStringOrNull(fieldValue(record, 'Time')),
-    end_time: toStringOrNull(fieldValue(record, 'Time_0')),
+    start_time: startTime,
+    end_time: endTime,
     target_quarter: toStringOrNull(fieldValue(record, 'targetQuarter')),
     interview_method: toStringOrNull(fieldValue(record, 'interviewMethod')),
     interview_place: toStringOrNull(fieldValue(record, 'interviewPlace')),
-    interview_duration_minutes: toNumberOrNull(fieldValue(record, 'timeInterview')),
+    interview_duration_minutes: toMinutesOrNull(startTime, endTime),
     company_id: toStringOrNull(fieldValue(record, 'COID')),
     company_name: toStringOrNull(fieldValue(record, 'companyName')),
     support_staff_name: toStringOrNull(fieldValue(record, 'supportName')),


### PR DESCRIPTION
## Summary
- Read App 98 record type from `timeInterview` first, falling back to `interview`
- Keep record 8841-style payloads importable where `interview` is blank HTML and `timeInterview` is `定期面談`
- Compute interview duration from `Time` / `Time_0` instead of using `timeInterview`, since that field is the interview category

## Why
Production pilot sync now reaches Kintone and links `WOID` to `people.id`, but still syncs 0 rows. A raw App 98 record showed `interview` contains blank HTML while the visible category is stored in `timeInterview`, so records were skipped as not importable.

## Verification
- `npm test -- lib/sync/interview-record-transformer.test.ts`
- `npm run typecheck 2>&1 | rg "lib/sync/(interview-record-transformer|kintone-sync)" || true`
- `git diff --check`

Related: funtoco/fun-docs#766

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated interview duration calculation to derive from start and end times instead of relying on a stored duration value
  * Improved interview type detection to use the correct data field structure for more accurate record identification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/funtoco/fun-base/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->