### PR TITLE
住民票写しの書類項目を削除

### DIFF
--- a/__tests__/marutama-fields.test.ts
+++ b/__tests__/marutama-fields.test.ts
@@ -81,14 +81,14 @@ describe('Person型: マルタマ対応フィールド', () => {
   })
 })
 
-// --- DocumentType: 新規6タイプ ---
+// --- DocumentType: 書類タイプ ---
 
 describe('DocumentType: 新規書類タイプ', () => {
   const VALID_DOCUMENT_TYPES: DocumentType[] = [
     'passport_front', 'passport_back',
     'residence_card_front', 'residence_card_back',
     'coe_copy', 'flight_ticket_copy', 'bank_card_copy',
-    'resident_card_copy', 'resume', 'designation_document',
+    'resume', 'designation_document',
   ]
 
   it('既存の4タイプが含まれること', () => {
@@ -98,11 +98,10 @@ describe('DocumentType: 新規書類タイプ', () => {
     expect(VALID_DOCUMENT_TYPES).toContain('residence_card_back')
   })
 
-  it('入社前書類の4タイプが含まれること', () => {
+  it('入社前書類の3タイプが含まれること', () => {
     expect(VALID_DOCUMENT_TYPES).toContain('coe_copy')
     expect(VALID_DOCUMENT_TYPES).toContain('flight_ticket_copy')
     expect(VALID_DOCUMENT_TYPES).toContain('bank_card_copy')
-    expect(VALID_DOCUMENT_TYPES).toContain('resident_card_copy')
   })
 
   it('入社後書類の2タイプが含まれること', () => {
@@ -110,8 +109,12 @@ describe('DocumentType: 新規書類タイプ', () => {
     expect(VALID_DOCUMENT_TYPES).toContain('designation_document')
   })
 
-  it('合計10タイプであること', () => {
-    expect(VALID_DOCUMENT_TYPES).toHaveLength(10)
+  it('住民票写しは書類タイプに含まれないこと', () => {
+    expect(VALID_DOCUMENT_TYPES).not.toContain('resident_card_copy')
+  })
+
+  it('合計9タイプであること', () => {
+    expect(VALID_DOCUMENT_TYPES).toHaveLength(9)
   })
 })
 
@@ -314,7 +317,6 @@ describe('書類セクション: 入社前・入社後書類の構成', () => {
         { type: 'coe_copy', label: 'COE写し' },
         { type: 'flight_ticket_copy', label: 'フライト写し' },
         { type: 'bank_card_copy', label: '口座カード写し' },
-        { type: 'resident_card_copy', label: '住民票写し' },
       ],
     },
     {
@@ -330,12 +332,12 @@ describe('書類セクション: 入社前・入社後書類の構成', () => {
     expect(DOCUMENT_SECTIONS).toHaveLength(4)
   })
 
-  it('入社前書類セクションに4つの書類タイプがあること', () => {
+  it('入社前書類セクションに3つの書類タイプがあること', () => {
     const preEmployment = DOCUMENT_SECTIONS.find(s => s.title === '入社前書類')
     expect(preEmployment).toBeDefined()
-    expect(preEmployment!.types).toHaveLength(4)
+    expect(preEmployment!.types).toHaveLength(3)
     expect(preEmployment!.types.map(t => t.type)).toEqual([
-      'coe_copy', 'flight_ticket_copy', 'bank_card_copy', 'resident_card_copy',
+      'coe_copy', 'flight_ticket_copy', 'bank_card_copy',
     ])
   })
 
@@ -348,9 +350,15 @@ describe('書類セクション: 入社前・入社後書類の構成', () => {
     ])
   })
 
-  it('全書類タイプの合計が10であること', () => {
+  it('全書類タイプの合計が9であること', () => {
     const allTypes = DOCUMENT_SECTIONS.flatMap(s => s.types)
-    expect(allTypes).toHaveLength(10)
+    expect(allTypes).toHaveLength(9)
+  })
+
+  it('住民票写しがどのセクションにも表示されないこと', () => {
+    const allTypes = DOCUMENT_SECTIONS.flatMap(s => s.types)
+    expect(allTypes.map(t => t.type)).not.toContain('resident_card_copy')
+    expect(allTypes.map(t => t.label)).not.toContain('住民票写し')
   })
 
   it('すべての書類タイプにラベルが設定されていること', () => {

--- a/app/api/people/[id]/documents/route.ts
+++ b/app/api/people/[id]/documents/route.ts
@@ -3,7 +3,7 @@ import { revalidatePath } from 'next/cache'
 import { createClient } from '@/lib/supabase/server'
 import { uploadFileToStorage, generateFilePath, deleteFileFromStorage } from '@/lib/storage/file-uploader'
 
-const VALID_DOCUMENT_TYPES = ['passport_front', 'passport_back', 'residence_card_front', 'residence_card_back', 'coe_copy', 'flight_ticket_copy', 'bank_card_copy', 'resident_card_copy', 'resume', 'designation_document']
+const VALID_DOCUMENT_TYPES = ['passport_front', 'passport_back', 'residence_card_front', 'residence_card_back', 'coe_copy', 'flight_ticket_copy', 'bank_card_copy', 'resume', 'designation_document']
 const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
 const VALID_CONTENT_TYPES = ['image/png', 'image/jpeg', 'image/webp', 'image/heic', 'image/heif', 'application/pdf']
 const BUCKET_NAME = 'person-documents'
@@ -28,6 +28,7 @@ export async function GET(
       .from('person_documents')
       .select('*')
       .eq('person_id', personId)
+      .neq('document_type', 'resident_card_copy')
       .order('created_at', { ascending: true })
 
     if (error) {

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -13,6 +13,11 @@ const DOCUMENT_TYPE_LABELS: Record<DocumentType, string> = {
   passport_back: "パスポート（裏）",
   residence_card_front: "在留カード（表）",
   residence_card_back: "在留カード（裏）",
+  coe_copy: "COE写し",
+  flight_ticket_copy: "フライト写し",
+  bank_card_copy: "口座カード写し",
+  resume: "履歴書",
+  designation_document: "指定書写し",
 }
 
 function formatFileSize(bytes?: number): string {

--- a/components/person-documents-tab.tsx
+++ b/components/person-documents-tab.tsx
@@ -31,7 +31,6 @@ const DOCUMENT_SECTIONS: { title: string; types: { type: DocumentType; label: st
       { type: "coe_copy", label: "COE写し" },
       { type: "flight_ticket_copy", label: "フライト写し" },
       { type: "bank_card_copy", label: "口座カード写し" },
-      { type: "resident_card_copy", label: "住民票写し" },
     ],
   },
   {

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -155,7 +155,7 @@ export type AnnouncementRead = {
   readAt: string
 }
 
-export type DocumentType = 'passport_front' | 'passport_back' | 'residence_card_front' | 'residence_card_back' | 'coe_copy' | 'flight_ticket_copy' | 'bank_card_copy' | 'resident_card_copy' | 'resume' | 'designation_document'
+export type DocumentType = 'passport_front' | 'passport_back' | 'residence_card_front' | 'residence_card_back' | 'coe_copy' | 'flight_ticket_copy' | 'bank_card_copy' | 'resume' | 'designation_document'
 
 export type PersonDocument = {
   id: string

--- a/lib/supabase/person-documents-server.ts
+++ b/lib/supabase/person-documents-server.ts
@@ -7,6 +7,7 @@ export async function getPersonDocumentsByPersonId(personId: string): Promise<Pe
     .from('person_documents')
     .select('*')
     .eq('person_id', personId)
+    .neq('document_type', 'resident_card_copy')
     .order('created_at', { ascending: true })
 
   if (error) {

--- a/lib/supabase/person-documents.ts
+++ b/lib/supabase/person-documents.ts
@@ -1,12 +1,16 @@
 import { createClient } from './client'
 import type { PersonDocument } from '@/lib/models'
 
+const REMOVED_DOCUMENT_TYPE = 'resident_card_copy'
+const VALID_DOCUMENT_TYPES = ['passport_front', 'passport_back', 'residence_card_front', 'residence_card_back', 'coe_copy', 'flight_ticket_copy', 'bank_card_copy', 'resume', 'designation_document']
+
 export async function getPersonDocuments(personId: string): Promise<PersonDocument[]> {
   const supabase = createClient()
   const { data, error } = await supabase
     .from('person_documents')
     .select('*')
     .eq('person_id', personId)
+    .neq('document_type', REMOVED_DOCUMENT_TYPE)
     .order('created_at', { ascending: true })
 
   if (error) {
@@ -27,6 +31,7 @@ export async function getAllPersonDocuments(): Promise<PersonDocumentWithPerson[
   const { data, error } = await supabase
     .from('person_documents')
     .select('*, people(name, kana)')
+    .neq('document_type', REMOVED_DOCUMENT_TYPE)
     .order('created_at', { ascending: false })
 
   if (error) {
@@ -64,6 +69,10 @@ export async function uploadDocumentDirect(
   documentType: string,
   file: File
 ): Promise<{ success: boolean; error?: string }> {
+  if (!VALID_DOCUMENT_TYPES.includes(documentType)) {
+    return { success: false, error: '対応していない書類種別です' }
+  }
+
   if (file.size > MAX_FILE_SIZE) {
     return { success: false, error: 'ファイルサイズは10MB以下にしてください' }
   }


### PR DESCRIPTION
## 概要
- 個人詳細の書類タブから住民票写しの登録項目を削除
- DocumentType / 書類API / 直接アップロードの許可リストから resident_card_copy を削除
- 書類取得時に既存の resident_card_copy レコードを管理対象から除外
- 書類管理一覧のラベル定義を現行9種に整理

## 既存データ方針
- 既存の person_documents.document_type = 'resident_card_copy' レコードは削除しない
- 画面/API取得では除外し、新規登録・再登録は受け付けない
- 物理削除が必要になった場合は、事前に本番DBで対象件数・保管ファイルを確認してから別途対応する

## 検証
- pnpm vitest run __tests__/marutama-fields.test.ts: pass（31 tests）
- pnpm tsc --noEmit: fail（既存の constants/meeting-taxonomy.ts の未クォート日本語キーで TS1127）
- pnpm vitest run: fail（既存の node:test 形式テストが Vitest で suite 検出されない）

Refs: funtoco/fun-docs#872