### PR TITLE
【FunBase】法人名で人材検索できるようにする

### DIFF
--- a/app/people/page.tsx
+++ b/app/people/page.tsx
@@ -7,6 +7,7 @@ import { DeadlineChip } from "@/components/ui/deadline-chip"
 import { PersonAvatar } from "@/components/ui/person-avatar"
 import { getPeople } from "@/lib/supabase/people"
 import { getVisas } from "@/lib/supabase/visas"
+import { PERSON_SEARCH_KEYS } from "@/lib/person-search"
 import type { Person } from "@/lib/models"
 
 interface PersonWithVisa extends Person {
@@ -297,7 +298,8 @@ export default function PeoplePage() {
         columns={columns}
         csvColumns={csvColumns}
         filters={filters}
-        searchKeys={["name", "kana", "company", "nationality", "employeeNumber"]}
+        searchKeys={PERSON_SEARCH_KEYS}
+        searchPlaceholder="人材名、法人名、事業所名で検索..."
         onRowClick={handleRowClick}
         initialSearchTerm={searchParams.get('search') || ''}
         initialActiveFilters={getFiltersFromUrl()}

--- a/app/visas/page.tsx
+++ b/app/visas/page.tsx
@@ -11,6 +11,7 @@ import { FilterMultiSelectPopover } from "@/components/ui/filter-multi-select-po
 import { Search, FileText, Clock, X, ChevronDown, ChevronUp, Building2 } from "lucide-react"
 import { getPeople } from "@/lib/supabase/people"
 import { getVisas } from "@/lib/supabase/visas"
+import { matchesPersonSearch } from "@/lib/person-search"
 import { cn, isExpiringSoon } from "@/lib/utils"
 import type { VisaStatus, Person, Visa } from "@/lib/models"
 
@@ -171,8 +172,7 @@ export default function VisasPage() {
 
     // Search filter
     if (searchTerm) {
-      const searchMatch = person.name.toLowerCase().includes(searchTerm.toLowerCase())
-      if (!searchMatch) return false
+      if (!matchesPersonSearch(person, searchTerm)) return false
     }
 
     // Type filter
@@ -272,8 +272,7 @@ export default function VisasPage() {
 
       // Search filter
       if (searchTerm) {
-        const searchMatch = person.name.toLowerCase().includes(searchTerm.toLowerCase())
-        if (!searchMatch) return false
+        if (!matchesPersonSearch(person, searchTerm)) return false
       }
 
       // Type filter
@@ -428,7 +427,7 @@ export default function VisasPage() {
           <div className="relative">
             <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
-              placeholder="人材名で検索..."
+              placeholder="人材名、法人名、事業所名で検索..."
               value={searchTerm}
               onChange={(e) => handleSearchChange(e.target.value)}
               className="pl-10 w-64"

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -26,9 +26,15 @@ import {
   markAllAnnouncementsAsRead,
 } from "@/lib/supabase/announcements"
 import { getPeople } from "@/lib/supabase/people"
+import { matchesPersonSearch, normalizePersonSearchText as normalizeSearchText } from "@/lib/person-search"
 import type { Announcement, Person } from "@/lib/models"
 
 type OfficeSuggestion = {
+  name: string
+  count: number
+}
+
+type LegalEntitySuggestion = {
   name: string
   count: number
 }
@@ -37,13 +43,12 @@ type SearchHistoryItem = {
   id: string
   label: string
   href: string
-  kind: "person" | "office" | "query"
+  kind: "person" | "legalEntity" | "office" | "query"
   description?: string
 }
 
 const SEARCH_HISTORY_STORAGE_KEY = "funbase:global-search-history"
 const MAX_SEARCH_HISTORY_ITEMS = 8
-const normalizeSearchText = (value?: string | null) => value?.toLowerCase().trim() ?? ""
 
 export function Header() {
   const { user, role, signOut, refreshUser } = useAuth()
@@ -162,14 +167,7 @@ export function Header() {
   const personSuggestions = useMemo(() => {
     const source = searchText
       ? people.filter((person) => {
-          const fields = [
-            person.name,
-            person.kana,
-            person.company,
-            person.nationality,
-            person.employeeNumber,
-          ]
-          return fields.some((field) => normalizeSearchText(field).includes(searchText))
+          return matchesPersonSearch(person, searchText)
         })
       : people.filter((person) => ["入社待ち", "在籍中"].includes(person.workingStatus ?? ""))
 
@@ -185,6 +183,26 @@ export function Header() {
         return bNameStarts - aNameStarts
       })
       .slice(0, 5)
+  }, [people, searchText])
+
+  const legalEntitySuggestions = useMemo(() => {
+    const counts = new Map<string, LegalEntitySuggestion>()
+
+    people.forEach((person) => {
+      const name = person.tenantName
+      if (!name) return
+      if (searchText && !normalizeSearchText(name).includes(searchText)) return
+
+      const current = counts.get(name)
+      counts.set(name, {
+        name,
+        count: (current?.count ?? 0) + 1,
+      })
+    })
+
+    return Array.from(counts.values())
+      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, "ja"))
+      .slice(0, searchText ? 4 : 3)
   }, [people, searchText])
 
   const companySuggestions = useMemo(() => {
@@ -229,9 +247,21 @@ export function Header() {
       label: person.name,
       href: `/people/${person.id}`,
       kind: "person",
-      description: [person.kana, person.company].filter(Boolean).join(" / ") || undefined,
+      description: [person.kana, person.tenantName, person.company].filter(Boolean).join(" / ") || undefined,
     })
     router.push(`/people/${person.id}`)
+  }
+
+  const goToLegalEntity = (suggestion: LegalEntitySuggestion) => {
+    setSearchOpen(false)
+    saveSearchHistory({
+      id: `legalEntity:${suggestion.name}`,
+      label: suggestion.name,
+      href: `/people?tenantName=${encodeURIComponent(suggestion.name)}`,
+      kind: "legalEntity",
+      description: `${suggestion.count}名`,
+    })
+    router.push(`/people?tenantName=${encodeURIComponent(suggestion.name)}`)
   }
 
   const goToCompany = (suggestion: OfficeSuggestion) => {
@@ -252,7 +282,11 @@ export function Header() {
     router.push(item.href)
   }
 
-  const hasSuggestions = historySuggestions.length > 0 || personSuggestions.length > 0 || companySuggestions.length > 0
+  const hasSuggestions =
+    historySuggestions.length > 0 ||
+    personSuggestions.length > 0 ||
+    legalEntitySuggestions.length > 0 ||
+    companySuggestions.length > 0
 
   const handleMarkAsRead = async (id: string) => {
     try {
@@ -286,7 +320,7 @@ export function Header() {
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             id="global-search-input"
-            placeholder="人材名、事業所名で検索... (/ でフォーカス)"
+            placeholder="人材名、法人名、事業所名で検索... (/ でフォーカス)"
             className="pl-10 pr-3 w-80"
             value={searchQuery}
             onFocus={() => setSearchOpen(true)}
@@ -355,7 +389,7 @@ export function Header() {
                           <div className="min-w-0">
                             <div className="truncate text-sm font-medium">{person.name}</div>
                             <div className="truncate text-xs text-muted-foreground">
-                              {[person.kana, person.company].filter(Boolean).join(" / ") || "事業所情報なし"}
+                              {[person.kana, person.tenantName, person.company].filter(Boolean).join(" / ") || "法人・事業所情報なし"}
                             </div>
                           </div>
                           {person.workingStatus && (
@@ -367,8 +401,28 @@ export function Header() {
                       ))}
                     </div>
                   )}
-                  {companySuggestions.length > 0 && (
+                  {legalEntitySuggestions.length > 0 && (
                     <div className={cn("py-1", (historySuggestions.length > 0 || personSuggestions.length > 0) && "border-t")}>
+                      <div className="px-3 py-1 text-[11px] font-medium text-muted-foreground">法人</div>
+                      {legalEntitySuggestions.map((legalEntity) => (
+                        <button
+                          key={legalEntity.name}
+                          type="button"
+                          className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left hover:bg-muted"
+                          onMouseDown={(e) => e.preventDefault()}
+                          onClick={() => goToLegalEntity(legalEntity)}
+                        >
+                          <div className="flex min-w-0 items-center gap-2">
+                            <Building2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+                            <span className="truncate text-sm font-medium">{legalEntity.name}</span>
+                          </div>
+                          <span className="shrink-0 text-xs text-muted-foreground">{legalEntity.count}名</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  {companySuggestions.length > 0 && (
+                    <div className={cn("py-1", (historySuggestions.length > 0 || personSuggestions.length > 0 || legalEntitySuggestions.length > 0) && "border-t")}>
                       <div className="px-3 py-1 text-[11px] font-medium text-muted-foreground">事業所</div>
                       {companySuggestions.map((company) => (
                         <button

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -26,7 +26,8 @@ interface DataTableProps<T> {
   columns: Column<T>[]
   csvColumns?: Column<T>[]
   filters?: Filter[]
-  searchKeys?: (keyof T)[]
+  searchKeys?: readonly (keyof T)[]
+  searchPlaceholder?: string
   onRowClick?: (row: T) => void
   className?: string
   // URLパラメータ永続化用
@@ -48,6 +49,7 @@ export function DataTable<T extends Record<string, any>>({
   csvColumns,
   filters = [],
   searchKeys = [],
+  searchPlaceholder = "検索...",
   onRowClick,
   className,
   initialSearchTerm = "",
@@ -193,7 +195,7 @@ export function DataTable<T extends Record<string, any>>({
             <div className="relative max-w-sm">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <Input
-                placeholder="検索..."
+                placeholder={searchPlaceholder}
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 className="pl-10"

--- a/lib/person-search.test.ts
+++ b/lib/person-search.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest"
+import { matchesPersonSearch, PERSON_SEARCH_KEYS } from "./person-search"
+import type { Person } from "./models"
+
+const basePerson: Person = {
+  id: "person-1",
+  name: "Nguyen Van A",
+  kana: "グエン ヴァン エー",
+  nationality: "ベトナム",
+  employeeNumber: "EMP-001",
+  tenantName: "社会福祉法人清光会",
+  company: "特別養護老人ホーム清光園",
+  workingStatus: "在籍中",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-02T00:00:00.000Z",
+}
+
+describe("person search", () => {
+  test("includes legal entity names in shared person search keys", () => {
+    expect(PERSON_SEARCH_KEYS).toContain("tenantName")
+  })
+
+  test("matches a person by legal entity name", () => {
+    expect(matchesPersonSearch(basePerson, "社会福祉法人清光会")).toBe(true)
+    expect(matchesPersonSearch(basePerson, "清光会")).toBe(true)
+  })
+
+  test("keeps matching existing person and office fields", () => {
+    expect(matchesPersonSearch(basePerson, "Nguyen")).toBe(true)
+    expect(matchesPersonSearch(basePerson, "清光園")).toBe(true)
+  })
+
+  test("does not match unrelated text", () => {
+    expect(matchesPersonSearch(basePerson, "社会福祉法人別法人")).toBe(false)
+  })
+})

--- a/lib/person-search.ts
+++ b/lib/person-search.ts
@@ -1,0 +1,23 @@
+import type { Person } from "@/lib/models"
+
+export const PERSON_SEARCH_KEYS = [
+  "name",
+  "kana",
+  "tenantName",
+  "company",
+  "nationality",
+  "employeeNumber",
+] satisfies (keyof Person)[]
+
+export function normalizePersonSearchText(value?: string | null) {
+  return value?.toLowerCase().trim() ?? ""
+}
+
+export function matchesPersonSearch(person: Person, searchTerm: string) {
+  const searchText = normalizePersonSearchText(searchTerm)
+  if (!searchText) return true
+
+  return PERSON_SEARCH_KEYS.some((key) => {
+    return normalizePersonSearchText(person[key]?.toString()).includes(searchText)
+  })
+}


### PR DESCRIPTION
## 概要
- 人材検索の共通キーに法人名（`tenantName`）を追加
- ヘッダー検索候補に法人セクションを追加し、法人選択時は人材一覧の会社フィルターへ遷移
- 人材一覧・ビザ進捗の検索プレースホルダーと検索判定を法人名対応に更新

## 確認
- `pnpm exec vitest run lib/person-search.test.ts` ✅
- `pnpm run build` ✅（既存のNext警告あり）
- `pnpm test` ⚠️ 既存の `node:test` 形式ファイルをVitestが suite なし扱いにして失敗
- `pnpm run typecheck` ⚠️ 既存の `constants/meeting-taxonomy.ts` の不正文字で失敗
- `pnpm run lint` ⚠️ ESLint未設定のためNextの対話プロンプトで終了

関連: funtoco/fun-docs#846

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced search functionality now supports searching across person names, legal entity names, and workplace names
  * Updated search hints to clarify all searchable fields
  * Improved search consistency across the application

* **Tests**
  * Added test coverage for search utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->