### PR TITLE
Fix invite redirect URL fallback

### DIFF
--- a/app/api/tenants/[tenantId]/members/[memberId]/resend/route.ts
+++ b/app/api/tenants/[tenantId]/members/[memberId]/resend/route.ts
@@ -91,7 +91,7 @@ export async function POST(
 
     let redirectTo: string
     try {
-      redirectTo = getInviteRedirectUrl()
+      redirectTo = getInviteRedirectUrl(request.nextUrl.origin)
     } catch (error) {
       console.error("Error resolving resend redirect URL:", error)
       return NextResponse.json(

--- a/app/api/tenants/[tenantId]/members/invite/route.ts
+++ b/app/api/tenants/[tenantId]/members/invite/route.ts
@@ -128,7 +128,7 @@ export async function POST(
 
     let redirectTo: string
     try {
-      redirectTo = getInviteRedirectUrl()
+      redirectTo = getInviteRedirectUrl(request.nextUrl.origin)
     } catch (error) {
       console.error("Error resolving invitation redirect URL:", error)
       return NextResponse.json(

--- a/lib/supabase/invite-redirect.test.ts
+++ b/lib/supabase/invite-redirect.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import { getInviteRedirectUrl } from "./invite-redirect"
+
+const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL
+
+afterEach(() => {
+  if (originalAppUrl === undefined) {
+    delete process.env.NEXT_PUBLIC_APP_URL
+  } else {
+    process.env.NEXT_PUBLIC_APP_URL = originalAppUrl
+  }
+})
+
+describe("getInviteRedirectUrl", () => {
+  it("uses NEXT_PUBLIC_APP_URL when configured", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://example.com/base"
+
+    expect(getInviteRedirectUrl("https://request.example.com")).toBe(
+      "https://example.com/auth/set-password"
+    )
+  })
+
+  it("falls back to the request origin when NEXT_PUBLIC_APP_URL is missing", () => {
+    delete process.env.NEXT_PUBLIC_APP_URL
+
+    expect(getInviteRedirectUrl("https://request.example.com")).toBe(
+      "https://request.example.com/auth/set-password"
+    )
+  })
+
+  it("still reports a configuration error when no URL source is available", () => {
+    delete process.env.NEXT_PUBLIC_APP_URL
+
+    expect(() => getInviteRedirectUrl()).toThrow(
+      "NEXT_PUBLIC_APP_URL is not configured"
+    )
+  })
+})

--- a/lib/supabase/invite-redirect.ts
+++ b/lib/supabase/invite-redirect.ts
@@ -1,5 +1,5 @@
-export function getInviteRedirectUrl(): string {
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL
+export function getInviteRedirectUrl(origin?: string): string {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || origin
 
   if (!appUrl) {
     throw new Error("NEXT_PUBLIC_APP_URL is not configured")


### PR DESCRIPTION
## Summary
- Fallback to the request origin when generating invite redirect URLs if NEXT_PUBLIC_APP_URL is not configured
- Apply the fallback to both invite and resend invitation endpoints
- Add coverage for configured, fallback, and missing URL cases

## Environment check
- Checked Vercel project: funtoco/fun-support-messaging-tool
- NEXT_PUBLIC_APP_URL is not currently configured in Development, Preview, or Production env vars listed by `npx vercel env ls --scope funtoco`

## Tests
- `npm run test -- lib/supabase/invite-redirect.test.ts` passed
- `npx tsc --noEmit` currently fails on existing `constants/meeting-taxonomy.ts` invalid-character errors unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced invitation and resend-invitation flows to properly resolve redirect URLs using the current request's origin as a fallback, improving reliability across different deployment environments.

* **Tests**
  * Added comprehensive test coverage for invitation redirect URL resolution, including fallback scenarios and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->