### PR TITLE
雇用保険通知書の書類項目を追加

### DIFF
--- a/__tests__/marutama-fields.test.ts
+++ b/__tests__/marutama-fields.test.ts
@@ -88,7 +88,7 @@ describe('DocumentType: 新規書類タイプ', () => {
     'passport_front', 'passport_back',
     'residence_card_front', 'residence_card_back',
     'coe_copy', 'flight_ticket_copy', 'bank_card_copy',
-    'resume', 'designation_document',
+    'resume', 'designation_document', 'employment_insurance_notice',
   ]
 
   it('既存の4タイプが含まれること', () => {
@@ -104,17 +104,18 @@ describe('DocumentType: 新規書類タイプ', () => {
     expect(VALID_DOCUMENT_TYPES).toContain('bank_card_copy')
   })
 
-  it('入社後書類の2タイプが含まれること', () => {
+  it('入社後書類の3タイプが含まれること', () => {
     expect(VALID_DOCUMENT_TYPES).toContain('resume')
     expect(VALID_DOCUMENT_TYPES).toContain('designation_document')
+    expect(VALID_DOCUMENT_TYPES).toContain('employment_insurance_notice')
   })
 
   it('住民票写しは書類タイプに含まれないこと', () => {
     expect(VALID_DOCUMENT_TYPES).not.toContain('resident_card_copy')
   })
 
-  it('合計9タイプであること', () => {
-    expect(VALID_DOCUMENT_TYPES).toHaveLength(9)
+  it('合計10タイプであること', () => {
+    expect(VALID_DOCUMENT_TYPES).toHaveLength(10)
   })
 })
 
@@ -324,6 +325,7 @@ describe('書類セクション: 入社前・入社後書類の構成', () => {
       types: [
         { type: 'resume', label: '履歴書' },
         { type: 'designation_document', label: '指定書写し' },
+        { type: 'employment_insurance_notice', label: '雇用保険通知書' },
       ],
     },
   ]
@@ -341,18 +343,18 @@ describe('書類セクション: 入社前・入社後書類の構成', () => {
     ])
   })
 
-  it('入社後書類セクションに2つの書類タイプがあること', () => {
+  it('入社後書類セクションに3つの書類タイプがあること', () => {
     const postEmployment = DOCUMENT_SECTIONS.find(s => s.title === '入社後書類')
     expect(postEmployment).toBeDefined()
-    expect(postEmployment!.types).toHaveLength(2)
+    expect(postEmployment!.types).toHaveLength(3)
     expect(postEmployment!.types.map(t => t.type)).toEqual([
-      'resume', 'designation_document',
+      'resume', 'designation_document', 'employment_insurance_notice',
     ])
   })
 
-  it('全書類タイプの合計が9であること', () => {
+  it('全書類タイプの合計が10であること', () => {
     const allTypes = DOCUMENT_SECTIONS.flatMap(s => s.types)
-    expect(allTypes).toHaveLength(9)
+    expect(allTypes).toHaveLength(10)
   })
 
   it('住民票写しがどのセクションにも表示されないこと', () => {

--- a/app/api/people/[id]/documents/route.ts
+++ b/app/api/people/[id]/documents/route.ts
@@ -3,7 +3,18 @@ import { revalidatePath } from 'next/cache'
 import { createClient } from '@/lib/supabase/server'
 import { uploadFileToStorage, generateFilePath, deleteFileFromStorage } from '@/lib/storage/file-uploader'
 
-const VALID_DOCUMENT_TYPES = ['passport_front', 'passport_back', 'residence_card_front', 'residence_card_back', 'coe_copy', 'flight_ticket_copy', 'bank_card_copy', 'resume', 'designation_document']
+const VALID_DOCUMENT_TYPES = [
+  'passport_front',
+  'passport_back',
+  'residence_card_front',
+  'residence_card_back',
+  'coe_copy',
+  'flight_ticket_copy',
+  'bank_card_copy',
+  'resume',
+  'designation_document',
+  'employment_insurance_notice',
+]
 const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
 const VALID_CONTENT_TYPES = ['image/png', 'image/jpeg', 'image/webp', 'image/heic', 'image/heif', 'application/pdf']
 const BUCKET_NAME = 'person-documents'

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -18,6 +18,7 @@ const DOCUMENT_TYPE_LABELS: Record<DocumentType, string> = {
   bank_card_copy: "口座カード写し",
   resume: "履歴書",
   designation_document: "指定書写し",
+  employment_insurance_notice: "雇用保険通知書",
 }
 
 function formatFileSize(bytes?: number): string {

--- a/components/person-documents-tab.tsx
+++ b/components/person-documents-tab.tsx
@@ -38,6 +38,7 @@ const DOCUMENT_SECTIONS: { title: string; types: { type: DocumentType; label: st
     types: [
       { type: "resume", label: "履歴書" },
       { type: "designation_document", label: "指定書写し" },
+      { type: "employment_insurance_notice", label: "雇用保険通知書" },
     ],
   },
 ]

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -155,7 +155,17 @@ export type AnnouncementRead = {
   readAt: string
 }
 
-export type DocumentType = 'passport_front' | 'passport_back' | 'residence_card_front' | 'residence_card_back' | 'coe_copy' | 'flight_ticket_copy' | 'bank_card_copy' | 'resume' | 'designation_document'
+export type DocumentType =
+  | 'passport_front'
+  | 'passport_back'
+  | 'residence_card_front'
+  | 'residence_card_back'
+  | 'coe_copy'
+  | 'flight_ticket_copy'
+  | 'bank_card_copy'
+  | 'resume'
+  | 'designation_document'
+  | 'employment_insurance_notice'
 
 export type PersonDocument = {
   id: string


### PR DESCRIPTION
## 概要
- 書類タイプに雇用保険通知書を追加
- 人材詳細の書類タブの入社後書類に雇用保険通知書を追加
- 書類アップロードAPIの許可リストと書類管理一覧の表示ラベルを更新

## DB確認
- person_documents.document_type は text 型で enum/check 制約なし
- DBマイグレーション不要

## 検証
- npm run test -- __tests__/marutama-fields.test.ts
- git diff --check

## 補足
- npm run typecheck は既存の connector / tenant-management まわりなどの型エラーで失敗
- npm run test 全体は既存の node:test 形式ファイルを Vitest が No test suite found と扱う問題で失敗

Closes funtoco/fun-docs#871