### PR TITLE
fix: use dropdown operator for interview type query

### DIFF
--- a/lib/sync/interview-record-transformer.test.ts
+++ b/lib/sync/interview-record-transformer.test.ts
@@ -62,27 +62,27 @@ test('isImportableInterviewRecord only requires completed status for regular int
 test('buildInterviewRecordsQuery keeps connector filters and limits record categories', () => {
   assert.equal(
     buildInterviewRecordsQuery('COID = "3222"'),
-    '(COID = "3222") and (timeInterview = "定期面談" or timeInterview = "日々の面談")'
+    '(COID = "3222") and timeInterview in ("定期面談", "日々の面談")'
   )
 
   assert.equal(
     buildInterviewRecordsQuery('COID = "3222" or Status = "確認不要"'),
-    '(COID = "3222" or Status = "確認不要") and (timeInterview = "定期面談" or timeInterview = "日々の面談")'
+    '(COID = "3222" or Status = "確認不要") and timeInterview in ("定期面談", "日々の面談")'
   )
 
   assert.equal(
     buildInterviewRecordsQuery('(COID = "3222" or Status = "確認不要")'),
-    '(COID = "3222" or Status = "確認不要") and (timeInterview = "定期面談" or timeInterview = "日々の面談")'
+    '(COID = "3222" or Status = "確認不要") and timeInterview in ("定期面談", "日々の面談")'
   )
 
   assert.equal(
-    buildInterviewRecordsQuery('COID = "3222" and (timeInterview = "定期面談" or timeInterview = "日々の面談")'),
-    'COID = "3222" and (timeInterview = "定期面談" or timeInterview = "日々の面談")'
+    buildInterviewRecordsQuery('COID = "3222" and timeInterview in ("定期面談", "日々の面談")'),
+    'COID = "3222" and timeInterview in ("定期面談", "日々の面談")'
   )
 
   assert.equal(
     buildInterviewRecordsQuery(),
-    '(timeInterview = "定期面談" or timeInterview = "日々の面談")'
+    'timeInterview in ("定期面談", "日々の面談")'
   )
 })
 

--- a/lib/sync/interview-record-transformer.ts
+++ b/lib/sync/interview-record-transformer.ts
@@ -4,7 +4,7 @@ export const DEFAULT_EXTERNAL_CONFIRMATION_STATUS = '確認待ち'
 export const IMPORTABLE_INTERVIEW_STATUS = '完了'
 export const KINTONE_INTERVIEW_SOURCE_SYSTEM = 'kintone'
 const KINTONE_INTERVIEW_RECORD_TYPE_QUERY =
-  '(timeInterview = "定期面談" or timeInterview = "日々の面談")'
+  'timeInterview in ("定期面談", "日々の面談")'
 
 type RecordType = 'regular_interview' | 'daily_support'
 
@@ -128,8 +128,9 @@ function recordTypeValue(record: KintoneRecord): any {
 
 function hasRecordTypeFilter(query: string): boolean {
   return (
-    /\btimeInterview\s*=\s*"定期面談"/.test(query) &&
-    /\btimeInterview\s*=\s*"日々の面談"/.test(query)
+    /\btimeInterview\s+in\s*\([^)]*"定期面談"[^)]*"日々の面談"[^)]*\)/.test(query) ||
+    (/\btimeInterview\s*=\s*"定期面談"/.test(query) &&
+      /\btimeInterview\s*=\s*"日々の面談"/.test(query))
   )
 }
 


### PR DESCRIPTION
## Summary
- change App 98 `timeInterview` record-type query from `=`/`or` to dropdown-compatible `in (...)`
- keep connector filter parentheses from #76
- update regression tests to cover the Kintone dropdown query shape

## Verification
- `npm test -- lib/sync/interview-record-transformer.test.ts`
- `git diff --check`
- `npm run typecheck 2>&1 | rg "lib/sync/(interview-record-transformer|kintone-sync)" || true`

## Production note
This fixes the Kintone API 400 error: `The operator = is not available for the field type of the field timeInterview.`