### PR TITLE
Restrict connector and access log pages to funtoco.jp users

### DIFF
--- a/app/admin/access-logs/page.tsx
+++ b/app/admin/access-logs/page.tsx
@@ -85,6 +85,15 @@ export default function AccessLogsPage() {
   const [eventType, setEventType] = useState<string>("all")
   const [emailFilter, setEmailFilter] = useState("")
 
+  const isFuntocoUser = user?.email?.endsWith("@funtoco.jp") ?? false
+
+  useEffect(() => {
+    if (authLoading) return
+    if (!isFuntocoUser) {
+      router.replace("/people")
+    }
+  }, [authLoading, isFuntocoUser])
+
   const fetchLogs = useCallback(async () => {
     setLoading(true)
     setError(null)
@@ -114,8 +123,8 @@ export default function AccessLogsPage() {
   }, [page, eventType, emailFilter])
 
   useEffect(() => {
-    if (!authLoading && user) fetchLogs()
-  }, [authLoading, user, fetchLogs])
+    if (!authLoading && user && isFuntocoUser) fetchLogs()
+  }, [authLoading, user, isFuntocoUser, fetchLogs])
 
   // reset to page 0 when filters change
   useEffect(() => { setPage(0) }, [eventType, emailFilter])

--- a/app/admin/connectors/layout.tsx
+++ b/app/admin/connectors/layout.tsx
@@ -1,7 +1,17 @@
-export default function AdminConnectorsLayout({
+import { redirect } from "next/navigation"
+import { createClient } from "@/lib/supabase/server"
+
+export default async function AdminConnectorsLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+
+  if (!user?.email?.endsWith("@funtoco.jp")) {
+    redirect("/people")
+  }
+
   return <>{children}</>
 }

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -574,21 +574,23 @@ export function Header() {
                 <Users className="mr-2 h-4 w-4" />
                 テナント管理
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => navigate('/admin/connectors/dashboard')}>
-                <Cable className="mr-2 h-4 w-4" />
-                コネクター管理
-              </DropdownMenuItem>
               {user?.email?.endsWith("@funtoco.jp") && (
-                <DropdownMenuItem onClick={() => navigate('/admin/announcements')}>
-                  <Megaphone className="mr-2 h-4 w-4" />
-                  お知らせ管理
-                </DropdownMenuItem>
+                <>
+                  <DropdownMenuItem onClick={() => navigate('/admin/connectors/dashboard')}>
+                    <Cable className="mr-2 h-4 w-4" />
+                    コネクター管理
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => navigate('/admin/announcements')}>
+                    <Megaphone className="mr-2 h-4 w-4" />
+                    お知らせ管理
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={() => navigate('/admin/access-logs')}>
+                    <ShieldCheck className="mr-2 h-4 w-4" />
+                    アクセスログ
+                  </DropdownMenuItem>
+                </>
               )}
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => navigate('/admin/access-logs')}>
-                <ShieldCheck className="mr-2 h-4 w-4" />
-                アクセスログ
-              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         )}


### PR DESCRIPTION
## Summary

- コネクター管理（`/admin/connectors/*`）を `@funtoco.jp` ドメインのユーザーのみに制限
- アクセスログ（`/admin/access-logs`）を `@funtoco.jp` ドメインのユーザーのみに制限
- 対象外ユーザーは `/people` にリダイレクト

## 変更内容

- `app/admin/connectors/layout.tsx` — server component でガード追加。配下の全ページ（dashboard、mappings、`[id]` など）を一括保護
- `app/admin/access-logs/page.tsx` — お知らせ管理と同じパターンで `isFuntocoUser` チェック追加

## Test plan

- [ ] `@funtoco.jp` アカウントでコネクター管理・アクセスログにアクセスできる
- [ ] 取引先アカウントでアクセスすると `/people` にリダイレクトされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enforced domain-based access for admin areas; unauthorized users are redirected away from restricted pages.
  * Access logs are now available only to users matching the allowed domain and are loaded only for those users.

* **UI**
  * Admin menu updated: the access-log entry is now shown only to users with the allowed domain, streamlining visible admin options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->