### PR TITLE
feat: batch interview record sync

### DIFF
--- a/.github/workflows/cron-sync.yml
+++ b/.github/workflows/cron-sync.yml
@@ -16,6 +16,10 @@ on:
           - visas
           - interview_records
           - both
+      batch_size:
+        description: 'Connector batch size for interview_records manual sync'
+        required: false
+        default: '10'
 
 jobs:
   sync-people:
@@ -100,4 +104,4 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
           echo "🕐 Starting interview_records sync at $(date)"
-          pnpm dlx tsx@4.20.3 scripts/sync-by-type.ts --type interview_records
+          pnpm dlx tsx@4.20.3 scripts/sync-by-type.ts --type interview_records --limit "${{ github.event.inputs.batch_size }}" --all-batches

--- a/.github/workflows/cron-sync.yml
+++ b/.github/workflows/cron-sync.yml
@@ -104,4 +104,8 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
           echo "🕐 Starting interview_records sync at $(date)"
-          pnpm dlx tsx@4.20.3 scripts/sync-by-type.ts --type interview_records --limit "${{ github.event.inputs.batch_size }}" --all-batches
+          cmd=(pnpm dlx tsx@4.20.3 scripts/sync-by-type.ts --type interview_records --all-batches)
+          if [ -n "${{ github.event.inputs.batch_size }}" ]; then
+            cmd+=(--limit "${{ github.event.inputs.batch_size }}")
+          fi
+          "${cmd[@]}"

--- a/app/api/cron/sync-by-type/route.ts
+++ b/app/api/cron/sync-by-type/route.ts
@@ -7,6 +7,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSyncService } from '@/lib/sync/kintone-sync'
 import { getConnector, setConnectorStatus } from '@/lib/db/connectors'
+import { buildConnectorBatchMetadata, parseConnectorBatchParams } from '@/lib/sync/connector-batch'
 import { createClient } from '@supabase/supabase-js'
 
 // Use Node.js runtime for crypto operations
@@ -50,6 +51,16 @@ async function handleSyncByType(request: NextRequest) {
     // Get target app type from query parameters
     const { searchParams } = new URL(request.url)
     const targetAppType = searchParams.get('type')
+    let batchParams
+
+    try {
+      batchParams = parseConnectorBatchParams(searchParams)
+    } catch (error) {
+      return NextResponse.json(
+        { error: error instanceof Error ? error.message : 'Invalid batch parameters' },
+        { status: 400 }
+      )
+    }
     
     if (!targetAppType || !['people', 'people_image', 'visas', 'interview_records'].includes(targetAppType)) {
       return NextResponse.json(
@@ -63,7 +74,7 @@ async function handleSyncByType(request: NextRequest) {
     const supabase = getServerClient()
     
     // Get all connected Kintone connectors that have active mappings for the target app type
-    const { data: connectors, error: connectorsError } = await supabase
+    let connectorsQuery = supabase
       .from('connectors')
       .select(`
         *,
@@ -78,6 +89,27 @@ async function handleSyncByType(request: NextRequest) {
       .eq('connection_status.status', 'connected')
       .eq('connector_app_mappings.target_app_type', targetAppType)
       .eq('connector_app_mappings.is_active', true)
+
+    const effectiveOffset = batchParams.connectorId ? 0 : batchParams.offset
+    if (batchParams.connectorId) {
+      connectorsQuery = connectorsQuery
+        .eq('id', batchParams.connectorId)
+        .limit(1)
+    } else {
+      // Fetch one extra connector to detect whether the workflow should request the next batch.
+      connectorsQuery = connectorsQuery
+        .order('created_at', { ascending: true })
+        .order('id', { ascending: true })
+        .range(batchParams.offset, batchParams.offset + batchParams.limit)
+    }
+
+    const { data: connectorRows, error: connectorsError } = await connectorsQuery
+    const batchMetadata = buildConnectorBatchMetadata({
+      fetchedCount: connectorRows?.length || 0,
+      limit: batchParams.limit,
+      offset: effectiveOffset,
+    })
+    const connectors = (connectorRows || []).slice(0, batchParams.limit)
     
     if (connectorsError) {
       throw new Error(`Failed to fetch connectors: ${connectorsError.message}`)
@@ -89,7 +121,9 @@ async function handleSyncByType(request: NextRequest) {
         success: true,
         message: `No connectors to sync for ${targetAppType}`,
         synced: 0,
-        targetAppType
+        targetAppType,
+        requestedConnectorId: batchParams.connectorId,
+        ...batchMetadata,
       })
     }
     
@@ -163,7 +197,8 @@ async function handleSyncByType(request: NextRequest) {
       message: `Scheduled ${targetAppType} sync completed: ${successCount} successful, ${failedCount} failed`,
       targetAppType,
       totalSynced,
-      connectorCount: connectors.length,
+      requestedConnectorId: batchParams.connectorId,
+      ...batchMetadata,
       successCount,
       failedCount,
       results

--- a/lib/sync/connector-batch.test.ts
+++ b/lib/sync/connector-batch.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildConnectorBatchMetadata,
+  parseConnectorBatchParams,
+  parseOptionalConnectorBatchParams,
+} from './connector-batch'
+
+test('parseConnectorBatchParams applies safe defaults for scheduled syncs', () => {
+  const params = parseConnectorBatchParams(new URLSearchParams())
+
+  assert.deepEqual(params, {
+    limit: 10,
+    offset: 0,
+    connectorId: null,
+  })
+})
+
+test('parseConnectorBatchParams accepts explicit batch controls', () => {
+  const params = parseConnectorBatchParams(new URLSearchParams({
+    limit: '5',
+    offset: '15',
+    connectorId: '3fd2b0bf-e863-4e69-bd69-a0052506401d',
+  }))
+
+  assert.deepEqual(params, {
+    limit: 5,
+    offset: 15,
+    connectorId: '3fd2b0bf-e863-4e69-bd69-a0052506401d',
+  })
+})
+
+test('parseOptionalConnectorBatchParams preserves legacy full sync when batch controls are absent', () => {
+  assert.equal(parseOptionalConnectorBatchParams(new URLSearchParams()), null)
+
+  assert.deepEqual(parseOptionalConnectorBatchParams(new URLSearchParams({ limit: '25' })), {
+    limit: 25,
+    offset: 0,
+    connectorId: null,
+  })
+
+  assert.deepEqual(parseOptionalConnectorBatchParams(new URLSearchParams({ allBatches: 'true' })), {
+    limit: 10,
+    offset: 0,
+    connectorId: null,
+  })
+})
+
+test('parseConnectorBatchParams rejects unsafe batch values', () => {
+  assert.throws(() => parseConnectorBatchParams(new URLSearchParams({ limit: '0' })), /limit must be between 1 and 50/)
+  assert.throws(() => parseConnectorBatchParams(new URLSearchParams({ limit: '51' })), /limit must be between 1 and 50/)
+  assert.throws(() => parseConnectorBatchParams(new URLSearchParams({ offset: '-1' })), /offset must be 0 or greater/)
+  assert.throws(() => parseConnectorBatchParams(new URLSearchParams({ offset: '1.5' })), /offset must be an integer/)
+})
+
+test('buildConnectorBatchMetadata uses an extra fetched row as hasMore probe', () => {
+  assert.deepEqual(
+    buildConnectorBatchMetadata({ fetchedCount: 11, limit: 10, offset: 20 }),
+    {
+      batchLimit: 10,
+      batchOffset: 20,
+      connectorCount: 10,
+      hasMore: true,
+      nextOffset: 30,
+    }
+  )
+
+  assert.deepEqual(
+    buildConnectorBatchMetadata({ fetchedCount: 4, limit: 10, offset: 20 }),
+    {
+      batchLimit: 10,
+      batchOffset: 20,
+      connectorCount: 4,
+      hasMore: false,
+      nextOffset: null,
+    }
+  )
+})

--- a/lib/sync/connector-batch.test.ts
+++ b/lib/sync/connector-batch.test.ts
@@ -33,6 +33,7 @@ test('parseConnectorBatchParams accepts explicit batch controls', () => {
 
 test('parseOptionalConnectorBatchParams preserves legacy full sync when batch controls are absent', () => {
   assert.equal(parseOptionalConnectorBatchParams(new URLSearchParams()), null)
+  assert.equal(parseOptionalConnectorBatchParams(new URLSearchParams({ connectorId: '' })), null)
 
   assert.deepEqual(parseOptionalConnectorBatchParams(new URLSearchParams({ limit: '25' })), {
     limit: 25,
@@ -52,6 +53,14 @@ test('parseConnectorBatchParams rejects unsafe batch values', () => {
   assert.throws(() => parseConnectorBatchParams(new URLSearchParams({ limit: '51' })), /limit must be between 1 and 50/)
   assert.throws(() => parseConnectorBatchParams(new URLSearchParams({ offset: '-1' })), /offset must be 0 or greater/)
   assert.throws(() => parseConnectorBatchParams(new URLSearchParams({ offset: '1.5' })), /offset must be an integer/)
+  assert.throws(
+    () => parseConnectorBatchParams(new URLSearchParams({ limit: String(Number.MAX_SAFE_INTEGER + 1) })),
+    /limit must be a safe integer/
+  )
+  assert.throws(
+    () => parseConnectorBatchParams(new URLSearchParams({ offset: String(Number.MAX_SAFE_INTEGER + 1) })),
+    /offset must be a safe integer/
+  )
 })
 
 test('buildConnectorBatchMetadata uses an extra fetched row as hasMore probe', () => {

--- a/lib/sync/connector-batch.ts
+++ b/lib/sync/connector-batch.ts
@@ -1,0 +1,79 @@
+export interface ConnectorBatchParams {
+  limit: number
+  offset: number
+  connectorId: string | null
+}
+
+export interface ConnectorBatchMetadata {
+  batchLimit: number
+  batchOffset: number
+  connectorCount: number
+  hasMore: boolean
+  nextOffset: number | null
+}
+
+const DEFAULT_CONNECTOR_BATCH_LIMIT = 10
+const MAX_CONNECTOR_BATCH_LIMIT = 50
+
+function parseOptionalInteger(value: string | null, defaultValue: number, name: string): number {
+  if (value === null || value.trim() === '') return defaultValue
+  if (!/^-?\d+$/.test(value)) {
+    throw new Error(`${name} must be an integer`)
+  }
+
+  return Number(value)
+}
+
+export function parseConnectorBatchParams(searchParams: URLSearchParams): ConnectorBatchParams {
+  const limit = parseOptionalInteger(searchParams.get('limit'), DEFAULT_CONNECTOR_BATCH_LIMIT, 'limit')
+  const offset = parseOptionalInteger(searchParams.get('offset'), 0, 'offset')
+  const connectorId = searchParams.get('connectorId')?.trim() || null
+
+  if (limit < 1 || limit > MAX_CONNECTOR_BATCH_LIMIT) {
+    throw new Error(`limit must be between 1 and ${MAX_CONNECTOR_BATCH_LIMIT}`)
+  }
+  if (offset < 0) {
+    throw new Error('offset must be 0 or greater')
+  }
+
+  return {
+    limit,
+    offset,
+    connectorId,
+  }
+}
+
+export function parseOptionalConnectorBatchParams(searchParams: URLSearchParams): ConnectorBatchParams | null {
+  const hasBatchControls =
+    searchParams.has('limit') ||
+    searchParams.has('offset') ||
+    searchParams.has('connectorId') ||
+    searchParams.get('allBatches') === 'true'
+
+  if (!hasBatchControls) {
+    return null
+  }
+
+  return parseConnectorBatchParams(searchParams)
+}
+
+export function buildConnectorBatchMetadata({
+  fetchedCount,
+  limit,
+  offset,
+}: {
+  fetchedCount: number
+  limit: number
+  offset: number
+}): ConnectorBatchMetadata {
+  const hasMore = fetchedCount > limit
+  const connectorCount = Math.min(fetchedCount, limit)
+
+  return {
+    batchLimit: limit,
+    batchOffset: offset,
+    connectorCount,
+    hasMore,
+    nextOffset: hasMore ? offset + limit : null,
+  }
+}

--- a/lib/sync/connector-batch.ts
+++ b/lib/sync/connector-batch.ts
@@ -21,7 +21,12 @@ function parseOptionalInteger(value: string | null, defaultValue: number, name: 
     throw new Error(`${name} must be an integer`)
   }
 
-  return Number(value)
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`${name} must be a safe integer`)
+  }
+
+  return parsed
 }
 
 export function parseConnectorBatchParams(searchParams: URLSearchParams): ConnectorBatchParams {
@@ -44,10 +49,11 @@ export function parseConnectorBatchParams(searchParams: URLSearchParams): Connec
 }
 
 export function parseOptionalConnectorBatchParams(searchParams: URLSearchParams): ConnectorBatchParams | null {
+  const connectorId = searchParams.get('connectorId')?.trim() || null
   const hasBatchControls =
     searchParams.has('limit') ||
     searchParams.has('offset') ||
-    searchParams.has('connectorId') ||
+    connectorId !== null ||
     searchParams.get('allBatches') === 'true'
 
   if (!hasBatchControls) {

--- a/scripts/sync-by-type.ts
+++ b/scripts/sync-by-type.ts
@@ -10,6 +10,8 @@ import {
 type SyncTargetType = 'people' | 'visas' | 'interview_records'
 type CliSyncType = SyncTargetType | 'both'
 
+const MAX_CONNECTOR_BATCH_ITERATIONS = 1000
+
 interface BatchControls {
   allBatches: boolean
   batchParams: ConnectorBatchParams | null
@@ -294,7 +296,7 @@ async function runSyncByTypeInBatches(
   let offset = initialBatchParams.offset
   const batchSummaries = []
 
-  while (true) {
+  while (batchSummaries.length < MAX_CONNECTOR_BATCH_ITERATIONS) {
     const summary = await runSyncByType(targetAppType, {
       ...initialBatchParams,
       offset,
@@ -307,7 +309,15 @@ async function runSyncByTypeInBatches(
       break
     }
 
+    if (nextOffset <= offset) {
+      throw new Error(`Batch sync did not advance: offset=${offset}, nextOffset=${nextOffset}`)
+    }
+
     offset = nextOffset
+  }
+
+  if (batchSummaries.length >= MAX_CONNECTOR_BATCH_ITERATIONS) {
+    throw new Error(`Exceeded maximum connector batch iterations (${MAX_CONNECTOR_BATCH_ITERATIONS})`)
   }
 
   const results = batchSummaries.flatMap(summary => summary.results)

--- a/scripts/sync-by-type.ts
+++ b/scripts/sync-by-type.ts
@@ -1,8 +1,25 @@
 import { createClient } from '@supabase/supabase-js'
 import { createSyncService } from '@/lib/sync/kintone-sync'
+import {
+  buildConnectorBatchMetadata,
+  ConnectorBatchMetadata,
+  ConnectorBatchParams,
+  parseOptionalConnectorBatchParams,
+} from '@/lib/sync/connector-batch'
 
 type SyncTargetType = 'people' | 'visas' | 'interview_records'
 type CliSyncType = SyncTargetType | 'both'
+
+interface BatchControls {
+  allBatches: boolean
+  batchParams: ConnectorBatchParams | null
+}
+
+interface FetchConnectorsResult {
+  connectors: any[]
+  batchMetadata: ConnectorBatchMetadata | null
+  requestedConnectorId: string | null
+}
 
 function getArgValue(flag: string): string | undefined {
   const index = process.argv.indexOf(flag)
@@ -11,6 +28,10 @@ function getArgValue(flag: string): string | undefined {
   }
 
   return process.argv[index + 1]
+}
+
+function hasFlag(flag: string): boolean {
+  return process.argv.includes(flag)
 }
 
 function parseSyncType(): CliSyncType {
@@ -25,6 +46,24 @@ function parseSyncType(): CliSyncType {
   }
 
   return rawType
+}
+
+function parseBatchControls(): BatchControls {
+  const searchParams = new URLSearchParams()
+  const limit = getArgValue('--limit') || process.env.SYNC_BATCH_LIMIT
+  const offset = getArgValue('--offset') || process.env.SYNC_BATCH_OFFSET
+  const connectorId = getArgValue('--connector-id') || process.env.SYNC_CONNECTOR_ID
+  const allBatches = hasFlag('--all-batches') || process.env.SYNC_ALL_BATCHES === 'true'
+
+  if (limit) searchParams.set('limit', limit)
+  if (offset) searchParams.set('offset', offset)
+  if (connectorId) searchParams.set('connectorId', connectorId)
+  if (allBatches) searchParams.set('allBatches', 'true')
+
+  return {
+    allBatches,
+    batchParams: parseOptionalConnectorBatchParams(searchParams),
+  }
 }
 
 function getServerClient() {
@@ -56,10 +95,13 @@ function getServerClient() {
   return createClient(supabaseUrl, serviceKey)
 }
 
-async function fetchConnectors(targetAppType: SyncTargetType) {
+async function fetchConnectors(
+  targetAppType: SyncTargetType,
+  batchParams: ConnectorBatchParams | null = null
+): Promise<FetchConnectorsResult> {
   const supabase = getServerClient()
 
-  const { data, error } = await supabase
+  let connectorsQuery = supabase
     .from('connectors')
     .select(`
       *,
@@ -75,22 +117,73 @@ async function fetchConnectors(targetAppType: SyncTargetType) {
     .eq('connector_app_mappings.target_app_type', targetAppType)
     .eq('connector_app_mappings.is_active', true)
 
+  if (batchParams?.connectorId) {
+    connectorsQuery = connectorsQuery
+      .eq('id', batchParams.connectorId)
+      .limit(1)
+  } else if (batchParams) {
+    // Fetch one extra connector to know whether the next batch exists.
+    connectorsQuery = connectorsQuery
+      .order('created_at', { ascending: true })
+      .order('id', { ascending: true })
+      .range(batchParams.offset, batchParams.offset + batchParams.limit)
+  } else {
+    connectorsQuery = connectorsQuery
+      .order('created_at', { ascending: true })
+      .order('id', { ascending: true })
+  }
+
+  const { data, error } = await connectorsQuery
+
   if (error) {
     throw new Error(`Failed to fetch connectors: ${error.message}`)
   }
 
-  return data || []
+  const connectorRows = data || []
+  if (!batchParams) {
+    return {
+      connectors: connectorRows,
+      batchMetadata: null,
+      requestedConnectorId: null,
+    }
+  }
+
+  const effectiveOffset = batchParams.connectorId ? 0 : batchParams.offset
+  const batchMetadata = buildConnectorBatchMetadata({
+    fetchedCount: connectorRows.length,
+    limit: batchParams.limit,
+    offset: effectiveOffset,
+  })
+
+  return {
+    connectors: connectorRows.slice(0, batchParams.limit),
+    batchMetadata,
+    requestedConnectorId: batchParams.connectorId,
+  }
 }
 
-async function runSyncByType(targetAppType: SyncTargetType) {
-  console.log(`🕐 Starting direct GitHub Actions sync for ${targetAppType}`)
+async function runSyncByType(
+  targetAppType: SyncTargetType,
+  batchParams: ConnectorBatchParams | null = null
+) {
+  console.log(`🕐 Starting direct GitHub Actions sync for ${targetAppType}`, {
+    connectorId: batchParams?.connectorId || null,
+    limit: batchParams?.limit || null,
+    offset: batchParams?.connectorId ? null : batchParams?.offset || null,
+  })
 
-  const connectors = await fetchConnectors(targetAppType)
+  const {
+    connectors,
+    batchMetadata,
+    requestedConnectorId,
+  } = await fetchConnectors(targetAppType, batchParams)
 
   if (connectors.length === 0) {
     const emptySummary = {
       success: true,
       targetAppType,
+      requestedConnectorId,
+      ...(batchMetadata || {}),
       connectorCount: 0,
       successCount: 0,
       failedCount: 0,
@@ -176,6 +269,8 @@ async function runSyncByType(targetAppType: SyncTargetType) {
   const summary = {
     success: failedCount === 0,
     targetAppType,
+    requestedConnectorId,
+    ...(batchMetadata || {}),
     connectorCount: connectors.length,
     successCount,
     failedCount,
@@ -188,15 +283,70 @@ async function runSyncByType(targetAppType: SyncTargetType) {
   return summary
 }
 
+async function runSyncByTypeInBatches(
+  targetAppType: SyncTargetType,
+  initialBatchParams: ConnectorBatchParams
+) {
+  if (initialBatchParams.connectorId) {
+    return runSyncByType(targetAppType, initialBatchParams)
+  }
+
+  let offset = initialBatchParams.offset
+  const batchSummaries = []
+
+  while (true) {
+    const summary = await runSyncByType(targetAppType, {
+      ...initialBatchParams,
+      offset,
+    })
+
+    batchSummaries.push(summary)
+
+    const nextOffset = summary.nextOffset
+    if (!summary.hasMore || typeof nextOffset !== 'number') {
+      break
+    }
+
+    offset = nextOffset
+  }
+
+  const results = batchSummaries.flatMap(summary => summary.results)
+  const totalSynced = batchSummaries.reduce((sum, summary) => sum + summary.totalSynced, 0)
+  const successCount = batchSummaries.reduce((sum, summary) => sum + summary.successCount, 0)
+  const failedCount = batchSummaries.reduce((sum, summary) => sum + summary.failedCount, 0)
+
+  const combinedSummary = {
+    success: failedCount === 0,
+    targetAppType,
+    allBatches: true,
+    batchLimit: initialBatchParams.limit,
+    batchCount: batchSummaries.length,
+    connectorCount: successCount + failedCount,
+    successCount,
+    failedCount,
+    totalSynced,
+    results,
+    batches: batchSummaries.map(({ results: _results, ...summary }) => summary),
+  }
+
+  console.log(JSON.stringify(combinedSummary, null, 2))
+
+  return combinedSummary
+}
+
 async function main() {
   const syncType = parseSyncType()
+  const { allBatches, batchParams } = parseBatchControls()
   const targetTypes: SyncTargetType[] =
     syncType === 'both' ? ['people', 'visas'] : [syncType]
 
   let hasFailure = false
 
   for (const targetType of targetTypes) {
-    const summary = await runSyncByType(targetType)
+    const summary = allBatches && batchParams
+      ? await runSyncByTypeInBatches(targetType, batchParams)
+      : await runSyncByType(targetType, batchParams)
+
     if (!summary.success) {
       hasFailure = true
     }


### PR DESCRIPTION
## Summary
- add connector batch parsing metadata for scheduled syncs
- add limit/offset/connectorId support to the sync-by-type API endpoint
- add opt-in --all-batches support to the GitHub Actions direct sync runner for interview_records
- add workflow_dispatch batch_size input for interview_records backfills

## Verification
- pnpm dlx tsx --test lib/sync/connector-batch.test.ts lib/sync/batch-utils.test.ts
- pnpm test lib/sync/interview-record-transformer.test.ts
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/cron-sync.yml'); puts 'workflow yaml ok'"
- git diff --check

## Notes
- pnpm run typecheck still stops on the existing constants/meeting-taxonomy.ts TS1127 baseline issue before this PR scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connector sync can run in batched mode with configurable limits, offsets, and single-connector targeting.
  * Manual sync workflow accepts an optional batch-size input for controlled, on-demand batching.

* **Tests**
  * Added tests covering batch parameter parsing, validation, and batch-metadata pagination behavior.

* **Chores**
  * Improved batch metadata reporting and error responses for sync operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/funtoco/fun-base/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->