### PR TITLE
[codex] Add navigation progress feedback

### DIFF
--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation"
 import { useEffect, useState } from "react"
 import { DataTable, type Column } from "@/components/ui/data-table"
 import { PersonAvatar } from "@/components/ui/person-avatar"
+import { useNavigationProgress } from "@/components/navigation-progress"
 import { getAllPersonDocuments, type PersonDocumentWithPerson } from "@/lib/supabase/person-documents"
 import type { DocumentType } from "@/lib/models"
 
@@ -34,6 +35,7 @@ function formatDate(dateString?: string): string {
 
 export default function DocumentsPage() {
   const router = useRouter()
+  const { startNavigation } = useNavigationProgress()
   const searchParams = useSearchParams()
   const [documents, setDocuments] = useState<PersonDocumentWithPerson[]>([])
   const [loading, setLoading] = useState(false)
@@ -158,6 +160,7 @@ export default function DocumentsPage() {
   ]
 
   const handleRowClick = (doc: PersonDocumentWithPerson) => {
+    startNavigation()
     router.push(`/people/${doc.personId}`)
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -152,3 +152,21 @@
     font-family: "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo, sans-serif;
   }
 }
+
+@keyframes navigation-progress {
+  0% {
+    transform: translateX(-100%) scaleX(0.45);
+  }
+  45% {
+    transform: translateX(-35%) scaleX(0.7);
+  }
+  100% {
+    transform: translateX(100%) scaleX(0.35);
+  }
+}
+
+@layer utilities {
+  .animate-navigation-progress {
+    animation: navigation-progress 1.15s ease-in-out infinite;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,9 +5,8 @@ import { GeistMono } from "geist/font/mono"
 import { Analytics } from "@vercel/analytics/next"
 import { Suspense } from "react"
 import { AuthProvider } from "@/contexts/auth-context"
-import { Sidebar } from "@/components/layout/sidebar"
-import { Header } from "@/components/layout/header"
 import { ConditionalLayout } from "@/components/layout/conditional-layout"
+import { NavigationProgressProvider } from "@/components/navigation-progress"
 import { Toaster } from "@/components/ui/toaster"
 import "./globals.css"
 
@@ -30,9 +29,11 @@ export default function RootLayout({
     <html lang="ja">
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
         <AuthProvider>
-          <ConditionalLayout>
-            <Suspense fallback={null}>{children}</Suspense>
-          </ConditionalLayout>
+          <NavigationProgressProvider>
+            <ConditionalLayout>
+              <Suspense fallback={null}>{children}</Suspense>
+            </ConditionalLayout>
+          </NavigationProgressProvider>
           <Toaster />
         </AuthProvider>
         <Analytics />

--- a/app/people/page.tsx
+++ b/app/people/page.tsx
@@ -5,6 +5,7 @@ import { DataTable, type Column } from "@/components/ui/data-table"
 import { StatusBadge } from "@/components/ui/status-badge"
 import { DeadlineChip } from "@/components/ui/deadline-chip"
 import { PersonAvatar } from "@/components/ui/person-avatar"
+import { useNavigationProgress } from "@/components/navigation-progress"
 import { getPeople } from "@/lib/supabase/people"
 import { getVisas } from "@/lib/supabase/visas"
 import type { Person } from "@/lib/models"
@@ -20,6 +21,7 @@ interface PersonWithVisa extends Person {
 
 export default function PeoplePage() {
   const router = useRouter()
+  const { startNavigation } = useNavigationProgress()
   const searchParams = useSearchParams()
   const [people, setPeople] = useState<Person[]>([])
   const [visas, setVisas] = useState<any[]>([])
@@ -249,6 +251,7 @@ export default function PeoplePage() {
   ]
 
   const handleRowClick = (person: PersonWithVisa) => {
+    startNavigation()
     router.push(`/people/${person.id}`)
   }
 

--- a/app/visas/page.tsx
+++ b/app/visas/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { FilterMultiSelectPopover } from "@/components/ui/filter-multi-select-popover"
+import { useNavigationProgress } from "@/components/navigation-progress"
 import { Search, FileText, Clock, X, ChevronDown, ChevronUp, Building2 } from "lucide-react"
 import { getPeople } from "@/lib/supabase/people"
 import { getVisas } from "@/lib/supabase/visas"
@@ -35,6 +36,7 @@ interface ExtendedKanbanColumn {
 
 export default function VisasPage() {
   const router = useRouter()
+  const { startNavigation } = useNavigationProgress()
   const searchParams = useSearchParams()
   const [searchTerm, setSearchTerm] = useState("")
   const [typeFilter, setTypeFilter] = useState<string>("all")
@@ -294,7 +296,8 @@ export default function VisasPage() {
   }
 
   const handleItemClick = (item: any) => {
-    window.location.href = `/people/${item.metadata.personId}`
+    startNavigation()
+    router.push(`/people/${item.metadata.personId}`)
   }
 
   const clearAllFilters = () => {

--- a/components/navigation-progress.tsx
+++ b/components/navigation-progress.tsx
@@ -1,0 +1,199 @@
+"use client"
+
+import type React from "react"
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react"
+import { usePathname } from "next/navigation"
+import { cn } from "@/lib/utils"
+
+type NavigationProgressContextValue = {
+  isNavigating: boolean
+  startNavigation: () => void
+  finishNavigation: () => void
+}
+
+const NavigationProgressContext = createContext<NavigationProgressContextValue | null>(null)
+
+const MIN_VISIBLE_MS = 280
+const DELAYED_LABEL_MS = 450
+const MAX_VISIBLE_MS = 8000
+
+function isModifiedClick(event: MouseEvent) {
+  return event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0
+}
+
+function isInternalNavigation(anchor: HTMLAnchorElement) {
+  if (!anchor.href || anchor.target || anchor.hasAttribute("download")) return false
+
+  const nextUrl = new URL(anchor.href)
+  const currentUrl = new URL(window.location.href)
+  const nextPath = `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`
+  const currentPath = `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`
+
+  return nextUrl.origin === currentUrl.origin && nextPath !== currentPath
+}
+
+export function NavigationProgressProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const [isNavigating, setIsNavigating] = useState(false)
+  const [showLabel, setShowLabel] = useState(false)
+  const startedAtRef = useRef(0)
+  const pathnameRef = useRef(pathname)
+  const finishTimerRef = useRef<number | null>(null)
+  const labelTimerRef = useRef<number | null>(null)
+  const maxTimerRef = useRef<number | null>(null)
+
+  const clearTimers = useCallback(() => {
+    if (finishTimerRef.current) {
+      window.clearTimeout(finishTimerRef.current)
+      finishTimerRef.current = null
+    }
+    if (labelTimerRef.current) {
+      window.clearTimeout(labelTimerRef.current)
+      labelTimerRef.current = null
+    }
+    if (maxTimerRef.current) {
+      window.clearTimeout(maxTimerRef.current)
+      maxTimerRef.current = null
+    }
+  }, [])
+
+  const startNavigation = useCallback(() => {
+    clearTimers()
+    startedAtRef.current = Date.now()
+    setIsNavigating(true)
+    setShowLabel(false)
+    labelTimerRef.current = window.setTimeout(() => {
+      setShowLabel(true)
+    }, DELAYED_LABEL_MS)
+    maxTimerRef.current = window.setTimeout(() => {
+      setIsNavigating(false)
+      setShowLabel(false)
+      maxTimerRef.current = null
+    }, MAX_VISIBLE_MS)
+  }, [clearTimers])
+
+  const finishNavigation = useCallback(() => {
+    const elapsed = Date.now() - startedAtRef.current
+    const remaining = Math.max(MIN_VISIBLE_MS - elapsed, 0)
+
+    if (labelTimerRef.current) {
+      window.clearTimeout(labelTimerRef.current)
+      labelTimerRef.current = null
+    }
+    if (maxTimerRef.current) {
+      window.clearTimeout(maxTimerRef.current)
+      maxTimerRef.current = null
+    }
+
+    finishTimerRef.current = window.setTimeout(() => {
+      setIsNavigating(false)
+      setShowLabel(false)
+      finishTimerRef.current = null
+    }, remaining)
+  }, [])
+
+  useEffect(() => {
+    if (pathnameRef.current !== pathname && isNavigating) {
+      pathnameRef.current = pathname
+      finishNavigation()
+      return
+    }
+
+    pathnameRef.current = pathname
+  }, [finishNavigation, isNavigating, pathname])
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (isModifiedClick(event)) return
+
+      const target = event.target as Element | null
+      const anchor = target?.closest("a")
+
+      if (anchor instanceof HTMLAnchorElement && isInternalNavigation(anchor)) {
+        startNavigation()
+      }
+    }
+
+    const handlePopState = () => {
+      startNavigation()
+    }
+
+    const patchHistoryMethod = (method: "pushState" | "replaceState") => {
+      const original = window.history[method]
+
+      window.history[method] = function patchedHistoryMethod(...args) {
+        const destination = args[2]
+
+        if (typeof destination === "string" || destination instanceof URL) {
+          const nextUrl = new URL(destination, window.location.href)
+          const currentUrl = new URL(window.location.href)
+          const nextPathWithSearch = `${nextUrl.pathname}${nextUrl.search}`
+          const currentPathWithSearch = `${currentUrl.pathname}${currentUrl.search}`
+
+          if (nextPathWithSearch !== currentPathWithSearch) {
+            startNavigation()
+          }
+        }
+
+        const result = original.apply(this, args)
+        window.setTimeout(() => {
+          finishNavigation()
+        }, 300)
+
+        return result
+      }
+
+      return () => {
+        window.history[method] = original
+      }
+    }
+
+    const restorePushState = patchHistoryMethod("pushState")
+    const restoreReplaceState = patchHistoryMethod("replaceState")
+
+    document.addEventListener("click", handleClick, true)
+    window.addEventListener("popstate", handlePopState)
+
+    return () => {
+      document.removeEventListener("click", handleClick, true)
+      window.removeEventListener("popstate", handlePopState)
+      restorePushState()
+      restoreReplaceState()
+      clearTimers()
+    }
+  }, [clearTimers, finishNavigation, startNavigation])
+
+  return (
+    <NavigationProgressContext.Provider value={{ isNavigating, startNavigation, finishNavigation }}>
+      {children}
+      <div
+        className={cn(
+          "pointer-events-none fixed inset-x-0 top-0 z-[200] h-0.5 overflow-hidden bg-transparent transition-opacity duration-150",
+          isNavigating ? "opacity-100" : "opacity-0",
+        )}
+        aria-hidden={!isNavigating}
+      >
+        <div className="h-full w-full origin-left animate-navigation-progress bg-primary shadow-[0_0_10px_rgba(59,139,255,0.55)]" />
+      </div>
+      {isNavigating && showLabel && (
+        <div
+          className="pointer-events-none fixed right-4 top-4 z-[201] rounded-md border border-border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground shadow-sm"
+          role="status"
+          aria-live="polite"
+        >
+          画面を読み込み中...
+        </div>
+      )}
+    </NavigationProgressContext.Provider>
+  )
+}
+
+export function useNavigationProgress() {
+  const context = useContext(NavigationProgressContext)
+
+  if (!context) {
+    throw new Error("useNavigationProgress must be used within NavigationProgressProvider")
+  }
+
+  return context
+}


### PR DESCRIPTION
## Summary
- Add a shared navigation progress provider that shows a thin top progress bar during internal route changes.
- Hook it into the root layout so links, history changes, and router-driven navigation get immediate feedback.
- Ensure the progress indicator clears after history updates so the blue line does not linger after navigation has completed.
- Start the navigation indicator explicitly for list/card interactions that route to person detail pages, including people, documents, and visas.
- Add the progress animation utility in global CSS.

## Impact
Users get clear feedback after clicking navigation controls, especially when route transitions take noticeable time. Person detail navigation from list-style UIs now shows the same feedback.

## Validation
- Confirmed visually in the in-app browser on `http://localhost:3001` for login/signup navigation, including that the loading status does not remain after the transition.
- `npm run typecheck` could not complete because existing errors remain in `constants/meeting-taxonomy.ts`.
- A limited typecheck for the touched files was also blocked by existing errors in `components/ui/button.tsx`, `components/ui/badge.tsx`, and `lib/hooks/use-toast.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual progress indicator that displays during page transitions to provide user feedback
  * Enhanced navigation performance on the visas page for a smoother user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->