### PR TITLE
[codex] Restrict people visibility by company access

### DIFF
--- a/lib/supabase/people-access.test.ts
+++ b/lib/supabase/people-access.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "vitest"
+import { buildCompanyAccess, canAccessPersonByCompany } from "./people-access"
+
+describe("people company access", () => {
+  test("allows owner-like roles to see every company in their tenant", () => {
+    const access = buildCompanyAccess([
+      {
+        tenant_id: "tenant-1",
+        role: "admin",
+        status: "active",
+      },
+    ])
+
+    expect(canAccessPersonByCompany({ tenant_id: "tenant-1", company: "名谷病院" }, access)).toBe(true)
+    expect(canAccessPersonByCompany({ tenant_id: "tenant-2", company: "名谷病院" }, access)).toBe(false)
+  })
+
+  test("limits scoped members to their assigned tenant offices", () => {
+    const access = buildCompanyAccess([
+      {
+        id: "membership-1",
+        tenant_id: "tenant-1",
+        role: "member",
+        status: "active",
+        offices: [
+          { name: "名谷病院" },
+          { name: "スーパー・コート東大阪新石切" },
+        ],
+      },
+    ])
+
+    expect(canAccessPersonByCompany({ tenant_id: "tenant-1", company: "名谷病院" }, access)).toBe(true)
+    expect(canAccessPersonByCompany({ tenant_id: "tenant-1", company: "天王寺特別養護老人ホーム" }, access)).toBe(false)
+  })
+
+  test("extracts company names from settings objects and comma-separated strings", () => {
+    const access = buildCompanyAccess([
+      {
+        tenant_id: "tenant-1",
+        role: "guest",
+        status: "active",
+        settings: {
+          company_names: "名谷病院, 医療法人鴻池会 秋津鴻池病院",
+        },
+      },
+    ])
+
+    expect(canAccessPersonByCompany({ tenant_id: "tenant-1", company: "医療法人鴻池会 秋津鴻池病院" }, access)).toBe(true)
+    expect(canAccessPersonByCompany({ tenant_id: "tenant-1", company: "柏原マルタマフーズ株式会社" }, access)).toBe(false)
+  })
+
+  test("keeps unassigned members at full tenant scope", () => {
+    const access = buildCompanyAccess([
+      {
+        id: "membership-1",
+        tenant_id: "tenant-1",
+        role: "member",
+        status: "active",
+        offices: [],
+      },
+    ])
+
+    expect(canAccessPersonByCompany({ tenant_id: "tenant-1", company: "名谷病院" }, access)).toBe(true)
+    expect(canAccessPersonByCompany({ tenant_id: "tenant-1", company: "天王寺特別養護老人ホーム" }, access)).toBe(true)
+  })
+
+  test("denies access when the user has no active tenant membership", () => {
+    const access = buildCompanyAccess([])
+
+    expect(canAccessPersonByCompany({ tenant_id: "tenant-1", company: "名谷病院" }, access)).toBe(false)
+  })
+})

--- a/lib/supabase/people-access.ts
+++ b/lib/supabase/people-access.ts
@@ -1,0 +1,290 @@
+type TenantMembership = {
+  id?: string | null
+  tenant_id?: string | null
+  role?: string | null
+  status?: string | null
+  offices?: Array<{ name?: string | null }> | null
+  [key: string]: unknown
+}
+
+export type CompanyAccess = {
+  fullTenantIds: Set<string>
+  restrictedTenantCompanies: Map<string, Set<string>>
+  hasActiveMembership: boolean
+}
+
+const FULL_ACCESS_ROLES = new Set(["owner", "admin", "supporter"])
+
+const COMPANY_ACCESS_KEYS = [
+  "accessible_companies",
+  "accessible_company_names",
+  "allowed_companies",
+  "allowed_company_names",
+  "assigned_companies",
+  "assigned_company_names",
+  "permitted_companies",
+  "permitted_company_names",
+  "viewable_companies",
+  "viewable_company_names",
+  "visible_companies",
+  "visible_company_names",
+  "accessible_offices",
+  "accessible_office_names",
+  "allowed_offices",
+  "allowed_office_names",
+  "assigned_offices",
+  "assigned_office_names",
+  "permitted_offices",
+  "permitted_office_names",
+  "viewable_offices",
+  "viewable_office_names",
+  "visible_offices",
+  "visible_office_names",
+  "company_access_scope",
+  "office_access_scope",
+  "visible_company_scope",
+  "visible_office_scope",
+  "settings",
+] as const
+
+function normalizeCompanyName(value: unknown): string | null {
+  if (typeof value !== "string") return null
+  const normalized = value.trim()
+  return normalized.length > 0 ? normalized : null
+}
+
+function extractCompanyNames(value: unknown): string[] {
+  if (!value) return []
+
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    if (!trimmed || trimmed === "all") return []
+
+    if (trimmed.startsWith("[") || trimmed.startsWith("{")) {
+      try {
+        return extractCompanyNames(JSON.parse(trimmed))
+      } catch {
+        // Fall through to comma-separated parsing.
+      }
+    }
+
+    return trimmed
+      .split(",")
+      .map(normalizeCompanyName)
+      .filter((name): name is string => Boolean(name))
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => {
+      if (typeof item === "string") return extractCompanyNames(item)
+      if (item && typeof item === "object") {
+        const record = item as Record<string, unknown>
+        return extractCompanyNames(
+          record.name ??
+            record.company ??
+            record.companyName ??
+            record.company_name ??
+            record.office ??
+            record.officeName ??
+            record.office_name
+        )
+      }
+      return []
+    })
+  }
+
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>
+    return [
+      "companies",
+      "companyNames",
+      "company_names",
+      "offices",
+      "officeNames",
+      "office_names",
+      "accessibleCompanies",
+      "accessible_companies",
+      "allowedCompanies",
+      "allowed_companies",
+      "viewableCompanies",
+      "viewable_companies",
+      "viewableOffices",
+      "viewable_offices",
+      "visibleCompanies",
+      "visible_companies",
+      "visibleOffices",
+      "visible_offices",
+    ].flatMap((key) => extractCompanyNames(record[key]))
+  }
+
+  return []
+}
+
+function membershipHasAllCompanyAccess(membership: TenantMembership): boolean {
+  return COMPANY_ACCESS_KEYS.some((key) => {
+    const value = membership[key]
+    return value === "all" || value === "*" || (value && typeof value === "object" && (value as Record<string, unknown>).mode === "all")
+  })
+}
+
+export function buildCompanyAccess(memberships: TenantMembership[]): CompanyAccess {
+  const access: CompanyAccess = {
+    fullTenantIds: new Set(),
+    restrictedTenantCompanies: new Map(),
+    hasActiveMembership: false,
+  }
+
+  memberships
+    .filter((membership) => membership.status === "active" && membership.tenant_id)
+    .forEach((membership) => {
+      access.hasActiveMembership = true
+      const tenantId = membership.tenant_id as string
+
+      if (FULL_ACCESS_ROLES.has(membership.role ?? "") || membershipHasAllCompanyAccess(membership)) {
+        access.fullTenantIds.add(tenantId)
+        return
+      }
+
+      const officeNames = (membership.offices || [])
+        .map((office) => normalizeCompanyName(office.name))
+        .filter((name): name is string => Boolean(name))
+      const companyNames = [
+        ...officeNames,
+        ...COMPANY_ACCESS_KEYS.flatMap((key) => extractCompanyNames(membership[key])),
+      ]
+
+      if (companyNames.length === 0) {
+        access.fullTenantIds.add(tenantId)
+        return
+      }
+
+      const companies = access.restrictedTenantCompanies.get(tenantId) ?? new Set<string>()
+      companyNames.forEach((name) => companies.add(name))
+      access.restrictedTenantCompanies.set(tenantId, companies)
+    })
+
+  return access
+}
+
+export async function getCompanyAccessForUser(
+  supabase: any,
+  userId: string
+): Promise<CompanyAccess> {
+  const { data: memberships, error: membershipsError } = await supabase
+    .from("user_tenants")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("status", "active")
+
+  if (membershipsError) {
+    throw membershipsError
+  }
+
+  const membershipRecords = (memberships || []) as TenantMembership[]
+  const membershipIds = membershipRecords
+    .map((membership) => membership.id)
+    .filter((id): id is string => Boolean(id))
+
+  if (membershipIds.length === 0) {
+    return buildCompanyAccess(membershipRecords)
+  }
+
+  const { data: assignments, error: assignmentsError } = await supabase
+    .from("user_tenant_offices")
+    .select("user_tenant_id, tenant_office_id")
+    .in("user_tenant_id", membershipIds)
+
+  if (assignmentsError) {
+    throw assignmentsError
+  }
+
+  const assignmentRecords = (assignments || []) as Array<{
+    user_tenant_id: string
+    tenant_office_id: string
+  }>
+  const officeIds = Array.from(
+    new Set(assignmentRecords.map((assignment) => assignment.tenant_office_id))
+  )
+
+  const officesById = new Map<string, { name?: string | null }>()
+  if (officeIds.length > 0) {
+    const { data: offices, error: officesError } = await supabase
+      .from("tenant_offices")
+      .select("id, name")
+      .eq("is_active", true)
+      .in("id", officeIds)
+
+    if (officesError) {
+      throw officesError
+    }
+
+    for (const office of offices || []) {
+      officesById.set(office.id, office)
+    }
+  }
+
+  const officeNamesByMembershipId = new Map<string, Array<{ name?: string | null }>>()
+  for (const assignment of assignmentRecords) {
+    const office = officesById.get(assignment.tenant_office_id)
+    if (!office) continue
+
+    const current = officeNamesByMembershipId.get(assignment.user_tenant_id) || []
+    current.push(office)
+    officeNamesByMembershipId.set(assignment.user_tenant_id, current)
+  }
+
+  return buildCompanyAccess(
+    membershipRecords.map((membership) => ({
+      ...membership,
+      offices: membership.id
+        ? officeNamesByMembershipId.get(membership.id) || []
+        : [],
+    }))
+  )
+}
+
+export function canAccessPersonByCompany(person: { tenant_id?: string | null; company?: string | null }, access: CompanyAccess): boolean {
+  if (!access.hasActiveMembership) return false
+  if (!person.tenant_id) return false
+  if (access.fullTenantIds.has(person.tenant_id)) return true
+
+  const allowedCompanies = access.restrictedTenantCompanies.get(person.tenant_id)
+  if (!allowedCompanies || allowedCompanies.size === 0) return false
+
+  const company = normalizeCompanyName(person.company)
+  return Boolean(company && allowedCompanies.has(company))
+}
+
+function quotePostgrestValue(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+}
+
+function buildPeopleAccessOrFilter(access: CompanyAccess): string | null {
+  if (!access.hasActiveMembership) return null
+
+  const clauses: string[] = []
+  const fullTenantIds = Array.from(access.fullTenantIds)
+
+  if (fullTenantIds.length > 0) {
+    clauses.push(`tenant_id.in.(${fullTenantIds.join(",")})`)
+  }
+
+  access.restrictedTenantCompanies.forEach((companies, tenantId) => {
+    if (access.fullTenantIds.has(tenantId) || companies.size === 0) return
+
+    clauses.push(
+      `and(tenant_id.eq.${tenantId},company.in.(${Array.from(companies).map(quotePostgrestValue).join(",")}))`
+    )
+  })
+
+  return clauses.length > 0 ? clauses.join(",") : null
+}
+
+export function applyPeopleAccessFilter<TQuery extends { or: (filters: string) => TQuery }>(
+  query: TQuery,
+  access: CompanyAccess
+): TQuery | null {
+  const filter = buildPeopleAccessOrFilter(access)
+  if (!filter) return null
+  return query.or(filter)
+}

--- a/lib/supabase/people-server.ts
+++ b/lib/supabase/people-server.ts
@@ -1,16 +1,41 @@
 import { createClient } from './server'
 import type { Person } from '@/lib/models'
+import {
+  applyPeopleAccessFilter,
+  canAccessPersonByCompany,
+  getCompanyAccessForUser,
+} from './people-access'
 
 export async function getPersonById(id: string): Promise<Person | null> {
   const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return null
+  }
+
+  let companyAccess
+  try {
+    companyAccess = await getCompanyAccessForUser(supabase, user.id)
+  } catch (error) {
+    console.error("Error fetching current user company access:", error)
+    return null
+  }
 
   console.log('Fetching person with ID:', id)
 
-  const { data, error } = await supabase
-    .from('people')
-    .select('*')
-    .eq('id', id)
-    .single()
+  const query = applyPeopleAccessFilter(
+    supabase
+      .from('people')
+      .select('*')
+      .eq('id', id),
+    companyAccess
+  )
+
+  if (!query) {
+    return null
+  }
+
+  const { data, error } = await query.single()
 
   console.log('Query result:', { data, error })
 
@@ -21,6 +46,10 @@ export async function getPersonById(id: string): Promise<Person | null> {
 
   if (!data) {
     console.log('No person found with ID:', id)
+    return null
+  }
+
+  if (!canAccessPersonByCompany(data, companyAccess)) {
     return null
   }
 
@@ -76,5 +105,3 @@ export async function getPersonById(id: string): Promise<Person | null> {
     updatedAt: data.updated_at,
   }
 }
-
-

--- a/lib/supabase/people.ts
+++ b/lib/supabase/people.ts
@@ -1,16 +1,86 @@
 import { createClient } from './client'
 import type { Person } from '@/lib/models'
+import {
+  applyPeopleAccessFilter,
+  canAccessPersonByCompany,
+  getCompanyAccessForUser,
+  type CompanyAccess,
+} from './people-access'
+
+async function getCurrentUserCompanyAccess(): Promise<CompanyAccess> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return {
+      fullTenantIds: new Set(),
+      restrictedTenantCompanies: new Map(),
+      hasActiveMembership: false,
+    }
+  }
+
+  try {
+    return await getCompanyAccessForUser(supabase, user.id)
+  } catch (error) {
+    console.error("Error fetching current user company access:", error)
+    throw error
+  }
+}
+
+function mapPersonRow(person: any, tenantName?: string): Person {
+  return {
+    id: person.id,
+    name: person.name,
+    kana: person.kana,
+    nationality: person.nationality,
+    dob: person.dob,
+    specificSkillField: person.specific_skill_field,
+    phone: person.phone,
+    employeeNumber: person.employee_number,
+    workingStatus: person.working_status,
+    residenceCardNo: person.residence_card_no,
+    residenceCardExpiryDate: person.residence_card_expiry_date,
+    residenceCardIssuedDate: person.residence_card_issued_date,
+    email: person.email,
+    address: person.address,
+    tenantName,
+    company: person.company,
+    note: person.note,
+    visaId: person.visa_id,
+    externalId: person.external_id,
+    imagePath: person.image_path,
+    employmentNotificationDate: person.employment_notification_date,
+    employmentChangeNotificationDate: person.employment_change_notification_date,
+    interviewDate: person.interview_date,
+    jobOfferDate: person.job_offer_date,
+    applicationNumber: person.application_number,
+    departureProcedureStatus: person.departure_procedure_status,
+    entryConfirmedDate: person.entry_confirmed_date,
+    myNumber: person.my_number,
+    joiningDate: person.joining_date,
+    insuranceNumber: person.insurance_number,
+    insuranceAcquiredDate: person.insurance_acquired_date,
+    insuranceEnrollmentStatus: person.insurance_enrollment_status,
+    createdAt: person.created_at,
+    updatedAt: person.updated_at
+  }
+}
 
 export async function getPeople(): Promise<Person[]> {
   const supabase = createClient()
+  const companyAccess = await getCurrentUserCompanyAccess()
+  const query = applyPeopleAccessFilter(
+    supabase
+      .from('people')
+      .select(`
+        *,
+        tenant:tenant_id (id, name)
+      `),
+    companyAccess
+  )
 
-  const { data, error } = await supabase
-    .from('people')
-    .select(`
-      *,
-      tenant:tenant_id (id, name)
-    `)
-    .order('created_at', { ascending: false })
+  if (!query) return []
+
+  const { data, error } = await query.order('created_at', { ascending: false })
 
   if (error) {
     console.error('Error fetching people:', error)
@@ -19,54 +89,28 @@ export async function getPeople(): Promise<Person[]> {
 
   if (!data || data.length === 0) return []
 
-  return data.map((person: any) => ({
-      id: person.id,
-      name: person.name,
-      kana: person.kana,
-      nationality: person.nationality,
-      dob: person.dob,
-      specificSkillField: person.specific_skill_field,
-      phone: person.phone,
-      employeeNumber: person.employee_number,
-      workingStatus: person.working_status,
-      residenceCardNo: person.residence_card_no,
-      residenceCardExpiryDate: person.residence_card_expiry_date,
-      residenceCardIssuedDate: person.residence_card_issued_date,
-      email: person.email,
-      address: person.address,
-      tenantName: person.tenant?.name,
-      company: person.company,
-      note: person.note,
-      visaId: person.visa_id,
-      externalId: person.external_id,
-      imagePath: person.image_path,
-      employmentNotificationDate: person.employment_notification_date,
-      employmentChangeNotificationDate: person.employment_change_notification_date,
-      interviewDate: person.interview_date,
-      jobOfferDate: person.job_offer_date,
-      applicationNumber: person.application_number,
-      departureProcedureStatus: person.departure_procedure_status,
-      entryConfirmedDate: person.entry_confirmed_date,
-      myNumber: person.my_number,
-      joiningDate: person.joining_date,
-      insuranceNumber: person.insurance_number,
-      insuranceAcquiredDate: person.insurance_acquired_date,
-      insuranceEnrollmentStatus: person.insurance_enrollment_status,
-      createdAt: person.created_at,
-      updatedAt: person.updated_at
-  }))
+  return data
+    .filter((person: any) => canAccessPersonByCompany(person, companyAccess))
+    .map((person: any) => mapPersonRow(person, person.tenant?.name))
 }
 
 export async function getPersonById(id: string): Promise<Person | null> {
   const supabase = createClient()
+  const companyAccess = await getCurrentUserCompanyAccess()
   
   console.log('Fetching person with ID:', id)
+
+  const query = applyPeopleAccessFilter(
+    supabase
+      .from('people')
+      .select('*')
+      .eq('id', id),
+    companyAccess
+  )
+
+  if (!query) return null
   
-  const { data, error } = await supabase
-    .from('people')
-    .select('*')
-    .eq('id', id)
-    .single()
+  const { data, error } = await query.single()
   
   console.log('Query result:', { data, error })
   
@@ -77,6 +121,10 @@ export async function getPersonById(id: string): Promise<Person | null> {
   
   if (!data) {
     console.log('No person found with ID:', id)
+    return null
+  }
+
+  if (!canAccessPersonByCompany(data, companyAccess)) {
     return null
   }
   
@@ -95,42 +143,7 @@ export async function getPersonById(id: string): Promise<Person | null> {
     }
   }
   
-  return {
-    id: data.id,
-    name: data.name,
-    kana: data.kana,
-    nationality: data.nationality,
-    dob: data.dob,
-    specificSkillField: data.specific_skill_field,
-    phone: data.phone,
-    employeeNumber: data.employee_number,
-    workingStatus: data.working_status,
-    residenceCardNo: data.residence_card_no,
-    residenceCardExpiryDate: data.residence_card_expiry_date,
-    residenceCardIssuedDate: data.residence_card_issued_date,
-    email: data.email,
-    address: data.address,
-    tenantName: tenantName,
-    company: data.company,
-    note: data.note,
-    visaId: data.visa_id,
-    externalId: data.external_id,
-    imagePath: data.image_path,
-    employmentNotificationDate: data.employment_notification_date,
-    employmentChangeNotificationDate: data.employment_change_notification_date,
-    interviewDate: data.interview_date,
-    jobOfferDate: data.job_offer_date,
-    applicationNumber: data.application_number,
-    departureProcedureStatus: data.departure_procedure_status,
-    entryConfirmedDate: data.entry_confirmed_date,
-    myNumber: data.my_number,
-    joiningDate: data.joining_date,
-    insuranceNumber: data.insurance_number,
-    insuranceAcquiredDate: data.insurance_acquired_date,
-    insuranceEnrollmentStatus: data.insurance_enrollment_status,
-    createdAt: data.created_at,
-    updatedAt: data.updated_at
-  }
+  return mapPersonRow(data, tenantName)
 }
 
 export async function createPerson(person: Omit<Person, 'createdAt' | 'updatedAt'>): Promise<Person> {


### PR DESCRIPTION
## Summary
- Rebased this PR onto the latest `main`, including the tenant affiliation scope controls.
- Add shared people-visibility helpers that read active `user_tenants` plus `user_tenant_offices -> tenant_offices.name` assignments.
- Apply the access filter to people list/search data and both client/server person detail fetches.
- Treat members with no assigned offices as full-tenant scope, matching the tenant management UI copy.

## Why
所属先の見れる範囲を設定しても、人材一覧や詳細取得側でその範囲が適用されていなかったため、一覧・検索候補・URL直打ちの詳細表示で制御されるようにしました。

Latest `main` stores tenant-management affiliation scopes in `tenant_offices` and `user_tenant_offices`; this PR now uses that model and compares `tenant_offices.name` to `people.company` when filtering.

## Validation
- Passed: `pnpm vitest run lib/supabase/people-access.test.ts`
- Partial: `pnpm tsc --noEmit` still fails on existing invalid characters in `constants/meeting-taxonomy.ts`, outside this PR's changed files.
- Manual: dev server starts with `.env.local`; unauthenticated `/admin/tenants` redirects to login, so tenant-management UI inspection requires a logged-in session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite validating company access rules including role-based tenant visibility, office and company scoping, and company name parsing from various formats.

* **New Features**
  * People record queries now filtered based on user company access and tenant memberships, restricting visibility according to assigned companies and office locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->