### PR TITLE
書類保管まわりでメモを残せるようにする

### DIFF
--- a/__tests__/document-notes.test.ts
+++ b/__tests__/document-notes.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { normalizeDocumentNote, resolveReplacementDocumentNote } from "@/lib/document-notes"
+
+describe("document note helpers", () => {
+  it("trims text notes and stores blank notes as null", () => {
+    expect(normalizeDocumentNote("  確認済み  ")).toBe("確認済み")
+    expect(normalizeDocumentNote("   ")).toBeNull()
+    expect(normalizeDocumentNote(null)).toBeNull()
+  })
+
+  it("preserves existing notes when replacement upload omits a note", () => {
+    expect(resolveReplacementDocumentNote(undefined, "既存メモ")).toBe("既存メモ")
+    expect(resolveReplacementDocumentNote(undefined, null)).toBeNull()
+  })
+
+  it("allows replacement upload to update or clear the note", () => {
+    expect(resolveReplacementDocumentNote(" 新しいメモ ", "既存メモ")).toBe("新しいメモ")
+    expect(resolveReplacementDocumentNote("", "既存メモ")).toBeNull()
+  })
+})

--- a/app/api/people/[id]/documents/[documentId]/route.ts
+++ b/app/api/people/[id]/documents/[documentId]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { revalidatePath } from 'next/cache'
 import { createClient } from '@/lib/supabase/server'
 import { deleteFileFromStorage } from '@/lib/storage/file-uploader'
+import { normalizeDocumentNote } from '@/lib/document-notes'
 
 const BUCKET_NAME = 'person-documents'
 
@@ -20,11 +21,12 @@ export async function PATCH(
     }
 
     const body = await request.json()
-    const title = typeof body.title === 'string' ? body.title.trim() : ''
+    const hasTitle = Object.prototype.hasOwnProperty.call(body, 'title')
+    const hasNote = Object.prototype.hasOwnProperty.call(body, 'note')
 
-    if (!title) {
+    if (!hasTitle && !hasNote) {
       return NextResponse.json(
-        { error: 'Title is required' },
+        { error: 'title or note is required' },
         { status: 400 }
       )
     }
@@ -45,16 +47,37 @@ export async function PATCH(
       )
     }
 
-    if (document.document_type !== 'other') {
-      return NextResponse.json(
-        { error: 'Only other documents can be renamed' },
-        { status: 400 }
-      )
+    const updates: Record<string, string | null> = {
+      updated_at: new Date().toISOString(),
+    }
+
+    if (hasTitle) {
+      const title = typeof body.title === 'string' ? body.title.trim() : ''
+
+      if (!title) {
+        return NextResponse.json(
+          { error: 'Title is required' },
+          { status: 400 }
+        )
+      }
+
+      if (document.document_type !== 'other') {
+        return NextResponse.json(
+          { error: 'Only other documents can be renamed' },
+          { status: 400 }
+        )
+      }
+
+      updates.title = title
+    }
+
+    if (hasNote) {
+      updates.note = normalizeDocumentNote(body.note)
     }
 
     const { data, error: updateError } = await supabase
       .from('person_documents')
-      .update({ title, updated_at: new Date().toISOString() })
+      .update(updates)
       .eq('id', documentId)
       .eq('person_id', personId)
       .select()
@@ -69,6 +92,7 @@ export async function PATCH(
     }
 
     revalidatePath(`/people/${personId}`)
+    revalidatePath('/documents')
 
     return NextResponse.json({
       id: data.id,
@@ -81,6 +105,7 @@ export async function PATCH(
       contentType: data.content_type,
       fileSizeBytes: data.file_size_bytes,
       uploadedBy: data.uploaded_by,
+      note: data.note,
       createdAt: data.created_at,
       updatedAt: data.updated_at,
     })

--- a/app/api/people/[id]/documents/route.ts
+++ b/app/api/people/[id]/documents/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { revalidatePath } from 'next/cache'
 import { createClient } from '@/lib/supabase/server'
 import { uploadFileToStorage, generateFilePath, deleteFileFromStorage } from '@/lib/storage/file-uploader'
+import { normalizeDocumentNote, resolveReplacementDocumentNote } from '@/lib/document-notes'
 
 const VALID_DOCUMENT_TYPES = [
   'passport_front',
@@ -62,6 +63,7 @@ export async function GET(
       contentType: row.content_type,
       fileSizeBytes: row.file_size_bytes,
       uploadedBy: row.uploaded_by,
+      note: row.note,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     }))
@@ -95,6 +97,7 @@ export async function POST(
     const documentType = formData.get('documentType') as string | null
     const replaceDocumentId = formData.get('replaceDocumentId') as string | null
     const title = formData.get('title') as string | null
+    const note = formData.has('note') ? normalizeDocumentNote(formData.get('note')) : undefined
 
     // Validate file
     if (!file) {
@@ -155,7 +158,7 @@ export async function POST(
 
     const tenantId = person.tenant_id
     const allowMultiple = documentType === 'other'
-    let documentToReplace: { id: string; storage_path: string; title?: string | null } | null = null
+    let documentToReplace: { id: string; storage_path: string; title?: string | null; note?: string | null } | null = null
 
     if (allowMultiple && !replaceDocumentId && !title?.trim()) {
       return NextResponse.json(
@@ -167,7 +170,7 @@ export async function POST(
     if (replaceDocumentId) {
       const { data: replaceDoc, error: replaceDocError } = await supabase
         .from('person_documents')
-        .select('id, storage_path, title')
+        .select('id, storage_path, title, note')
         .eq('id', replaceDocumentId)
         .eq('person_id', personId)
         .eq('document_type', documentType)
@@ -185,7 +188,7 @@ export async function POST(
       // Preserve the existing one-document-per-type behavior for fixed document types.
       const { data: existingDoc } = await supabase
         .from('person_documents')
-        .select('id, storage_path, title')
+        .select('id, storage_path, title, note')
         .eq('person_id', personId)
         .eq('document_type', documentType)
         .maybeSingle()
@@ -241,6 +244,7 @@ export async function POST(
         content_type: contentType,
         file_size_bytes: file.size,
         uploaded_by: user.id,
+        note: resolveReplacementDocumentNote(note, documentToReplace?.note),
       })
       .select()
       .single()

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -134,6 +134,16 @@ export default function DocumentsPage() {
       ),
     },
     {
+      key: "note",
+      label: "メモ",
+      sortable: true,
+      render: (value) => (
+        <span className="line-clamp-2 max-w-[260px] text-sm text-muted-foreground">
+          {value || "-"}
+        </span>
+      ),
+    },
+    {
       key: "contentType",
       label: "形式",
       sortable: true,
@@ -208,7 +218,7 @@ export default function DocumentsPage() {
         data={documentsWithLabel}
         columns={columns}
         filters={filters}
-        searchKeys={["personName", "title", "fileName", "documentTypeLabel"]}
+        searchKeys={["personName", "title", "fileName", "documentTypeLabel", "note"]}
         onRowClick={handleRowClick}
         initialSearchTerm={searchParams.get("search") || ""}
         initialActiveFilters={getFiltersFromUrl()}

--- a/components/person-documents-tab.tsx
+++ b/components/person-documents-tab.tsx
@@ -73,6 +73,7 @@ export function PersonDocumentsTab({ personId, personDocuments: initialDocuments
       title: doc.title,
       fileName: doc.fileName,
       contentType: doc.contentType,
+      note: doc.note,
     }
   }
 
@@ -85,6 +86,7 @@ export function PersonDocumentsTab({ personId, personDocuments: initialDocuments
         title: doc.title,
         fileName: doc.fileName,
         contentType: doc.contentType,
+        note: doc.note,
       }))
   )
 

--- a/components/ui/document-upload-card.tsx
+++ b/components/ui/document-upload-card.tsx
@@ -4,8 +4,10 @@ import { useState, useEffect, useMemo, useRef, type ChangeEvent, type FormEvent 
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
-import { Upload, Trash2, RefreshCw, Loader2, Pencil } from "lucide-react"
+import { Upload, Trash2, RefreshCw, Loader2, Pencil, Save } from "lucide-react"
 import { getDocumentSignedUrl, uploadDocumentDirect } from "@/lib/supabase/person-documents"
 
 type ExistingDocument = {
@@ -14,6 +16,7 @@ type ExistingDocument = {
   title?: string
   fileName?: string
   contentType?: string
+  note?: string
 }
 
 interface DocumentUploadCardProps {
@@ -41,20 +44,27 @@ export function DocumentUploadCard({
   const [deletingId, setDeletingId] = useState<string | null>(null)
   const [editingTitleId, setEditingTitleId] = useState<string | null>(null)
   const [savingTitleId, setSavingTitleId] = useState<string | null>(null)
+  const [savingNoteId, setSavingNoteId] = useState<string | null>(null)
   const [titleDraft, setTitleDraft] = useState("")
   const [titleDialogOpen, setTitleDialogOpen] = useState(false)
   const [newDocumentTitle, setNewDocumentTitle] = useState("")
+  const [newDocumentNote, setNewDocumentNote] = useState("")
   const [signedUrls, setSignedUrls] = useState<Record<string, string>>({})
+  const [noteDrafts, setNoteDrafts] = useState<Record<string, string>>({})
+  const [savedNotes, setSavedNotes] = useState<Record<string, string>>({})
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [noteMessageId, setNoteMessageId] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const replaceDocumentIdRef = useRef<string | null>(null)
   const uploadTitleRef = useRef<string | null>(null)
+  const uploadNoteRef = useRef<string | null>(null)
 
   const documents = useMemo(
     () => existingDocuments ?? (existingDocument ? [existingDocument] : []),
     [existingDocument, existingDocuments]
   )
   const hasDocuments = documents.length > 0
+  const newDocumentNoteInputId = `document-note-new-${personId}-${documentType}`
 
   useEffect(() => {
     if (documents.length === 0) {
@@ -82,6 +92,16 @@ export function DocumentUploadCard({
     return () => { active = false }
   }, [documents])
 
+  useEffect(() => {
+    const nextNotes = documents.reduce<Record<string, string>>((acc, document) => {
+      acc[document.id] = document.note || ""
+      return acc
+    }, {})
+    setNoteDrafts(nextNotes)
+    setSavedNotes(nextNotes)
+    setNoteMessageId(null)
+  }, [documents])
+
   const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (!file) return
@@ -97,8 +117,10 @@ export function DocumentUploadCard({
       const result = await uploadDocumentDirect(personId, documentType, file, {
         replaceDocumentId: replaceDocumentIdRef.current,
         title: uploadTitleRef.current,
+        note: uploadNoteRef.current ?? undefined,
       })
       if (!result.success) throw new Error(result.error || 'Upload failed')
+      setNewDocumentNote("")
       onUploadComplete?.()
     } catch (error) {
       console.error("Upload error:", error)
@@ -107,6 +129,7 @@ export function DocumentUploadCard({
       setUploading(false)
       replaceDocumentIdRef.current = null
       uploadTitleRef.current = null
+      uploadNoteRef.current = null
       if (fileInputRef.current) fileInputRef.current.value = ""
     }
   }
@@ -158,25 +181,56 @@ export function DocumentUploadCard({
     }
   }
 
+  const handleSaveNote = async (documentId: string) => {
+    const note = noteDrafts[documentId] || ""
+
+    setSavingNoteId(documentId)
+    setErrorMessage(null)
+    setNoteMessageId(null)
+    try {
+      const res = await fetch(`/api/people/${personId}/documents/${documentId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ note }),
+      })
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        throw new Error(data?.error || `Save note failed: ${res.statusText}`)
+      }
+
+      setSavedNotes((current) => ({ ...current, [documentId]: note.trim() }))
+      setNoteMessageId(documentId)
+      onUploadComplete?.()
+    } catch (error) {
+      console.error("Save note error:", error)
+      setErrorMessage(error instanceof Error ? error.message : "メモの保存に失敗しました")
+    } finally {
+      setSavingNoteId(null)
+    }
+  }
+
   const startEditingTitle = (document: ExistingDocument, fallbackTitle: string) => {
     setEditingTitleId(document.id)
     setTitleDraft(document.title || fallbackTitle)
     setErrorMessage(null)
   }
 
-  const triggerFileInput = (replaceDocumentId?: string, title?: string | null) => {
+  const triggerFileInput = (replaceDocumentId?: string, title?: string | null, note?: string | null) => {
     replaceDocumentIdRef.current = replaceDocumentId ?? null
     uploadTitleRef.current = title?.trim() || null
+    uploadNoteRef.current = note ?? null
     fileInputRef.current?.click()
   }
 
   const handleStartAdd = () => {
     if (!allowMultiple) {
-      triggerFileInput()
+      triggerFileInput(undefined, undefined, newDocumentNote)
       return
     }
 
     setNewDocumentTitle("")
+    setNewDocumentNote("")
     setErrorMessage(null)
     setTitleDialogOpen(true)
   }
@@ -191,7 +245,7 @@ export function DocumentUploadCard({
     }
 
     setTitleDialogOpen(false)
-    triggerFileInput(undefined, title)
+    triggerFileInput(undefined, title, newDocumentNote)
   }
 
   const renderEmptyUploadButton = () => (
@@ -237,6 +291,9 @@ export function DocumentUploadCard({
               const isPdf = document.contentType === 'application/pdf'
               const fallbackTitle = allowMultiple ? `${label} ${index + 1}` : label
               const title = document.title || fallbackTitle
+              const noteInputId = `document-note-${personId}-${document.id}`
+              const noteDraft = noteDrafts[document.id] || ""
+              const savedNote = savedNotes[document.id] || ""
 
               return (
                 <div key={document.id} className="space-y-2 rounded-md border border-border p-2">
@@ -325,6 +382,23 @@ export function DocumentUploadCard({
                     )}
                   </div>
 
+                  <div className="space-y-2">
+                    <Label htmlFor={noteInputId} className="text-xs">
+                      メモ
+                    </Label>
+                    <Textarea
+                      id={noteInputId}
+                      value={noteDraft}
+                      onChange={(event) => {
+                        setNoteDrafts((current) => ({ ...current, [document.id]: event.target.value }))
+                        setNoteMessageId(null)
+                      }}
+                      placeholder="確認事項や対応メモを入力"
+                      className="min-h-20 resize-none text-xs"
+                      disabled={savingNoteId === document.id}
+                    />
+                  </div>
+
                   <div className="flex gap-1">
                     <Button
                       type="button"
@@ -340,6 +414,20 @@ export function DocumentUploadCard({
                       type="button"
                       variant="outline"
                       size="sm"
+                      onClick={() => handleSaveNote(document.id)}
+                      disabled={savingNoteId === document.id || noteDraft.trim() === savedNote.trim()}
+                    >
+                      {savingNoteId === document.id ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : (
+                        <Save className="h-3 w-3" />
+                      )}
+                      保存
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
                       onClick={() => handleDelete(document.id)}
                       disabled={deletingId === document.id}
                     >
@@ -350,6 +438,10 @@ export function DocumentUploadCard({
                       )}
                     </Button>
                   </div>
+
+                  {noteMessageId === document.id && (
+                    <p className="text-xs text-muted-foreground">メモを保存しました</p>
+                  )}
                 </div>
               )
             })}
@@ -362,6 +454,21 @@ export function DocumentUploadCard({
           )}
           {renderEmptyUploadButton()}
         </>
+      )}
+
+      {!hasDocuments && !allowMultiple && !uploading && (
+        <div className="space-y-2">
+          <Label htmlFor={newDocumentNoteInputId} className="text-xs">
+            登録時メモ（任意）
+          </Label>
+          <Textarea
+            id={newDocumentNoteInputId}
+            value={newDocumentNote}
+            onChange={(event) => setNewDocumentNote(event.target.value)}
+            placeholder="アップロード時に一緒に残すメモ"
+            className="min-h-20 resize-none text-xs"
+          />
+        </div>
       )}
 
       {errorMessage && (
@@ -384,6 +491,18 @@ export function DocumentUploadCard({
                 onChange={(event) => setNewDocumentTitle(event.target.value)}
                 placeholder="例: 健康診断書"
                 autoFocus
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="other-document-note" className="text-sm font-medium">
+                メモ（任意）
+              </Label>
+              <Textarea
+                id="other-document-note"
+                value={newDocumentNote}
+                onChange={(event) => setNewDocumentNote(event.target.value)}
+                placeholder="アップロード時に一緒に残すメモ"
+                className="min-h-20 resize-none text-sm"
               />
             </div>
             <DialogFooter>

--- a/lib/document-notes.ts
+++ b/lib/document-notes.ts
@@ -1,0 +1,17 @@
+export function normalizeDocumentNote(note: unknown): string | null {
+  if (typeof note !== "string") return null
+
+  const trimmed = note.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+export function resolveReplacementDocumentNote(
+  nextNote: string | null | undefined,
+  existingNote?: string | null,
+): string | null {
+  if (nextNote === undefined) {
+    return existingNote || null
+  }
+
+  return normalizeDocumentNote(nextNote)
+}

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -179,6 +179,7 @@ export type PersonDocument = {
   contentType?: string
   fileSizeBytes?: number
   uploadedBy?: string
+  note?: string
   createdAt: string
   updatedAt: string
 }

--- a/lib/supabase/person-documents-server.ts
+++ b/lib/supabase/person-documents-server.ts
@@ -26,6 +26,7 @@ export async function getPersonDocumentsByPersonId(personId: string): Promise<Pe
     contentType: row.content_type,
     fileSizeBytes: row.file_size_bytes,
     uploadedBy: row.uploaded_by,
+    note: row.note,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }))

--- a/lib/supabase/person-documents.ts
+++ b/lib/supabase/person-documents.ts
@@ -1,8 +1,21 @@
 import { createClient } from './client'
 import type { PersonDocument } from '@/lib/models'
+import { resolveReplacementDocumentNote } from '@/lib/document-notes'
 
 const REMOVED_DOCUMENT_TYPE = 'resident_card_copy'
-const VALID_DOCUMENT_TYPES = ['passport_front', 'passport_back', 'residence_card_front', 'residence_card_back', 'coe_copy', 'flight_ticket_copy', 'bank_card_copy', 'resume', 'designation_document']
+const VALID_DOCUMENT_TYPES = [
+  'passport_front',
+  'passport_back',
+  'residence_card_front',
+  'residence_card_back',
+  'coe_copy',
+  'flight_ticket_copy',
+  'bank_card_copy',
+  'resume',
+  'designation_document',
+  'employment_insurance_notice',
+  'other',
+]
 
 export async function getPersonDocuments(personId: string): Promise<PersonDocument[]> {
   const supabase = createClient()
@@ -68,7 +81,7 @@ export async function uploadDocumentDirect(
   personId: string,
   documentType: string,
   file: File,
-  options: { replaceDocumentId?: string | null; title?: string | null } = {}
+  options: { replaceDocumentId?: string | null; title?: string | null; note?: string | null } = {}
 ): Promise<{ success: boolean; error?: string }> {
   if (!VALID_DOCUMENT_TYPES.includes(documentType)) {
     return { success: false, error: '対応していない書類種別です' }
@@ -99,12 +112,12 @@ export async function uploadDocumentDirect(
   const timestamp = Date.now()
   const filePath = `${tenantId}/${documentType}/${documentType}_${personId}_${timestamp}.${extension}`
   const allowMultiple = documentType === 'other'
-  let documentToReplace: { id: string; storage_path: string; title?: string | null } | null = null
+  let documentToReplace: { id: string; storage_path: string; title?: string | null; note?: string | null } | null = null
 
   if (options.replaceDocumentId) {
     const { data: replaceDoc, error: replaceDocError } = await supabase
       .from('person_documents')
-      .select('id, storage_path, title')
+      .select('id, storage_path, title, note')
       .eq('id', options.replaceDocumentId)
       .eq('person_id', personId)
       .eq('document_type', documentType)
@@ -119,7 +132,7 @@ export async function uploadDocumentDirect(
     // Preserve the existing one-document-per-type behavior for fixed document types.
     const { data: existingDoc } = await supabase
       .from('person_documents')
-      .select('id, storage_path, title')
+      .select('id, storage_path, title, note')
       .eq('person_id', personId)
       .eq('document_type', documentType)
       .maybeSingle()
@@ -163,6 +176,7 @@ export async function uploadDocumentDirect(
       content_type: file.type,
       file_size_bytes: file.size,
       uploaded_by: user?.id || null,
+      note: resolveReplacementDocumentNote(options.note ?? undefined, documentToReplace?.note),
     })
 
   if (insertError) {
@@ -192,6 +206,7 @@ function mapToPersonDocument(data: any): PersonDocument {
     contentType: data.content_type,
     fileSizeBytes: data.file_size_bytes,
     uploadedBy: data.uploaded_by,
+    note: data.note,
     createdAt: data.created_at,
     updatedAt: data.updated_at,
   }


### PR DESCRIPTION
## 概要
- 書類アップロード時に任意メモを保存できるようにしました
- アップロード済み書類カードで保存済みメモを確認・編集できるようにしました
- 書類管理一覧にメモ列を追加し、検索対象にも含めました
- 再アップロード時にメモ未指定なら既存メモを保持するようにしました

## DB migration
- migration追加PR: funtoco/fun-base-infra#59（merge済み）
- migration順序修正PR: funtoco/fun-base-infra#60
- このPRは #60 の修正commitを指すsubmodule pointerを含みます

## 関連Issue
- funtoco/fun-docs#874

## 確認
- pnpm install --frozen-lockfile
- npx vitest run __tests__/document-notes.test.ts ✅
- npm run typecheck ⚠️ 既存の constants/meeting-taxonomy.ts の invalid character で失敗
- npm test ⚠️ 既存の node:test 形式ファイルが Vitest 上で No test suite found となり失敗。ただし実行されたテストは通過