### PR TITLE
[codex] Add affiliation-based tenant member scopes

### DIFF
--- a/app/api/tenants/[tenantId]/members/[memberId]/route.ts
+++ b/app/api/tenants/[tenantId]/members/[memberId]/route.ts
@@ -12,6 +12,23 @@ import {
 const MANAGEABLE_ROLES = ["owner", "admin", "member", "guest"] as const
 type ManageableRole = (typeof MANAGEABLE_ROLES)[number]
 
+function normalizeOfficeIds(value: unknown): string[] | null {
+  if (typeof value === "undefined") {
+    return null
+  }
+
+  if (!Array.isArray(value)) {
+    return null
+  }
+
+  const normalizedIds = value
+    .filter((id): id is string => typeof id === "string")
+    .map((id) => id.trim())
+    .filter(Boolean)
+
+  return Array.from(new Set(normalizedIds))
+}
+
 export async function PATCH(
   request: NextRequest,
   { params }: { params: { tenantId: string; memberId: string } }
@@ -26,17 +43,27 @@ export async function PATCH(
 
     const body = await request.json()
     const { role } = body
+    const officeIds = normalizeOfficeIds(body.officeIds)
+    const hasRoleUpdate = typeof role !== "undefined"
+    const hasOfficeUpdate = typeof body.officeIds !== "undefined"
 
-    if (!role) {
+    if (!hasRoleUpdate && !hasOfficeUpdate) {
       return NextResponse.json(
-        { error: "Role is required" },
+        { error: "Role or officeIds is required" },
         { status: 400 }
       )
     }
 
-    if (!MANAGEABLE_ROLES.includes(role)) {
+    if (hasRoleUpdate && (typeof role !== "string" || !MANAGEABLE_ROLES.includes(role as ManageableRole))) {
       return NextResponse.json(
         { error: "Invalid role" },
+        { status: 400 }
+      )
+    }
+
+    if (hasOfficeUpdate && officeIds === null) {
+      return NextResponse.json(
+        { error: "Invalid officeIds" },
         { status: 400 }
       )
     }
@@ -71,8 +98,9 @@ export async function PATCH(
       )
     }
 
+    const memberships = actorMemberships || []
     let activeOwnerCount = 0
-    if (targetMember.role === "owner" && role !== "owner") {
+    if (hasRoleUpdate && targetMember.role === "owner" && role !== "owner") {
       const { count, error: ownerCountError } = await supabase
         .from("user_tenants")
         .select("id", { count: "exact", head: true })
@@ -91,37 +119,108 @@ export async function PATCH(
       activeOwnerCount = count ?? 0
     }
 
-    const permissionError = getTenantMemberRoleUpdateError({
-      currentUserId: user.id,
-      targetUserId: targetMember.user_id,
-      targetRole: targetMember.role,
-      actorMemberships: actorMemberships || [],
-      nextRole: role as ManageableRole,
-      activeOwnerCount,
-    })
+    if (hasRoleUpdate) {
+      const permissionError = getTenantMemberRoleUpdateError({
+        currentUserId: user.id,
+        targetUserId: targetMember.user_id,
+        targetRole: targetMember.role,
+        actorMemberships: memberships,
+        nextRole: role as ManageableRole,
+        activeOwnerCount,
+      })
 
-    if (permissionError) {
-      const status =
-        permissionError === "ロールを変更する権限がありません" ||
-        permissionError === "オーナーのロールは変更できません"
-          ? 403
-          : 400
+      if (permissionError) {
+        const status =
+          permissionError === "ロールを変更する権限がありません" ||
+          permissionError === "オーナーのロールは変更できません"
+            ? 403
+            : 400
 
-      return NextResponse.json({ error: permissionError }, { status })
+        return NextResponse.json({ error: permissionError }, { status })
+      }
     }
 
-    const { error: updateError } = await supabase
-      .from("user_tenants")
-      .update({ role: role as ManageableRole })
-      .eq("id", params.memberId)
-      .eq("tenant_id", params.tenantId)
-
-    if (updateError) {
-      console.error("Error updating member role:", updateError)
+    if (hasOfficeUpdate && !canManageTenant(memberships)) {
       return NextResponse.json(
-        { error: "Failed to update member role" },
-        { status: 500 }
+        { error: "所属先を変更する権限がありません" },
+        { status: 403 }
       )
+    }
+
+    if (hasRoleUpdate) {
+      const { error: updateError } = await supabase
+        .from("user_tenants")
+        .update({ role: role as ManageableRole })
+        .eq("id", params.memberId)
+        .eq("tenant_id", params.tenantId)
+
+      if (updateError) {
+        console.error("Error updating member role:", updateError)
+        return NextResponse.json(
+          { error: "Failed to update member role" },
+          { status: 500 }
+        )
+      }
+    }
+
+    if (hasOfficeUpdate) {
+      const nextOfficeIds = officeIds || []
+
+      if (nextOfficeIds.length > 0) {
+        const { data: offices, error: officesError } = await supabase
+          .from("tenant_offices")
+          .select("id")
+          .eq("tenant_id", params.tenantId)
+          .eq("is_active", true)
+          .in("id", nextOfficeIds)
+
+        if (officesError) {
+          console.error("Error verifying member offices:", officesError)
+          return NextResponse.json(
+            { error: "Failed to verify affiliations" },
+            { status: 500 }
+          )
+        }
+
+        if ((offices || []).length !== nextOfficeIds.length) {
+          return NextResponse.json(
+            { error: "Invalid officeIds" },
+            { status: 400 }
+          )
+        }
+      }
+
+      const { error: deleteOfficeError } = await supabase
+        .from("user_tenant_offices")
+        .delete()
+        .eq("tenant_id", params.tenantId)
+        .eq("user_tenant_id", params.memberId)
+
+      if (deleteOfficeError) {
+        console.error("Error deleting member office assignments:", deleteOfficeError)
+        return NextResponse.json(
+          { error: "Failed to update member affiliations" },
+          { status: 500 }
+        )
+      }
+
+      if (nextOfficeIds.length > 0) {
+        const { error: insertOfficeError } = await supabase
+          .from("user_tenant_offices")
+          .insert(nextOfficeIds.map((officeId) => ({
+            tenant_id: params.tenantId,
+            user_tenant_id: params.memberId,
+            tenant_office_id: officeId,
+          })))
+
+        if (insertOfficeError) {
+          console.error("Error inserting member office assignments:", insertOfficeError)
+          return NextResponse.json(
+            { error: "Failed to update member affiliations" },
+            { status: 500 }
+          )
+        }
+      }
     }
 
     return NextResponse.json({ success: true })

--- a/app/api/tenants/[tenantId]/members/add/route.ts
+++ b/app/api/tenants/[tenantId]/members/add/route.ts
@@ -3,6 +3,58 @@ import { createClient } from "@/lib/supabase/server"
 import { createAdminClient } from "@/lib/supabase/client"
 import { canManageTenant } from "@/lib/tenant-access"
 
+function normalizeOfficeIds(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return Array.from(
+    new Set(
+      value
+        .filter((id): id is string => typeof id === "string")
+        .map((id) => id.trim())
+        .filter(Boolean)
+    )
+  )
+}
+
+async function replaceOfficeAssignments(
+  adminSupabase: ReturnType<typeof createAdminClient>,
+  tenantId: string,
+  userTenantId: string,
+  officeIds: string[]
+): Promise<string | null> {
+  const { error: deleteError } = await adminSupabase
+    .from("user_tenant_offices")
+    .delete()
+    .eq("tenant_id", tenantId)
+    .eq("user_tenant_id", userTenantId)
+
+  if (deleteError) {
+    console.error("Error deleting member office assignments:", deleteError)
+    return "Failed to update member affiliations"
+  }
+
+  if (officeIds.length === 0) {
+    return null
+  }
+
+  const { error: insertError } = await adminSupabase
+    .from("user_tenant_offices")
+    .insert(officeIds.map((officeId) => ({
+      tenant_id: tenantId,
+      user_tenant_id: userTenantId,
+      tenant_office_id: officeId,
+    })))
+
+  if (insertError) {
+    console.error("Error inserting member office assignments:", insertError)
+    return "Failed to update member affiliations"
+  }
+
+  return null
+}
+
 export async function POST(
   request: NextRequest,
   { params }: { params: { tenantId: string } }
@@ -17,6 +69,7 @@ export async function POST(
 
     const body = await request.json()
     const { userId, role } = body
+    const officeIds = normalizeOfficeIds(body.officeIds)
 
     if (!userId || !role) {
       return NextResponse.json(
@@ -46,6 +99,30 @@ export async function POST(
         { error: "You don't have permission to add members" },
         { status: 403 }
       )
+    }
+
+    if (officeIds.length > 0) {
+      const { data: offices, error: officesError } = await supabase
+        .from("tenant_offices")
+        .select("id")
+        .eq("tenant_id", params.tenantId)
+        .eq("is_active", true)
+        .in("id", officeIds)
+
+      if (officesError) {
+        console.error("Error verifying member offices:", officesError)
+        return NextResponse.json(
+          { error: "Failed to verify affiliations" },
+          { status: 500 }
+        )
+      }
+
+      if ((offices || []).length !== officeIds.length) {
+        return NextResponse.json(
+          { error: "Invalid officeIds" },
+          { status: 400 }
+        )
+      }
     }
 
     // Check if the user is already a member
@@ -78,9 +155,11 @@ export async function POST(
       (membership) => membership.status === 'pending'
     )
 
+    const adminSupabase = createAdminClient()
+
     if (pendingMembership) {
         // If pending, update to active with new role
-        const { error: updateError } = await supabase
+        const { error: updateError } = await adminSupabase
           .from('user_tenants')
           .update({
             role: role,
@@ -97,6 +176,20 @@ export async function POST(
           )
         }
 
+        const officeAssignmentError = await replaceOfficeAssignments(
+          adminSupabase,
+          params.tenantId,
+          pendingMembership.id,
+          officeIds
+        )
+
+        if (officeAssignmentError) {
+          return NextResponse.json(
+            { error: officeAssignmentError },
+            { status: 500 }
+          )
+        }
+
         return NextResponse.json({ 
           success: true, 
           message: "Member added successfully" 
@@ -104,7 +197,6 @@ export async function POST(
     }
 
     // Get user email from auth.users
-    const adminSupabase = createAdminClient()
     const { data: authUserData, error: authUserError } = await adminSupabase.auth.admin.getUserById(userId)
     
     if (authUserError || !authUserData?.user) {
@@ -143,7 +235,7 @@ export async function POST(
     }
 
     // Add the user to the tenant
-    const { error: insertError } = await supabase
+    const { data: userTenant, error: insertError } = await adminSupabase
       .from('user_tenants')
       .insert({
         user_id: userId,
@@ -154,11 +246,27 @@ export async function POST(
         invited_by: user.id,
         joined_at: new Date().toISOString()
       })
+      .select("id")
+      .single()
 
     if (insertError) {
       console.error('Error adding member:', insertError)
       return NextResponse.json(
         { error: "Failed to add member" },
+        { status: 500 }
+      )
+    }
+
+    const officeAssignmentError = await replaceOfficeAssignments(
+      adminSupabase,
+      params.tenantId,
+      userTenant.id,
+      officeIds
+    )
+
+    if (officeAssignmentError) {
+      return NextResponse.json(
+        { error: officeAssignmentError },
         { status: 500 }
       )
     }

--- a/app/api/tenants/[tenantId]/members/invite/route.ts
+++ b/app/api/tenants/[tenantId]/members/invite/route.ts
@@ -10,6 +10,21 @@ import {
 
 const INVITABLE_ROLES = new Set(["admin", "member", "guest"])
 
+function normalizeOfficeIds(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return Array.from(
+    new Set(
+      value
+        .filter((id): id is string => typeof id === "string")
+        .map((id) => id.trim())
+        .filter(Boolean)
+    )
+  )
+}
+
 export async function POST(
   request: NextRequest,
   { params }: { params: { tenantId: string } }
@@ -24,6 +39,7 @@ export async function POST(
 
     const body = await request.json()
     const { email, role } = body
+    const officeIds = normalizeOfficeIds(body.officeIds)
     const normalizedEmail = typeof email === "string" ? email.toLowerCase().trim() : ""
 
     if (!normalizedEmail || !role) {
@@ -93,6 +109,30 @@ export async function POST(
       }
     }
 
+    if (officeIds.length > 0) {
+      const { data: offices, error: officesError } = await supabase
+        .from("tenant_offices")
+        .select("id")
+        .eq("tenant_id", params.tenantId)
+        .eq("is_active", true)
+        .in("id", officeIds)
+
+      if (officesError) {
+        console.error("Error verifying invitation offices:", officesError)
+        return NextResponse.json(
+          { error: "Failed to verify affiliations" },
+          { status: 500 }
+        )
+      }
+
+      if ((offices || []).length !== officeIds.length) {
+        return NextResponse.json(
+          { error: "Invalid officeIds" },
+          { status: 400 }
+        )
+      }
+    }
+
     // Check if email is already a member
     const { data: existingMemberships, error: existingMembershipsError } = await supabase
       .from('user_tenants')
@@ -146,7 +186,8 @@ export async function POST(
         data: {
           tenant_id: params.tenantId,
           role: role,
-          invited_by: user.id
+          invited_by: user.id,
+          office_ids: officeIds,
         },
         redirectTo
       })
@@ -160,7 +201,7 @@ export async function POST(
       }
       
       // Store the invitation metadata in user_tenants with pending status
-      const { error: userTenantError } = await supabase
+      const { data: userTenant, error: userTenantError } = await adminSupabase
         .from('user_tenants')
         .insert({
           user_id: data.user.id,
@@ -171,6 +212,8 @@ export async function POST(
           invited_by: user.id,
           invited_at: new Date().toISOString()
         })
+        .select("id")
+        .single()
       
       if (userTenantError) {
         console.error('Error creating user tenant record:', userTenantError)
@@ -185,6 +228,24 @@ export async function POST(
           { error: "Failed to create user tenant record" },
           { status: 500 }
         )
+      }
+
+      if (officeIds.length > 0) {
+        const { error: officeAssignmentError } = await adminSupabase
+          .from("user_tenant_offices")
+          .insert(officeIds.map((officeId) => ({
+            tenant_id: params.tenantId,
+            user_tenant_id: userTenant.id,
+            tenant_office_id: officeId,
+          })))
+
+        if (officeAssignmentError) {
+          console.error("Error creating user tenant office assignments:", officeAssignmentError)
+          return NextResponse.json(
+            { error: "Failed to assign affiliations" },
+            { status: 500 }
+          )
+        }
       }
       
       return NextResponse.json({ 

--- a/app/api/tenants/[tenantId]/offices/route.ts
+++ b/app/api/tenants/[tenantId]/offices/route.ts
@@ -1,0 +1,183 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { createAdminClient } from "@/lib/supabase/client"
+
+interface TenantOfficeRecord {
+  id: string
+  tenant_id: string
+  name: string
+  slug?: string | null
+  address?: string | null
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+function officeKey(name: string) {
+  return name.trim().toLocaleLowerCase("ja-JP")
+}
+
+function uniqueAffiliationNames(rows: Array<{ company: string | null }>) {
+  const namesByKey = new Map<string, string>()
+
+  for (const row of rows) {
+    const name = row.company?.trim()
+    if (!name) {
+      continue
+    }
+
+    const key = officeKey(name)
+    if (!namesByKey.has(key)) {
+      namesByKey.set(key, name)
+    }
+  }
+
+  return Array.from(namesByKey.values()).sort((a, b) =>
+    a.localeCompare(b, "ja-JP")
+  )
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { tenantId: string } }
+) {
+  try {
+    const supabase = await createClient()
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const { data: memberships, error: membershipError } = await supabase
+      .from("user_tenants")
+      .select("id")
+      .eq("tenant_id", params.tenantId)
+      .eq("user_id", user.id)
+      .eq("status", "active")
+      .limit(1)
+
+    if (membershipError) {
+      console.error("Error verifying tenant membership:", membershipError)
+      return NextResponse.json(
+        { error: "Failed to verify membership" },
+        { status: 500 }
+      )
+    }
+
+    if (!memberships || memberships.length === 0) {
+      return NextResponse.json(
+        { error: "Tenant membership is required" },
+        { status: 403 }
+      )
+    }
+
+    const adminSupabase = createAdminClient()
+    const { data: people, error: peopleError } = await adminSupabase
+      .from("people")
+      .select("company")
+      .eq("tenant_id", params.tenantId)
+
+    if (peopleError) {
+      console.error("Error fetching tenant affiliations:", peopleError)
+      return NextResponse.json(
+        { error: "Failed to fetch affiliations" },
+        { status: 500 }
+      )
+    }
+
+    const affiliationNames = uniqueAffiliationNames(people || [])
+    if (affiliationNames.length === 0) {
+      return NextResponse.json({ offices: [] })
+    }
+
+    const affiliationKeys = new Set(affiliationNames.map(officeKey))
+    const { data: existingOffices, error: existingOfficesError } = await adminSupabase
+      .from("tenant_offices")
+      .select("id, tenant_id, name, slug, address, is_active, created_at, updated_at")
+      .eq("tenant_id", params.tenantId)
+
+    if (existingOfficesError) {
+      console.error("Error fetching affiliation scopes:", existingOfficesError)
+      return NextResponse.json(
+        { error: "Failed to fetch affiliations" },
+        { status: 500 }
+      )
+    }
+
+    const existingByKey = new Map<string, TenantOfficeRecord>()
+    for (const office of existingOffices || []) {
+      existingByKey.set(officeKey(office.name), office)
+    }
+
+    const inactiveMatchingOfficeIds = (existingOffices || [])
+      .filter((office) => affiliationKeys.has(officeKey(office.name)) && !office.is_active)
+      .map((office) => office.id)
+
+    if (inactiveMatchingOfficeIds.length > 0) {
+      const { error: reactivateError } = await adminSupabase
+        .from("tenant_offices")
+        .update({ is_active: true })
+        .eq("tenant_id", params.tenantId)
+        .in("id", inactiveMatchingOfficeIds)
+
+      if (reactivateError) {
+        console.error("Error reactivating affiliation scopes:", reactivateError)
+        return NextResponse.json(
+          { error: "Failed to update affiliations" },
+          { status: 500 }
+        )
+      }
+    }
+
+    for (const name of affiliationNames) {
+      if (existingByKey.has(officeKey(name))) {
+        continue
+      }
+
+      const { error: insertError } = await adminSupabase
+        .from("tenant_offices")
+        .insert({
+          tenant_id: params.tenantId,
+          name,
+          metadata: {
+            source: "people.company",
+          },
+        })
+
+      if (insertError && insertError.code !== "23505") {
+        console.error("Error creating affiliation scope:", insertError)
+        return NextResponse.json(
+          { error: "Failed to update affiliations" },
+          { status: 500 }
+        )
+      }
+    }
+
+    const { data: offices, error: officesError } = await adminSupabase
+      .from("tenant_offices")
+      .select("id, tenant_id, name, slug, address, is_active, created_at, updated_at")
+      .eq("tenant_id", params.tenantId)
+      .eq("is_active", true)
+
+    if (officesError) {
+      console.error("Error fetching affiliation scopes:", officesError)
+      return NextResponse.json(
+        { error: "Failed to fetch affiliations" },
+        { status: 500 }
+      )
+    }
+
+    const syncedOffices = (offices || [])
+      .filter((office) => affiliationKeys.has(officeKey(office.name)))
+      .sort((a, b) => a.name.localeCompare(b.name, "ja-JP"))
+
+    return NextResponse.json({ offices: syncedOffices })
+  } catch (error) {
+    console.error("Error fetching tenant affiliations:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch affiliations" },
+      { status: 500 }
+    )
+  }
+}

--- a/components/tenant/add-existing-member-dialog.tsx
+++ b/components/tenant/add-existing-member-dialog.tsx
@@ -12,16 +12,19 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { CheckCircle, Search, Loader2 } from "lucide-react"
 import { useToast } from "@/lib/hooks/use-toast"
+import type { TenantOffice } from "@/lib/supabase/tenants"
 
 interface AddExistingMemberDialogProps {
   tenantId: string
   open: boolean
   onOpenChange: (open: boolean) => void
   onAddMember: () => void
+  offices?: TenantOffice[]
 }
 
 interface SearchUser {
@@ -36,12 +39,14 @@ export function AddExistingMemberDialog({
   tenantId, 
   open, 
   onOpenChange, 
-  onAddMember 
+  onAddMember,
+  offices = [],
 }: AddExistingMemberDialogProps) {
   const [searchQuery, setSearchQuery] = useState("")
   const [searchResults, setSearchResults] = useState<SearchUser[]>([])
   const [selectedUser, setSelectedUser] = useState<SearchUser | null>(null)
   const [role, setRole] = useState<'admin' | 'member' | 'guest'>('member')
+  const [selectedOfficeIds, setSelectedOfficeIds] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
   const [searching, setSearching] = useState(false)
   const { toast } = useToast()
@@ -108,7 +113,8 @@ export function AddExistingMemberDialog({
         },
         body: JSON.stringify({
           userId: selectedUser.user_id,
-          role: role
+          role: role,
+          officeIds: selectedOfficeIds,
         })
       })
 
@@ -128,6 +134,7 @@ export function AddExistingMemberDialog({
       setSearchResults([])
       setSelectedUser(null)
       setRole('member')
+      setSelectedOfficeIds([])
       onOpenChange(false)
       onAddMember()
     } catch (error) {
@@ -147,7 +154,16 @@ export function AddExistingMemberDialog({
     setSearchResults([])
     setSelectedUser(null)
     setRole('member')
+    setSelectedOfficeIds([])
     onOpenChange(false)
+  }
+
+  const toggleOffice = (officeId: string, checked: boolean) => {
+    setSelectedOfficeIds((currentOfficeIds) =>
+      checked
+        ? Array.from(new Set([...currentOfficeIds, officeId]))
+        : currentOfficeIds.filter((id) => id !== officeId)
+    )
   }
 
   const getRoleBadgeColor = (role: string) => {
@@ -276,6 +292,28 @@ export function AddExistingMemberDialog({
                 </Select>
               </div>
             )}
+
+            {selectedUser && offices.length > 0 && (
+              <div className="grid gap-2">
+                <Label>所属先</Label>
+                <div className="max-h-48 space-y-2 overflow-y-auto rounded-md border p-3">
+                  {offices.map((office) => (
+                    <Label
+                      key={office.id}
+                      htmlFor={`add-office-${office.id}`}
+                      className="flex cursor-pointer items-center gap-3 rounded-md px-2 py-2 hover:bg-muted"
+                    >
+                      <Checkbox
+                        id={`add-office-${office.id}`}
+                        checked={selectedOfficeIds.includes(office.id)}
+                        onCheckedChange={(checked) => toggleOffice(office.id, checked === true)}
+                      />
+                      <span className="text-sm font-medium">{office.name}</span>
+                    </Label>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={handleCancel} disabled={loading}>
@@ -290,4 +328,3 @@ export function AddExistingMemberDialog({
     </Dialog>
   )
 }
-

--- a/components/tenant/invite-member-dialog.tsx
+++ b/components/tenant/invite-member-dialog.tsx
@@ -12,8 +12,10 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useToast } from "@/lib/hooks/use-toast"
+import type { TenantOffice } from "@/lib/supabase/tenants"
 
 interface InviteMemberDialogProps {
   tenantId: string
@@ -21,6 +23,7 @@ interface InviteMemberDialogProps {
   onOpenChange: (open: boolean) => void
   onInviteSent: () => void
   canChooseRole?: boolean
+  offices?: TenantOffice[]
 }
 
 export function InviteMemberDialog({ 
@@ -29,10 +32,12 @@ export function InviteMemberDialog({
   onOpenChange, 
   onInviteSent,
   canChooseRole = true,
+  offices = [],
 }: InviteMemberDialogProps) {
   const [name, setName] = useState("")
   const [email, setEmail] = useState("")
   const [role, setRole] = useState<'admin' | 'member' | 'guest'>('member')
+  const [selectedOfficeIds, setSelectedOfficeIds] = useState<string[]>([])
   const [errors, setErrors] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(false)
   const { toast } = useToast()
@@ -73,7 +78,8 @@ export function InviteMemberDialog({
         },
         body: JSON.stringify({
           email: email.toLowerCase().trim(),
-          role: inviteRole
+          role: inviteRole,
+          officeIds: selectedOfficeIds,
         })
       })
 
@@ -92,6 +98,7 @@ export function InviteMemberDialog({
       setName("")
       setEmail("")
       setRole('member')
+      setSelectedOfficeIds([])
       setErrors({})
       onOpenChange(false)
       onInviteSent()
@@ -111,8 +118,17 @@ export function InviteMemberDialog({
     setName("")
     setEmail("")
     setRole('member')
+    setSelectedOfficeIds([])
     setErrors({})
     onOpenChange(false)
+  }
+
+  const toggleOffice = (officeId: string, checked: boolean) => {
+    setSelectedOfficeIds((currentOfficeIds) =>
+      checked
+        ? Array.from(new Set([...currentOfficeIds, officeId]))
+        : currentOfficeIds.filter((id) => id !== officeId)
+    )
   }
 
   return (
@@ -163,6 +179,27 @@ export function InviteMemberDialog({
                 <Label>ロール</Label>
                 <div className="rounded-md border px-3 py-2 text-sm text-muted-foreground">
                   member - 企業担当者は member として招待されます
+                </div>
+              </div>
+            )}
+            {offices.length > 0 && (
+              <div className="grid gap-2">
+                <Label>所属先</Label>
+                <div className="max-h-48 space-y-2 overflow-y-auto rounded-md border p-3">
+                  {offices.map((office) => (
+                    <Label
+                      key={office.id}
+                      htmlFor={`invite-office-${office.id}`}
+                      className="flex cursor-pointer items-center gap-3 rounded-md px-2 py-2 hover:bg-muted"
+                    >
+                      <Checkbox
+                        id={`invite-office-${office.id}`}
+                        checked={selectedOfficeIds.includes(office.id)}
+                        onCheckedChange={(checked) => toggleOffice(office.id, checked === true)}
+                      />
+                      <span className="text-sm font-medium">{office.name}</span>
+                    </Label>
+                  ))}
                 </div>
               </div>
             )}

--- a/components/tenant/member-offices-dialog.tsx
+++ b/components/tenant/member-offices-dialog.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
+import type { TenantOffice, UserTenant } from "@/lib/supabase/tenants"
+
+interface MemberOfficesDialogProps {
+  member: UserTenant | null
+  offices: TenantOffice[]
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSave: (memberId: string, officeIds: string[]) => Promise<void>
+}
+
+export function MemberOfficesDialog({
+  member,
+  offices,
+  open,
+  onOpenChange,
+  onSave,
+}: MemberOfficesDialogProps) {
+  const [selectedOfficeIds, setSelectedOfficeIds] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!member || !open) {
+      setSelectedOfficeIds([])
+      setError(null)
+      return
+    }
+
+    setSelectedOfficeIds((member.offices || []).map((office) => office.id))
+    setError(null)
+  }, [member, open])
+
+  const selectedOfficeIdSet = useMemo(
+    () => new Set(selectedOfficeIds),
+    [selectedOfficeIds]
+  )
+
+  const toggleOffice = (officeId: string, checked: boolean) => {
+    setSelectedOfficeIds((currentOfficeIds) =>
+      checked
+        ? Array.from(new Set([...currentOfficeIds, officeId]))
+        : currentOfficeIds.filter((id) => id !== officeId)
+    )
+  }
+
+  const handleSave = async () => {
+    if (!member) {
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      await onSave(member.id, selectedOfficeIds)
+      onOpenChange(false)
+    } catch (saveError) {
+      console.error("Error updating member offices:", saveError)
+      setError(saveError instanceof Error ? saveError.message : "所属先の更新に失敗しました")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>所属先スコープ</DialogTitle>
+          <DialogDescription>{member?.email || "メンバー"} の担当所属先を管理します。</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2">
+          <div className="rounded-md border px-3 py-2 text-sm text-muted-foreground">
+            未選択の場合は全所属先を対象にします
+          </div>
+
+          {offices.length === 0 ? (
+            <div className="rounded-md border px-3 py-6 text-center text-sm text-muted-foreground">
+              所属先が見つかりません
+            </div>
+          ) : (
+            <div className="max-h-64 space-y-2 overflow-y-auto rounded-md border p-3">
+              {offices.map((office) => (
+                <Label
+                  key={office.id}
+                  htmlFor={`office-${office.id}`}
+                  className="flex cursor-pointer items-center gap-3 rounded-md px-2 py-2 hover:bg-muted"
+                >
+                  <Checkbox
+                    id={`office-${office.id}`}
+                    checked={selectedOfficeIdSet.has(office.id)}
+                    onCheckedChange={(checked) => toggleOffice(office.id, checked === true)}
+                  />
+                  <span className="text-sm font-medium">{office.name}</span>
+                </Label>
+              ))}
+            </div>
+          )}
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
+            キャンセル
+          </Button>
+          <Button type="button" onClick={handleSave} disabled={loading}>
+            {loading ? "保存中..." : "保存"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/tenant/members-table.tsx
+++ b/components/tenant/members-table.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { MoreHorizontal, RefreshCw, Trash2 } from "lucide-react"
+import { Building2, MoreHorizontal, Pencil, RefreshCw, Trash2 } from "lucide-react"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import {
   DropdownMenu,
@@ -18,6 +18,8 @@ import { StatusBadge } from "./status-badge"
 import type { UserTenant } from "@/lib/supabase/tenants"
 import { isCompanyContactEmail, isCompanyContactRole } from "@/lib/tenant-access"
 
+type DisplayRole = 'owner' | 'admin' | 'member' | 'guest'
+
 interface MembersTableProps {
   members: UserTenant[]
   selectedMembers: string[]
@@ -25,6 +27,7 @@ interface MembersTableProps {
   onSelectAll: (memberIds: string[], selected: boolean) => void
   onChangeRole: (memberId: string, role: 'owner' | 'admin' | 'member' | 'guest') => void
   onDeleteMember: (memberId: string) => void
+  onEditOffices?: (member: UserTenant) => void
   onResendInvite?: (memberId: string) => void
   currentUserRole: 'owner' | 'admin' | 'member' | 'guest'
   canManageCompanyContacts?: boolean
@@ -38,6 +41,7 @@ export function MembersTable({
   onSelectAll,
   onChangeRole,
   onDeleteMember,
+  onEditOffices,
   onResendInvite,
   currentUserRole,
   canManageCompanyContacts = false,
@@ -55,6 +59,9 @@ export function MembersTable({
       minute: "2-digit",
     })
   }
+
+  const getDisplayRole = (role: UserTenant["role"]): DisplayRole =>
+    role === "supporter" ? "member" : role
 
   // Permission checks
   const canChangeRole = (targetMember: UserTenant) => {
@@ -90,6 +97,11 @@ export function MembersTable({
     return isCompanyContactEmail(targetMember.email) && isCompanyContactRole(targetMember.role)
   }
 
+  const canEditOffices = (targetMember: UserTenant) =>
+    Boolean(onEditOffices) &&
+    (currentUserRole === "owner" || currentUserRole === "admin") &&
+    targetMember.user_id !== currentUserId
+
   const canSelectMember = (targetMember: UserTenant) =>
     canBulkDeleteMembers && canDeleteMember(targetMember)
 
@@ -111,6 +123,7 @@ export function MembersTable({
 
   const hasRowActions = (targetMember: UserTenant) =>
     canChangeRole(targetMember) ||
+    canEditOffices(targetMember) ||
     canResendInvite(targetMember) ||
     canDeleteMember(targetMember)
 
@@ -122,6 +135,11 @@ export function MembersTable({
   const handleDeleteMember = (member: UserTenant) => {
     if (!canDeleteMember(member)) return
     onDeleteMember(member.id)
+  }
+
+  const handleEditOffices = (member: UserTenant) => {
+    if (!canEditOffices(member)) return
+    onEditOffices?.(member)
   }
 
   const handleResendInvite = (member: UserTenant) => {
@@ -149,6 +167,7 @@ export function MembersTable({
             ) : null}
             <TableHead>メール</TableHead>
             <TableHead>ロール</TableHead>
+            <TableHead>所属先</TableHead>
             <TableHead>ステータス</TableHead>
             <TableHead>参加日</TableHead>
             <TableHead className="w-12"></TableHead>
@@ -191,7 +210,37 @@ export function MembersTable({
                   </div>
                 </TableCell>
                 <TableCell>
-                  <RoleBadge role={member.role} />
+                  <RoleBadge role={getDisplayRole(member.role)} />
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    {member.offices && member.offices.length > 0 ? (
+                      <div className="flex max-w-64 flex-wrap gap-1">
+                        {member.offices.slice(0, 2).map((office) => (
+                          <Badge key={office.id} variant="outline" className="max-w-40 truncate">
+                            {office.name}
+                          </Badge>
+                        ))}
+                        {member.offices.length > 2 && (
+                          <Badge variant="outline">+{member.offices.length - 2}</Badge>
+                        )}
+                      </div>
+                    ) : (
+                      <Badge variant="secondary">全所属先</Badge>
+                    )}
+                    {canEditOffices(member) && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-7 shrink-0 px-2 text-xs"
+                        onClick={() => handleEditOffices(member)}
+                      >
+                        <Pencil className="size-3.5" />
+                        変更
+                      </Button>
+                    )}
+                  </div>
                 </TableCell>
                 <TableCell>
                   <StatusBadge status={member.status} />
@@ -242,7 +291,18 @@ export function MembersTable({
                           </>
                         )}
 
-                        {canChangeRole(member) && (canResendInvite(member) || canDeleteMember(member)) && (
+                        {canChangeRole(member) && (canEditOffices(member) || canResendInvite(member) || canDeleteMember(member)) && (
+                          <DropdownMenuSeparator />
+                        )}
+
+                        {canEditOffices(member) && (
+                          <DropdownMenuItem onClick={() => handleEditOffices(member)}>
+                            <Building2 className="size-4 mr-2" />
+                            所属先を変更
+                          </DropdownMenuItem>
+                        )}
+
+                        {canEditOffices(member) && (canResendInvite(member) || canDeleteMember(member)) && (
                           <DropdownMenuSeparator />
                         )}
 

--- a/components/tenant/tenant-members-page.tsx
+++ b/components/tenant/tenant-members-page.tsx
@@ -11,13 +11,17 @@ import { InviteMemberDialog } from "./invite-member-dialog"
 import { AddExistingMemberDialog } from "./add-existing-member-dialog"
 import { CreateUserDialog } from "./create-user-dialog"
 import { InviteLinkDialog } from "./invite-link-dialog"
+import { MemberOfficesDialog } from "./member-offices-dialog"
 import { ConfirmDialog } from "./confirm-dialog"
 import { EmptyState } from "./empty-state"
 import { 
   getTenantMembers, 
+  getTenantOffices,
   resendTenantInvitation,
   updateUserTenantRole,
+  updateUserTenantOffices,
   removeUserFromTenant,
+  type TenantOffice,
   type UserTenant
 } from "@/lib/supabase/tenants"
 import { useAuth } from "@/contexts/auth-context"
@@ -32,10 +36,12 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
   const { user } = useAuth()
   const { toast } = useToast()
   const [members, setMembers] = useState<UserTenant[]>([])
+  const [offices, setOffices] = useState<TenantOffice[]>([])
   const [searchQuery, setSearchQuery] = useState("")
   const [selectedMembers, setSelectedMembers] = useState<string[]>([])
   const [activeTab, setActiveTab] = useState("all")
   const [loading, setLoading] = useState(true)
+  const [officeEditingMember, setOfficeEditingMember] = useState<UserTenant | null>(null)
 
   // Dialog states
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false)
@@ -61,8 +67,12 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
   const fetchData = useCallback(async () => {
     try {
       setLoading(true)
-      const membersData = await getTenantMembers(tenantId)
+      const [membersData, officesData] = await Promise.all([
+        getTenantMembers(tenantId),
+        getTenantOffices(tenantId),
+      ])
       setMembers(membersData)
+      setOffices(officesData)
     } catch (error) {
       console.error('Error fetching data:', error)
     } finally {
@@ -76,7 +86,10 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
 
   // Get current user's role in this tenant
   const currentUserMember = members.find(m => m.user_id === user?.id)
-  const currentUserRole = currentUserMember?.role || 'guest'
+  const currentUserRole =
+    currentUserMember?.role && currentUserMember.role !== 'supporter'
+      ? currentUserMember.role
+      : 'guest'
   const canManageMembers = currentUserRole === 'owner' || currentUserRole === 'admin'
   const canManageCompanyContacts = canManageCompanyContactsForActor(
     currentUserMember ? [{ role: currentUserMember.role }] : [],
@@ -93,6 +106,9 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
       filtered = filtered.filter(
         (member) =>
           (member.email || '').toLowerCase().includes(searchQuery.toLowerCase())
+          || (member.offices || []).some((office) =>
+            office.name.toLowerCase().includes(searchQuery.toLowerCase())
+          )
       )
     }
 
@@ -133,6 +149,15 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
     } catch (error) {
       console.error('Error updating role:', error)
     }
+  }
+
+  const handleUpdateMemberOffices = async (memberId: string, officeIds: string[]) => {
+    await updateUserTenantOffices(tenantId, memberId, officeIds)
+    await fetchData()
+    toast({
+      title: "完了",
+      description: "所属先スコープを更新しました",
+    })
   }
 
   // Handle member removal
@@ -341,6 +366,7 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
               onSelectAll={handleSelectAll}
               onChangeRole={handleChangeRole}
               onDeleteMember={showDeleteConfirm}
+              onEditOffices={setOfficeEditingMember}
               onResendInvite={handleResendInvite}
               currentUserRole={currentUserRole}
               canManageCompanyContacts={canManageCompanyContacts}
@@ -362,6 +388,7 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
               onSelectAll={handleSelectAll}
               onChangeRole={handleChangeRole}
               onDeleteMember={showDeleteConfirm}
+              onEditOffices={setOfficeEditingMember}
               onResendInvite={handleResendInvite}
               currentUserRole={currentUserRole}
               canManageCompanyContacts={canManageCompanyContacts}
@@ -383,6 +410,7 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
               onSelectAll={handleSelectAll}
               onChangeRole={handleChangeRole}
               onDeleteMember={showDeleteConfirm}
+              onEditOffices={setOfficeEditingMember}
               onResendInvite={handleResendInvite}
               currentUserRole={currentUserRole}
               canManageCompanyContacts={canManageCompanyContacts}
@@ -399,6 +427,7 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
         onOpenChange={setIsInviteDialogOpen}
         onInviteSent={fetchData}
         canChooseRole={canManageMembers}
+        offices={offices}
       />
 
       <AddExistingMemberDialog
@@ -406,6 +435,7 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
         open={isAddDialogOpen}
         onOpenChange={setIsAddDialogOpen}
         onAddMember={fetchData}
+        offices={offices}
       />
 
       <CreateUserDialog
@@ -413,6 +443,18 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
         open={isCreateUserDialogOpen}
         onOpenChange={setIsCreateUserDialogOpen}
         onUserCreated={fetchData}
+      />
+
+      <MemberOfficesDialog
+        member={officeEditingMember}
+        offices={offices}
+        open={Boolean(officeEditingMember)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setOfficeEditingMember(null)
+          }
+        }}
+        onSave={handleUpdateMemberOffices}
       />
 
       <InviteLinkDialog

--- a/lib/supabase/tenants.ts
+++ b/lib/supabase/tenants.ts
@@ -11,12 +11,30 @@ export interface Tenant {
   updated_at: string
 }
 
+export interface TenantOffice {
+  id: string
+  tenant_id: string
+  name: string
+  slug?: string | null
+  address?: string | null
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
 export interface UserTenant {
   id: string
   user_id: string
   tenant_id: string
   email?: string
-  role: 'owner' | 'admin' | 'member' | 'guest'
+  user?: {
+    email?: string
+    user_metadata?: {
+      name?: string
+      [key: string]: any
+    }
+  }
+  role: 'owner' | 'admin' | 'member' | 'guest' | 'supporter'
   status: 'active' | 'pending' | 'suspended'
   invited_by?: string
   invited_at?: string
@@ -24,8 +42,13 @@ export interface UserTenant {
   created_at: string
   updated_at: string
   tenant?: Tenant
+  offices?: TenantOffice[]
 }
 
+interface UserTenantOfficeAssignment {
+  user_tenant_id: string
+  tenant_office_id: string
+}
 
 export async function getTenants(): Promise<Tenant[]> {
   const supabase = createClient()
@@ -131,7 +154,55 @@ export async function getTenantMembers(tenantId: string): Promise<UserTenant[]> 
     return []
   }
 
-  return members
+  const memberIds = members.map((member: UserTenant) => member.id)
+
+  const { data: assignments, error: assignmentsError } = await supabase
+    .from('user_tenant_offices')
+    .select('user_tenant_id, tenant_office_id')
+    .eq('tenant_id', tenantId)
+    .in('user_tenant_id', memberIds)
+
+  if (assignmentsError) {
+    console.error('Error fetching tenant member office assignments:', assignmentsError)
+    throw assignmentsError
+  }
+
+  const assignmentRecords = (assignments || []) as UserTenantOfficeAssignment[]
+  const officeIds = Array.from(
+    new Set(assignmentRecords.map((assignment) => assignment.tenant_office_id))
+  )
+
+  const officesById = new Map<string, TenantOffice>()
+  if (officeIds.length > 0) {
+    const { data: officeRecords, error: officesError } = await supabase
+      .from('tenant_offices')
+      .select('id, tenant_id, name, slug, address, is_active, created_at, updated_at')
+      .eq('tenant_id', tenantId)
+      .in('id', officeIds)
+
+    if (officesError) {
+      console.error('Error fetching tenant member offices:', officesError)
+      throw officesError
+    }
+
+    for (const office of officeRecords || []) {
+      officesById.set(office.id, office)
+    }
+  }
+
+  const officeIdsByMemberId = new Map<string, string[]>()
+  for (const assignment of assignmentRecords) {
+    const currentOfficeIds = officeIdsByMemberId.get(assignment.user_tenant_id) || []
+    currentOfficeIds.push(assignment.tenant_office_id)
+    officeIdsByMemberId.set(assignment.user_tenant_id, currentOfficeIds)
+  }
+
+  return members.map((member: UserTenant) => ({
+    ...member,
+    offices: (officeIdsByMemberId.get(member.id) || [])
+      .map((officeId) => officesById.get(officeId))
+      .filter((office): office is TenantOffice => Boolean(office)),
+  }))
 }
 
 export async function getTenantInvitations(tenantId: string): Promise<UserTenant[]> {
@@ -152,10 +223,26 @@ export async function getTenantInvitations(tenantId: string): Promise<UserTenant
   return data || []
 }
 
+export async function getTenantOffices(tenantId: string): Promise<TenantOffice[]> {
+  if (!tenantId || tenantId === 'null') {
+    return []
+  }
+
+  const response = await fetch(`/api/tenants/${tenantId}/offices`)
+  const result = await response.json()
+
+  if (!response.ok) {
+    throw new Error(result.error || 'Failed to fetch affiliations')
+  }
+
+  return result.offices || []
+}
+
 export async function createTenantInvitation(
   tenantId: string,
   email: string,
-  role: 'admin' | 'member' | 'guest'
+  role: 'admin' | 'member' | 'guest',
+  officeIds: string[] = []
 ): Promise<{ success: boolean; error?: string }> {
   try {
     // Call the API route instead of using admin client directly
@@ -166,7 +253,8 @@ export async function createTenantInvitation(
       },
       body: JSON.stringify({
         email,
-        role
+        role,
+        officeIds,
       })
     })
 
@@ -288,6 +376,26 @@ export async function updateUserTenantRole(
 
   if (!response.ok) {
     throw new Error(result.error || 'Failed to update user tenant role')
+  }
+}
+
+export async function updateUserTenantOffices(
+  tenantId: string,
+  userTenantId: string,
+  officeIds: string[]
+): Promise<void> {
+  const response = await fetch(`/api/tenants/${tenantId}/members/${userTenantId}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ officeIds }),
+  })
+
+  const result = await response.json()
+
+  if (!response.ok) {
+    throw new Error(result.error || 'Failed to update member affiliations')
   }
 }
 


### PR DESCRIPTION
## Summary
- Add tenant member affiliation scopes based on the existing `people.company` value shown as `所属先`
- Sync affiliation candidates from people records through `/api/tenants/[tenantId]/offices`
- Let admins/owners assign affiliation scopes when inviting, adding, or editing members
- Show `所属先` directly in the members table with a visible `変更` action
- Update the `supabase` submodule pointer to the companion migration branch commit

## Why
Issue #92 needs accounts under the same tenant to be separated by the actual workplace/affiliation. The relevant field in FunBase is the people list `所属先`, not a manually maintained office master.

## Companion PR
- fun-base-infra: https://github.com/funtoco/fun-base-infra/pull/57

## Validation
- Started local Next.js dev server at `http://localhost:3000`
- Verified `/api/tenants/[tenantId]/offices` compiles and returns `401` when unauthenticated
- Verified authenticated local logs show the affiliation API returning `200`
- Applied the new Supabase migration locally
- Verified local `people.company` affiliation values exist
- Ran targeted TypeScript diagnostics for touched tenant files: passed
- Ran `git diff --check`: passed

## Known Existing Issue
- Full `npm run typecheck` is currently blocked by pre-existing invalid characters in `constants/meeting-taxonomy.ts`, unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Office affiliation management: Assign members to one or more offices when inviting or adding them to your tenant
  * Member office editor: Dedicated interface to manage which offices each team member belongs to
  * Enhanced member visibility: Office affiliations now displayed in member listings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->