### PR TITLE
fix: import daily interview records regardless of status

### DIFF
--- a/lib/sync/interview-record-transformer.test.ts
+++ b/lib/sync/interview-record-transformer.test.ts
@@ -62,7 +62,17 @@ test('isImportableInterviewRecord only requires completed status for regular int
 test('buildInterviewRecordsQuery keeps connector filters and limits record categories', () => {
   assert.equal(
     buildInterviewRecordsQuery('COID = "3222"'),
-    'COID = "3222" and (timeInterview = "定期面談" or timeInterview = "日々の面談")'
+    '(COID = "3222") and (timeInterview = "定期面談" or timeInterview = "日々の面談")'
+  )
+
+  assert.equal(
+    buildInterviewRecordsQuery('COID = "3222" or Status = "確認不要"'),
+    '(COID = "3222" or Status = "確認不要") and (timeInterview = "定期面談" or timeInterview = "日々の面談")'
+  )
+
+  assert.equal(
+    buildInterviewRecordsQuery('(COID = "3222" or Status = "確認不要")'),
+    '(COID = "3222" or Status = "確認不要") and (timeInterview = "定期面談" or timeInterview = "日々の面談")'
   )
 
   assert.equal(

--- a/lib/sync/interview-record-transformer.test.ts
+++ b/lib/sync/interview-record-transformer.test.ts
@@ -9,7 +9,7 @@ import {
   transformInterviewRecord,
 } from './interview-record-transformer'
 
-test('isImportableInterviewRecord only accepts completed regular or daily interview records', () => {
+test('isImportableInterviewRecord only requires completed status for regular interviews', () => {
   assert.equal(
     isImportableInterviewRecord({
       $id: { value: '9559' },
@@ -24,6 +24,15 @@ test('isImportableInterviewRecord only accepts completed regular or daily interv
     isImportableInterviewRecord({
       $id: { value: '9560' },
       $revision: { value: '1' },
+      Status: { value: '確認不要' },
+      timeInterview: { value: '日々の面談' },
+    }),
+    true
+  )
+  assert.equal(
+    isImportableInterviewRecord({
+      $id: { value: '9561' },
+      $revision: { value: '1' },
       Status: { value: '確認中' },
       timeInterview: { value: '定期面談' },
     }),
@@ -31,7 +40,7 @@ test('isImportableInterviewRecord only accepts completed regular or daily interv
   )
   assert.equal(
     isImportableInterviewRecord({
-      $id: { value: '9561' },
+      $id: { value: '9562' },
       $revision: { value: '1' },
       Status: { value: '完了' },
       timeInterview: { value: '家族面談' },
@@ -40,7 +49,7 @@ test('isImportableInterviewRecord only accepts completed regular or daily interv
   )
   assert.equal(
     isImportableInterviewRecord({
-      $id: { value: '9562' },
+      $id: { value: '9563' },
       $revision: { value: '1' },
       Status: { value: '完了' },
       interview: { value: '定期面談' },
@@ -50,15 +59,20 @@ test('isImportableInterviewRecord only accepts completed regular or daily interv
   )
 })
 
-test('buildInterviewRecordsQuery keeps connector filters and enforces completed status', () => {
+test('buildInterviewRecordsQuery keeps connector filters and limits record categories', () => {
   assert.equal(
     buildInterviewRecordsQuery('COID = "3222"'),
-    'COID = "3222" and Status = "完了"'
+    'COID = "3222" and (timeInterview = "定期面談" or timeInterview = "日々の面談")'
   )
 
   assert.equal(
-    buildInterviewRecordsQuery('COID = "3222" and Status = "完了"'),
-    'COID = "3222" and Status = "完了"'
+    buildInterviewRecordsQuery('COID = "3222" and (timeInterview = "定期面談" or timeInterview = "日々の面談")'),
+    'COID = "3222" and (timeInterview = "定期面談" or timeInterview = "日々の面談")'
+  )
+
+  assert.equal(
+    buildInterviewRecordsQuery(),
+    '(timeInterview = "定期面談" or timeInterview = "日々の面談")'
   )
 })
 
@@ -129,6 +143,47 @@ test('transformInterviewRecord ignores invalid clock values for duration', () =>
   )
 
   assert.equal(row.interview_duration_minutes, null)
+})
+
+test('transformInterviewRecord maps daily support regardless of source status', () => {
+  const row = transformInterviewRecord(
+    {
+      $id: { value: '6254' },
+      $revision: { value: '1' },
+      HRID: { value: '1697' },
+      WOID: { value: '2666' },
+      Status: { value: '確認不要' },
+      timeInterview: { value: '日々の面談' },
+      interviewDate: { value: '2025-09-30' },
+      tableStorageDaily: {
+        value: [
+          {
+            id: 'row-1',
+            value: {
+              dai: { value: '生活支援' },
+              chu: { value: '銀行・送金' },
+              shou: { value: ['口座開設'] },
+            },
+          },
+        ],
+      },
+    },
+    {
+      tenantId: 'tenant-1',
+      personId: 'person-1',
+      sourceAppId: '98',
+    }
+  )
+
+  assert.equal(row.record_type, 'daily_support')
+  assert.equal(row.source_status, '確認不要')
+  assert.deepEqual(row.activity_entries, [
+    {
+      dai: '生活支援',
+      chu: '銀行・送金',
+      shou: '口座開設',
+    },
+  ])
 })
 
 test('transformInterviewRecord falls back to HRID when WOID is missing', () => {

--- a/lib/sync/interview-record-transformer.ts
+++ b/lib/sync/interview-record-transformer.ts
@@ -3,6 +3,8 @@ import type { KintoneRecord } from '@/lib/kintone/api-client'
 export const DEFAULT_EXTERNAL_CONFIRMATION_STATUS = '確認待ち'
 export const IMPORTABLE_INTERVIEW_STATUS = '完了'
 export const KINTONE_INTERVIEW_SOURCE_SYSTEM = 'kintone'
+const KINTONE_INTERVIEW_RECORD_TYPE_QUERY =
+  '(timeInterview = "定期面談" or timeInterview = "日々の面談")'
 
 type RecordType = 'regular_interview' | 'daily_support'
 
@@ -124,25 +126,29 @@ function recordTypeValue(record: KintoneRecord): any {
   return toStringOrNull(fieldValue(record, 'timeInterview')) ?? fieldValue(record, 'interview')
 }
 
-function hasCompletedStatusFilter(query: string): boolean {
-  return /\bStatus\s*=\s*"完了"/.test(query)
+function hasRecordTypeFilter(query: string): boolean {
+  return (
+    /\btimeInterview\s*=\s*"定期面談"/.test(query) &&
+    /\btimeInterview\s*=\s*"日々の面談"/.test(query)
+  )
 }
 
 export function buildInterviewRecordsQuery(baseQuery = ''): string {
   const trimmed = baseQuery.trim()
-  const statusFilter = 'Status = "完了"'
 
-  if (!trimmed) return statusFilter
-  if (hasCompletedStatusFilter(trimmed)) return trimmed
+  if (!trimmed) return KINTONE_INTERVIEW_RECORD_TYPE_QUERY
+  if (hasRecordTypeFilter(trimmed)) return trimmed
 
-  return `${trimmed} and ${statusFilter}`
+  return `${trimmed} and ${KINTONE_INTERVIEW_RECORD_TYPE_QUERY}`
 }
 
 export function isImportableInterviewRecord(record: KintoneRecord): boolean {
-  return (
-    toStringOrNull(fieldValue(record, 'Status')) === IMPORTABLE_INTERVIEW_STATUS &&
-    normalizeRecordType(recordTypeValue(record)) !== null
-  )
+  const recordType = normalizeRecordType(recordTypeValue(record))
+  if (recordType === 'regular_interview') {
+    return toStringOrNull(fieldValue(record, 'Status')) === IMPORTABLE_INTERVIEW_STATUS
+  }
+
+  return recordType === 'daily_support'
 }
 
 export function getInterviewRecordSourceWorkId(record: KintoneRecord): string | null {

--- a/lib/sync/interview-record-transformer.ts
+++ b/lib/sync/interview-record-transformer.ts
@@ -133,13 +133,17 @@ function hasRecordTypeFilter(query: string): boolean {
   )
 }
 
+function parenthesizeQuery(query: string): string {
+  return query.startsWith('(') && query.endsWith(')') ? query : `(${query})`
+}
+
 export function buildInterviewRecordsQuery(baseQuery = ''): string {
   const trimmed = baseQuery.trim()
 
   if (!trimmed) return KINTONE_INTERVIEW_RECORD_TYPE_QUERY
   if (hasRecordTypeFilter(trimmed)) return trimmed
 
-  return `${trimmed} and ${KINTONE_INTERVIEW_RECORD_TYPE_QUERY}`
+  return `${parenthesizeQuery(trimmed)} and ${KINTONE_INTERVIEW_RECORD_TYPE_QUERY}`
 }
 
 export function isImportableInterviewRecord(record: KintoneRecord): boolean {


### PR DESCRIPTION
## Summary
- stop enforcing `Status = "完了"` globally for App 98 interview sync
- keep query bounded to App 98 interview categories via `timeInterview`
- require `完了` only for `定期面談`, while allowing all statuses for `日々の面談`

## Verification
- `npm test -- lib/sync/interview-record-transformer.test.ts`
- `git diff --check`
- `npm run typecheck 2>&1 | rg "lib/sync/(interview-record-transformer|kintone-sync)" || true`

## Notes
- Follow-up for funtoco/fun-docs#766 after #75 confirmed regular interview sync works in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interview record filtering now uses record type to properly distinguish between regular and daily interviews.
  * Daily support records are now processed without requiring completion status checks.

* **Tests**
  * Updated test suite to reflect revised interview record importability and query logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/funtoco/fun-base/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->