### PR TITLE
ヘッダー検索に候補とレコメンドを追加

### DIFF
--- a/app/people/page.tsx
+++ b/app/people/page.tsx
@@ -297,7 +297,7 @@ export default function PeoplePage() {
         columns={columns}
         csvColumns={csvColumns}
         filters={filters}
-        searchKeys={["name", "tenantName", "nationality"]}
+        searchKeys={["name", "kana", "company", "nationality", "employeeNumber"]}
         onRowClick={handleRowClick}
         initialSearchTerm={searchParams.get('search') || ''}
         initialActiveFilters={getFiltersFromUrl()}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
-import { Search, Bell, Settings, User, LogOut, RefreshCw, Cable, Users, ShieldCheck, Megaphone } from "lucide-react"
+import { useState, useEffect, useCallback, useMemo } from "react"
+import { Search, Bell, Settings, LogOut, RefreshCw, Cable, Users, ShieldCheck, Megaphone, Building2, ArrowRight, History } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
@@ -18,19 +18,40 @@ import { Badge } from "@/components/ui/badge"
 import { useAuth } from "@/contexts/auth-context"
 import { useRouter } from "next/navigation"
 import { currentUser } from "@/data/users"
-import { formatDate } from "@/lib/utils"
+import { cn, formatDate } from "@/lib/utils"
 import {
   getPublishedAnnouncements,
   getReadAnnouncementIds,
   markAnnouncementAsRead,
   markAllAnnouncementsAsRead,
 } from "@/lib/supabase/announcements"
-import type { Announcement } from "@/lib/models"
+import { getPeople } from "@/lib/supabase/people"
+import type { Announcement, Person } from "@/lib/models"
+
+type OfficeSuggestion = {
+  name: string
+  count: number
+}
+
+type SearchHistoryItem = {
+  id: string
+  label: string
+  href: string
+  kind: "person" | "office" | "query"
+  description?: string
+}
+
+const SEARCH_HISTORY_STORAGE_KEY = "funbase:global-search-history"
+const MAX_SEARCH_HISTORY_ITEMS = 8
+const normalizeSearchText = (value?: string | null) => value?.toLowerCase().trim() ?? ""
 
 export function Header() {
   const { user, role, signOut, refreshUser } = useAuth()
   const router = useRouter()
   const [searchQuery, setSearchQuery] = useState("")
+  const [people, setPeople] = useState<Person[]>([])
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [searchHistory, setSearchHistory] = useState<SearchHistoryItem[]>([])
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
   const [readIds, setReadIds] = useState<string[]>([])
   const [announcementsOpen, setAnnouncementsOpen] = useState(false)
@@ -55,6 +76,183 @@ export function Header() {
       loadAnnouncements()
     }
   }, [user, loadAnnouncements])
+
+  useEffect(() => {
+    try {
+      const storedHistory = window.localStorage.getItem(SEARCH_HISTORY_STORAGE_KEY)
+      if (!storedHistory) return
+
+      const parsedHistory = JSON.parse(storedHistory)
+      if (Array.isArray(parsedHistory)) {
+        setSearchHistory(parsedHistory.slice(0, MAX_SEARCH_HISTORY_ITEMS))
+      }
+    } catch (err) {
+      console.debug("Failed to load search history:", err)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!user) return
+
+    let cancelled = false
+
+    getPeople()
+      .then((items) => {
+        if (!cancelled) setPeople(items)
+      })
+      .catch((err) => {
+        console.debug("Failed to load search suggestions:", err)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [user])
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null
+      const isTyping =
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.isContentEditable
+
+      if (event.key === "/" && !isTyping) {
+        event.preventDefault()
+        document.getElementById("global-search-input")?.focus()
+        setSearchOpen(true)
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [])
+
+  const searchText = normalizeSearchText(searchQuery)
+
+  const saveSearchHistory = (item: SearchHistoryItem) => {
+    setSearchHistory((current) => {
+      const next = [
+        item,
+        ...current.filter((historyItem) => historyItem.id !== item.id),
+      ].slice(0, MAX_SEARCH_HISTORY_ITEMS)
+
+      try {
+        window.localStorage.setItem(SEARCH_HISTORY_STORAGE_KEY, JSON.stringify(next))
+      } catch (err) {
+        console.debug("Failed to save search history:", err)
+      }
+
+      return next
+    })
+  }
+
+  const historySuggestions = useMemo(() => {
+    return searchHistory
+      .filter((item) => {
+        if (!searchText) return true
+
+        return [item.label, item.description]
+          .filter(Boolean)
+          .some((value) => normalizeSearchText(value).includes(searchText))
+      })
+      .slice(0, 5)
+  }, [searchHistory, searchText])
+
+  const personSuggestions = useMemo(() => {
+    const source = searchText
+      ? people.filter((person) => {
+          const fields = [
+            person.name,
+            person.kana,
+            person.company,
+            person.nationality,
+            person.employeeNumber,
+          ]
+          return fields.some((field) => normalizeSearchText(field).includes(searchText))
+        })
+      : people.filter((person) => ["入社待ち", "在籍中"].includes(person.workingStatus ?? ""))
+
+    return source
+      .slice()
+      .sort((a, b) => {
+        if (!searchText) {
+          return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+        }
+
+        const aNameStarts = normalizeSearchText(a.name).startsWith(searchText) ? 1 : 0
+        const bNameStarts = normalizeSearchText(b.name).startsWith(searchText) ? 1 : 0
+        return bNameStarts - aNameStarts
+      })
+      .slice(0, 5)
+  }, [people, searchText])
+
+  const companySuggestions = useMemo(() => {
+    const counts = new Map<string, OfficeSuggestion>()
+
+    people.forEach((person) => {
+      const name = person.company
+      if (!name) return
+      if (searchText && !normalizeSearchText(name).includes(searchText)) return
+
+      const current = counts.get(name)
+      counts.set(name, {
+        name,
+        count: (current?.count ?? 0) + 1,
+      })
+    })
+
+    return Array.from(counts.values())
+      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, "ja"))
+      .slice(0, searchText ? 4 : 3)
+  }, [people, searchText])
+
+  const goToPeopleSearch = (query = searchQuery) => {
+    const trimmed = query.trim()
+    setSearchOpen(false)
+    if (trimmed) {
+      saveSearchHistory({
+        id: `query:${trimmed}`,
+        label: trimmed,
+        href: `/people?search=${encodeURIComponent(trimmed)}`,
+        kind: "query",
+        description: "人材一覧を検索",
+      })
+    }
+    router.push(trimmed ? `/people?search=${encodeURIComponent(trimmed)}` : "/people")
+  }
+
+  const goToPerson = (person: Person) => {
+    setSearchOpen(false)
+    saveSearchHistory({
+      id: `person:${person.id}`,
+      label: person.name,
+      href: `/people/${person.id}`,
+      kind: "person",
+      description: [person.kana, person.company].filter(Boolean).join(" / ") || undefined,
+    })
+    router.push(`/people/${person.id}`)
+  }
+
+  const goToCompany = (suggestion: OfficeSuggestion) => {
+    setSearchOpen(false)
+    saveSearchHistory({
+      id: `office:${suggestion.name}`,
+      label: suggestion.name,
+      href: `/people?company=${encodeURIComponent(suggestion.name)}`,
+      kind: "office",
+      description: `${suggestion.count}名`,
+    })
+    router.push(`/people?company=${encodeURIComponent(suggestion.name)}`)
+  }
+
+  const goToHistoryItem = (item: SearchHistoryItem) => {
+    setSearchOpen(false)
+    saveSearchHistory(item)
+    router.push(item.href)
+  }
+
+  const hasSuggestions = historySuggestions.length > 0 || personSuggestions.length > 0 || companySuggestions.length > 0
 
   const handleMarkAsRead = async (id: string) => {
     try {
@@ -87,11 +285,125 @@ export function Header() {
         <div className="relative max-w-md">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
-            placeholder="人材名、会社名で検索... (/ でフォーカス)"
-            className="pl-10 w-80"
+            id="global-search-input"
+            placeholder="人材名、事業所名で検索... (/ でフォーカス)"
+            className="pl-10 pr-3 w-80"
             value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            onFocus={() => setSearchOpen(true)}
+            onBlur={() => window.setTimeout(() => setSearchOpen(false), 120)}
+            onChange={(e) => {
+              setSearchQuery(e.target.value)
+              setSearchOpen(true)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault()
+                const firstPerson = personSuggestions[0]
+                if (firstPerson && searchQuery.trim()) {
+                  goToPerson(firstPerson)
+                  return
+                }
+                goToPeopleSearch()
+              }
+              if (e.key === "Escape") {
+                setSearchOpen(false)
+              }
+            }}
           />
+          {searchOpen && (
+            <div className="absolute left-0 top-full z-50 mt-2 w-[28rem] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-lg">
+              <div className="border-b px-3 py-2 text-xs font-medium text-muted-foreground">
+                {searchQuery.trim() ? "検索候補" : "レコメンド"}
+              </div>
+              {hasSuggestions ? (
+                <div className="max-h-96 overflow-y-auto py-1">
+                  {historySuggestions.length > 0 && (
+                    <div className="py-1">
+                      <div className="px-3 py-1 text-[11px] font-medium text-muted-foreground">最近の検索</div>
+                      {historySuggestions.map((item) => (
+                        <button
+                          key={item.id}
+                          type="button"
+                          className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left hover:bg-muted"
+                          onMouseDown={(e) => e.preventDefault()}
+                          onClick={() => goToHistoryItem(item)}
+                        >
+                          <div className="flex min-w-0 items-center gap-2">
+                            <History className="h-4 w-4 shrink-0 text-muted-foreground" />
+                            <div className="min-w-0">
+                              <div className="truncate text-sm font-medium">{item.label}</div>
+                              {item.description && (
+                                <div className="truncate text-xs text-muted-foreground">{item.description}</div>
+                              )}
+                            </div>
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  {personSuggestions.length > 0 && (
+                    <div className={cn("py-1", historySuggestions.length > 0 && "border-t")}>
+                      <div className="px-3 py-1 text-[11px] font-medium text-muted-foreground">人材</div>
+                      {personSuggestions.map((person) => (
+                        <button
+                          key={person.id}
+                          type="button"
+                          className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left hover:bg-muted"
+                          onMouseDown={(e) => e.preventDefault()}
+                          onClick={() => goToPerson(person)}
+                        >
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-medium">{person.name}</div>
+                            <div className="truncate text-xs text-muted-foreground">
+                              {[person.kana, person.company].filter(Boolean).join(" / ") || "事業所情報なし"}
+                            </div>
+                          </div>
+                          {person.workingStatus && (
+                            <span className="shrink-0 rounded border px-2 py-0.5 text-xs text-muted-foreground">
+                              {person.workingStatus}
+                            </span>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  {companySuggestions.length > 0 && (
+                    <div className={cn("py-1", (historySuggestions.length > 0 || personSuggestions.length > 0) && "border-t")}>
+                      <div className="px-3 py-1 text-[11px] font-medium text-muted-foreground">事業所</div>
+                      {companySuggestions.map((company) => (
+                        <button
+                          key={company.name}
+                          type="button"
+                          className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left hover:bg-muted"
+                          onMouseDown={(e) => e.preventDefault()}
+                          onClick={() => goToCompany(company)}
+                        >
+                          <div className="flex min-w-0 items-center gap-2">
+                            <Building2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+                            <span className="truncate text-sm font-medium">{company.name}</span>
+                          </div>
+                          <span className="shrink-0 text-xs text-muted-foreground">{company.count}名</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+                  一致する候補がありません
+                </div>
+              )}
+              <button
+                type="button"
+                className="flex w-full items-center justify-between border-t px-3 py-2 text-sm hover:bg-muted"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => goToPeopleSearch()}
+              >
+                <span>{searchQuery.trim() ? `「${searchQuery.trim()}」で人材一覧を検索` : "人材一覧を開く"}</span>
+                <ArrowRight className="h-4 w-4 text-muted-foreground" />
+              </button>
+            </div>
+          )}
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
- ヘッダー検索に人材・事業所の候補ドロップダウンを追加
- 未入力時は最近の検索履歴、入社待ち/在籍中の人材、人数の多い事業所を表示
- 人材・事業所・検索語の利用履歴を localStorage に最大8件保存
- 人材一覧の検索対象にフリガナ、事業所、従業員番号を追加

## Verification
- npm run build
- npm run typecheck は既存の constants/meeting-taxonomy.ts の Invalid character エラーで停止