### PR TITLE
Fix expired auth redirects to login

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -15,18 +15,18 @@ import { useSearchParams } from "next/navigation"
 
 function getSafeNextPath(next: string | null) {
   if (!next || !next.startsWith("/") || next.startsWith("//")) {
-    return "/people"
+    return "/dashboard"
   }
 
   let nextUrl: URL
   try {
     nextUrl = new URL(next, "https://funbase.local")
   } catch {
-    return "/people"
+    return "/dashboard"
   }
 
   if (nextUrl.pathname === "/login" || nextUrl.pathname === "/signup" || nextUrl.pathname.startsWith("/auth")) {
-    return "/people"
+    return "/dashboard"
   }
 
   return `${nextUrl.pathname}${nextUrl.search}`

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -9,28 +9,10 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Alert, AlertDescription } from "@/components/ui/alert"
+import { getSafeRedirectPath } from "@/lib/auth-route-guards"
 import Link from "next/link"
 import Image from "next/image"
 import { useSearchParams } from "next/navigation"
-
-function getSafeNextPath(next: string | null) {
-  if (!next || !next.startsWith("/") || next.startsWith("//")) {
-    return "/dashboard"
-  }
-
-  let nextUrl: URL
-  try {
-    nextUrl = new URL(next, "https://funbase.local")
-  } catch {
-    return "/dashboard"
-  }
-
-  if (nextUrl.pathname === "/login" || nextUrl.pathname === "/signup" || nextUrl.pathname.startsWith("/auth")) {
-    return "/dashboard"
-  }
-
-  return `${nextUrl.pathname}${nextUrl.search}`
-}
 
 export default function LoginPage() {
   const [email, setEmail] = useState("")
@@ -45,7 +27,7 @@ export default function LoginPage() {
     setLoading(true)
     setError("")
 
-    const { error } = await signIn(email, password, getSafeNextPath(searchParams.get("next")))
+    const { error } = await signIn(email, password, getSafeRedirectPath(searchParams.get("next")))
 
     if (error) {
       setError("ログインに失敗しました。メールアドレスとパスワードを確認してください。")

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -11,6 +11,26 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import Link from "next/link"
 import Image from "next/image"
+import { useSearchParams } from "next/navigation"
+
+function getSafeNextPath(next: string | null) {
+  if (!next || !next.startsWith("/") || next.startsWith("//")) {
+    return "/people"
+  }
+
+  let nextUrl: URL
+  try {
+    nextUrl = new URL(next, "https://funbase.local")
+  } catch {
+    return "/people"
+  }
+
+  if (nextUrl.pathname === "/login" || nextUrl.pathname === "/signup" || nextUrl.pathname.startsWith("/auth")) {
+    return "/people"
+  }
+
+  return `${nextUrl.pathname}${nextUrl.search}`
+}
 
 export default function LoginPage() {
   const [email, setEmail] = useState("")
@@ -18,13 +38,14 @@ export default function LoginPage() {
   const [error, setError] = useState("")
   const [loading, setLoading] = useState(false)
   const { signIn } = useAuth()
+  const searchParams = useSearchParams()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setLoading(true)
     setError("")
 
-    const { error } = await signIn(email, password)
+    const { error } = await signIn(email, password, getSafeNextPath(searchParams.get("next")))
 
     if (error) {
       setError("ログインに失敗しました。メールアドレスとパスワードを確認してください。")

--- a/components/layout/conditional-layout.tsx
+++ b/components/layout/conditional-layout.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react"
 import { useAuth } from "@/contexts/auth-context"
 import { Sidebar } from "@/components/layout/sidebar"
 import { Header } from "@/components/layout/header"
+import { isPublicRoute } from "@/lib/auth-route-guards"
 import { usePathname, useRouter } from "next/navigation"
 import { usePageViewLogger } from "@/hooks/use-page-view-logger"
 
@@ -16,14 +17,7 @@ export function ConditionalLayout({ children }: ConditionalLayoutProps) {
   const { user, loading } = useAuth()
   const pathname = usePathname()
   const router = useRouter()
-
-  // 認証が不要なページ（ログイン、サインアップ）
-  const publicPages = ["/login", "/signup"]
-  const isPublicPage =
-    publicPages.includes(pathname) ||
-    pathname.startsWith("/auth") ||
-    pathname === "/invite" ||
-    pathname.startsWith("/invite/")
+  const isPublicPage = isPublicRoute(pathname)
 
   // auth が完了していてログイン済みの非公開ページのみ記録する
   usePageViewLogger({ enabled: !loading && !!user && !isPublicPage })

--- a/components/layout/conditional-layout.tsx
+++ b/components/layout/conditional-layout.tsx
@@ -1,9 +1,11 @@
 "use client"
 
+import type React from "react"
+import { useEffect } from "react"
 import { useAuth } from "@/contexts/auth-context"
 import { Sidebar } from "@/components/layout/sidebar"
 import { Header } from "@/components/layout/header"
-import { usePathname } from "next/navigation"
+import { usePathname, useRouter } from "next/navigation"
 import { usePageViewLogger } from "@/hooks/use-page-view-logger"
 
 interface ConditionalLayoutProps {
@@ -13,6 +15,7 @@ interface ConditionalLayoutProps {
 export function ConditionalLayout({ children }: ConditionalLayoutProps) {
   const { user, loading } = useAuth()
   const pathname = usePathname()
+  const router = useRouter()
 
   // 認証が不要なページ（ログイン、サインアップ）
   const publicPages = ["/login", "/signup"]
@@ -25,7 +28,16 @@ export function ConditionalLayout({ children }: ConditionalLayoutProps) {
   // auth が完了していてログイン済みの非公開ページのみ記録する
   usePageViewLogger({ enabled: !loading && !!user && !isPublicPage })
 
-  if (loading) {
+  useEffect(() => {
+    if (loading || user || isPublicPage) {
+      return
+    }
+
+    const search = typeof window !== "undefined" ? window.location.search : ""
+    router.replace(`/login?next=${encodeURIComponent(`${pathname}${search}`)}`)
+  }, [isPublicPage, loading, pathname, router, user])
+
+  if (loading || (!isPublicPage && !user)) {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -21,7 +21,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 function getSafeRedirectPath(redirectTo?: string) {
   if (!redirectTo || !redirectTo.startsWith("/") || redirectTo.startsWith("//")) {
-    return "/people"
+    return "/dashboard"
   }
 
   return redirectTo
@@ -130,7 +130,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         email,
         password,
         options: {
-          emailRedirectTo: process.env.NEXT_PUBLIC_DEV_SUPABASE_REDIRECT_URL || `${window.location.origin}/people`,
+          emailRedirectTo: process.env.NEXT_PUBLIC_DEV_SUPABASE_REDIRECT_URL || `${window.location.origin}/dashboard`,
           data: {
             tenant_name: tenantName,
           },

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -4,6 +4,7 @@ import type React from "react"
 
 import { createContext, useContext, useEffect, useState } from "react"
 import type { User } from "@supabase/supabase-js"
+import { DEFAULT_AUTH_REDIRECT_PATH, getSafeRedirectPath } from "@/lib/auth-route-guards"
 import { createClient } from "@/lib/supabase/client"
 import { accessLogger } from "@/lib/access-logger"
 
@@ -18,14 +19,6 @@ interface AuthContextType {
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
-
-function getSafeRedirectPath(redirectTo?: string) {
-  if (!redirectTo || !redirectTo.startsWith("/") || redirectTo.startsWith("//")) {
-    return "/dashboard"
-  }
-
-  return redirectTo
-}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
@@ -130,7 +123,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         email,
         password,
         options: {
-          emailRedirectTo: process.env.NEXT_PUBLIC_DEV_SUPABASE_REDIRECT_URL || `${window.location.origin}/dashboard`,
+          emailRedirectTo:
+            process.env.NEXT_PUBLIC_DEV_SUPABASE_REDIRECT_URL ||
+            `${window.location.origin}${DEFAULT_AUTH_REDIRECT_PATH}`,
           data: {
             tenant_name: tenantName,
           },

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -11,13 +11,21 @@ interface AuthContextType {
   user: User | null
   loading: boolean
   role: string | null
-  signIn: (email: string, password: string) => Promise<{ error: any }>
+  signIn: (email: string, password: string, redirectTo?: string) => Promise<{ error: any }>
   signUp: (email: string, password: string, tenantName?: string) => Promise<{ error: any }>
   signOut: () => Promise<void>
   refreshUser: () => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+function getSafeRedirectPath(redirectTo?: string) {
+  if (!redirectTo || !redirectTo.startsWith("/") || redirectTo.startsWith("//")) {
+    return "/people"
+  }
+
+  return redirectTo
+}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
@@ -64,7 +72,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return () => subscription.unsubscribe()
   }, [supabase.auth, isAuthEnabled])
 
-  const signIn = async (email: string, password: string) => {
+  const signIn = async (email: string, password: string, redirectTo?: string) => {
     if (!isAuthEnabled) {
       console.log("認証機能が無効化されているため、ログインをスキップします")
       return { error: new Error("認証機能が無効化されています") }
@@ -95,8 +103,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
         accessLogger.login()
 
-        // ログイン成功時はミドルウェアがリダイレクトを処理
-        window.location.href = "/people"
+        window.location.href = getSafeRedirectPath(redirectTo)
       }
 
       if (error) {

--- a/lib/auth-route-guards.ts
+++ b/lib/auth-route-guards.ts
@@ -1,0 +1,43 @@
+export const DEFAULT_AUTH_REDIRECT_PATH = "/dashboard"
+
+const AUTH_ROUTES = ["/login", "/signup"]
+const PUBLIC_ROUTE_PREFIXES = ["/auth", "/invite"]
+
+function matchesRoute(pathname: string, route: string) {
+  return pathname === route || pathname.startsWith(`${route}/`)
+}
+
+export function isAuthRoute(pathname: string) {
+  return AUTH_ROUTES.some((route) => matchesRoute(pathname, route))
+}
+
+export function isPublicRoute(pathname: string) {
+  if (pathname === "/") {
+    return true
+  }
+
+  if (isAuthRoute(pathname)) {
+    return true
+  }
+
+  return PUBLIC_ROUTE_PREFIXES.some((route) => matchesRoute(pathname, route))
+}
+
+export function getSafeRedirectPath(redirectTo: string | null | undefined) {
+  if (!redirectTo || !redirectTo.startsWith("/") || redirectTo.startsWith("//")) {
+    return DEFAULT_AUTH_REDIRECT_PATH
+  }
+
+  let redirectUrl: URL
+  try {
+    redirectUrl = new URL(redirectTo, "https://funbase.local")
+  } catch {
+    return DEFAULT_AUTH_REDIRECT_PATH
+  }
+
+  if (isPublicRoute(redirectUrl.pathname)) {
+    return DEFAULT_AUTH_REDIRECT_PATH
+  }
+
+  return `${redirectUrl.pathname}${redirectUrl.search}`
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,43 +1,6 @@
 import { createServerClient } from "@supabase/ssr"
+import { getSafeRedirectPath, isAuthRoute, isPublicRoute } from "@/lib/auth-route-guards"
 import { NextResponse, type NextRequest } from "next/server"
-
-const AUTH_ROUTES = ["/login", "/signup"]
-const PUBLIC_ROUTE_PREFIXES = ["/auth", "/invite"]
-
-function isAuthRoute(pathname: string) {
-  return AUTH_ROUTES.some((route) => pathname === route || pathname.startsWith(`${route}/`))
-}
-
-function isPublicRoute(pathname: string) {
-  if (pathname === "/") {
-    return true
-  }
-
-  if (isAuthRoute(pathname)) {
-    return true
-  }
-
-  return PUBLIC_ROUTE_PREFIXES.some((route) => pathname === route || pathname.startsWith(`${route}/`))
-}
-
-function getSafeNextPath(next: string | null) {
-  if (!next || !next.startsWith("/") || next.startsWith("//")) {
-    return null
-  }
-
-  let nextUrl: URL
-  try {
-    nextUrl = new URL(next, "https://funbase.local")
-  } catch {
-    return null
-  }
-
-  if (isPublicRoute(nextUrl.pathname)) {
-    return null
-  }
-
-  return `${nextUrl.pathname}${nextUrl.search}`
-}
 
 export async function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname
@@ -108,7 +71,7 @@ export async function middleware(request: NextRequest) {
   // Redirect authenticated users away from auth pages to the default landing page.
   if (isAuthenticated && isAuthRoute(pathname)) {
     const url = request.nextUrl.clone()
-    const nextPath = getSafeNextPath(request.nextUrl.searchParams.get("next")) || "/dashboard"
+    const nextPath = getSafeRedirectPath(request.nextUrl.searchParams.get("next"))
     const nextUrl = new URL(nextPath, request.nextUrl.origin)
     url.pathname = nextUrl.pathname
     url.search = nextUrl.search

--- a/middleware.ts
+++ b/middleware.ts
@@ -105,10 +105,10 @@ export async function middleware(request: NextRequest) {
     return redirectWithSessionCookies(url)
   }
 
-  // Redirect to people page if authenticated and trying to access auth pages
+  // Redirect authenticated users away from auth pages to the default landing page.
   if (isAuthenticated && isAuthRoute(pathname)) {
     const url = request.nextUrl.clone()
-    const nextPath = getSafeNextPath(request.nextUrl.searchParams.get("next")) || "/people"
+    const nextPath = getSafeNextPath(request.nextUrl.searchParams.get("next")) || "/dashboard"
     const nextUrl = new URL(nextPath, request.nextUrl.origin)
     url.pathname = nextUrl.pathname
     url.search = nextUrl.search

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,61 @@
 import { createServerClient } from "@supabase/ssr"
 import { NextResponse, type NextRequest } from "next/server"
 
+const AUTH_ROUTES = ["/login", "/signup"]
+const PUBLIC_ROUTE_PREFIXES = ["/auth", "/invite"]
+
+function isAuthRoute(pathname: string) {
+  return AUTH_ROUTES.some((route) => pathname === route || pathname.startsWith(`${route}/`))
+}
+
+function isPublicRoute(pathname: string) {
+  if (pathname === "/") {
+    return true
+  }
+
+  if (isAuthRoute(pathname)) {
+    return true
+  }
+
+  return PUBLIC_ROUTE_PREFIXES.some((route) => pathname === route || pathname.startsWith(`${route}/`))
+}
+
+function getSafeNextPath(next: string | null) {
+  if (!next || !next.startsWith("/") || next.startsWith("//")) {
+    return null
+  }
+
+  let nextUrl: URL
+  try {
+    nextUrl = new URL(next, "https://funbase.local")
+  } catch {
+    return null
+  }
+
+  if (isPublicRoute(nextUrl.pathname)) {
+    return null
+  }
+
+  return `${nextUrl.pathname}${nextUrl.search}`
+}
+
 export async function middleware(request: NextRequest) {
+  const pathname = request.nextUrl.pathname
+
+  if (pathname.startsWith("/api/")) {
+    return NextResponse.next({
+      request,
+    })
+  }
+
+  const shouldCheckAuth = !isPublicRoute(pathname) || isAuthRoute(pathname)
+
+  if (!shouldCheckAuth) {
+    return NextResponse.next({
+      request,
+    })
+  }
+
   let supabaseResponse = NextResponse.next({
     request,
   })
@@ -25,23 +79,40 @@ export async function middleware(request: NextRequest) {
     },
   )
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  let isAuthenticated = false
+  try {
+    const {
+      data: { user: currentUser },
+    } = await supabase.auth.getUser()
+    isAuthenticated = Boolean(currentUser)
+  } catch (error) {
+    console.error("Failed to verify auth session in middleware:", error)
+  }
 
-  // Redirect to login if not authenticated and trying to access protected routes
-  // Temporarily disabled for testing
-  // if (!user && !request.nextUrl.pathname.startsWith("/login") && !request.nextUrl.pathname.startsWith("/signup")) {
-  //   const url = request.nextUrl.clone()
-  //   url.pathname = "/login"
-  //   return NextResponse.redirect(url)
-  // }
+  const redirectWithSessionCookies = (url: URL) => {
+    const response = NextResponse.redirect(url)
+    supabaseResponse.cookies.getAll().forEach((cookie) => {
+      response.cookies.set(cookie.name, cookie.value, cookie)
+    })
+    return response
+  }
+
+  if (!isAuthenticated && !isPublicRoute(pathname)) {
+    const url = request.nextUrl.clone()
+    url.pathname = "/login"
+    url.search = ""
+    url.searchParams.set("next", `${pathname}${request.nextUrl.search}`)
+    return redirectWithSessionCookies(url)
+  }
 
   // Redirect to people page if authenticated and trying to access auth pages
-  if (user && (request.nextUrl.pathname.startsWith("/login") || request.nextUrl.pathname.startsWith("/signup"))) {
+  if (isAuthenticated && isAuthRoute(pathname)) {
     const url = request.nextUrl.clone()
-    url.pathname = "/people"
-    return NextResponse.redirect(url)
+    const nextPath = getSafeNextPath(request.nextUrl.searchParams.get("next")) || "/people"
+    const nextUrl = new URL(nextPath, request.nextUrl.origin)
+    url.pathname = nextUrl.pathname
+    url.search = nextUrl.search
+    return redirectWithSessionCookies(url)
   }
 
   return supabaseResponse


### PR DESCRIPTION
## Summary
- re-enable server-side auth guarding in middleware for protected FunBase pages
- preserve the requested protected URL with `/login?next=...` and return there after login
- use `/dashboard` as the default landing page when there is no safe `next` target
- share auth/public route matching across middleware, login, layout, and auth context
- keep `/auth/*`, `/invite/*`, and `/api/*` flows outside the page redirect guard

## Root Cause
The unauthenticated redirect in `middleware.ts` existed but had been commented out for testing. The client layout then assumed middleware had already guaranteed authentication, so an expired session could still show sidebar/header and empty page state instead of redirecting to login.

## Security Review
### Threat analysis
- Main risk: expired or unauthenticated sessions could view the protected app shell and trigger protected page data loading attempts.
- Redirect risk: user-controlled `next` values could create open redirects or loop users back into auth/public flows if not validated.
- API risk: API clients must keep receiving status-coded JSON responses instead of HTML login redirects.
- Session-cookie risk: Supabase middleware may refresh cookies during `getUser()`, so redirect responses must preserve those cookie updates.

### Implementation plan
- `middleware.ts` verifies the user with Supabase `getUser()` for protected page routes only.
- Unauthenticated protected page requests redirect to `/login?next=<original protected path>`.
- `/api/*` bypasses page redirects so API handlers keep returning their own JSON `401`/error responses.
- `/auth/*`, `/invite/*`, `/login`, `/signup`, and `/` are treated as public routes.
- `getSafeRedirectPath()` rejects empty, absolute, malformed, auth, and public redirect targets; fallback is `/dashboard`.
- `redirectWithSessionCookies()` copies Supabase cookie updates onto redirect responses so refresh/session cookie behavior is preserved.
- `ConditionalLayout` uses the same shared public-route matcher as middleware as a client-side fallback.

### Rollback / mitigation
- If unexpected redirect behavior appears, revert this PR to restore the prior behavior quickly.
- If one public page is accidentally guarded, add it to the shared public route matcher in `lib/auth-route-guards.ts` and redeploy.
- If an API route is affected, verify it remains under `/api/*`; middleware bypasses that prefix.

### Approval
- Leader/security owner approval is required before merge because this touches auth gating behavior.

## Issue
Closes funtoco/fun-docs#785

## Verification
- `git diff --check -- lib/auth-route-guards.ts middleware.ts app/login/page.tsx components/layout/conditional-layout.tsx contexts/auth-context.tsx`
- targeted edited-file TypeScript check: passed
- local smoke on `127.0.0.1:3106`:
  - `/people` without login -> `307 /login?next=%2Fpeople`
  - `/admin/tenants?foo=bar` without login -> `307 /login?next=%2Fadmin%2Ftenants%3Ffoo%3Dbar`
  - `POST /api/auth/activate-membership` remains `401` JSON
  - `/invite/example-token` remains public `200`
- `npm run typecheck` still fails on existing baseline `constants/meeting-taxonomy.ts` `TS1127: Invalid character`, unrelated to this PR
