### PR TITLE
[codex] Schedule interview records sync safely

### DIFF
--- a/.github/workflows/cron-sync.yml
+++ b/.github/workflows/cron-sync.yml
@@ -112,25 +112,40 @@ jobs:
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          BATCH_SIZE: ${{ github.event.inputs.batch_size }}
+          RECORD_ID_FROM: ${{ github.event.inputs.record_id_from }}
+          RECORD_ID_TO: ${{ github.event.inputs.record_id_to }}
+          RECORD_ID_TAIL_SIZE: ${{ github.event.inputs.record_id_tail_size }}
         run: |
           echo "🕐 Starting interview_records sync at $(date)"
           cmd=(pnpm dlx tsx@4.20.3 scripts/sync-by-type.ts --type interview_records)
-          if [ "${{ github.event_name }}" = "schedule" ]; then
+
+          add_numeric_arg() {
+            local input_name="$1"
+            local input_value="$2"
+            local arg_name="$3"
+
+            if [ -z "$input_value" ]; then
+              return 0
+            fi
+
+            if [[ ! "$input_value" =~ ^[0-9]+$ ]]; then
+              echo "::error title=Invalid workflow input::${input_name} must be digits only"
+              exit 1
+            fi
+
+            cmd+=("$arg_name" "$input_value")
+          }
+
+          if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
             # 04:00 JST daily: small newest-record window, one connector at a time.
             cmd+=(--all-batches --limit 1 --record-id-tail-size 2000)
           else
             cmd+=(--all-batches)
-            if [ -n "${{ github.event.inputs.batch_size }}" ]; then
-              cmd+=(--limit "${{ github.event.inputs.batch_size }}")
-            fi
-            if [ -n "${{ github.event.inputs.record_id_from }}" ]; then
-              cmd+=(--record-id-from "${{ github.event.inputs.record_id_from }}")
-            fi
-            if [ -n "${{ github.event.inputs.record_id_to }}" ]; then
-              cmd+=(--record-id-to "${{ github.event.inputs.record_id_to }}")
-            fi
-            if [ -n "${{ github.event.inputs.record_id_tail_size }}" ]; then
-              cmd+=(--record-id-tail-size "${{ github.event.inputs.record_id_tail_size }}")
-            fi
+            add_numeric_arg "batch_size" "${BATCH_SIZE:-}" "--limit"
+            add_numeric_arg "record_id_from" "${RECORD_ID_FROM:-}" "--record-id-from"
+            add_numeric_arg "record_id_to" "${RECORD_ID_TO:-}" "--record-id-to"
+            add_numeric_arg "record_id_tail_size" "${RECORD_ID_TAIL_SIZE:-}" "--record-id-tail-size"
           fi
           "${cmd[@]}"

--- a/.github/workflows/cron-sync.yml
+++ b/.github/workflows/cron-sync.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 2 * * *'
     - cron: '0 3 * * *'
+    - cron: '0 19 * * *'
   workflow_dispatch:
     inputs:
       sync_type:
@@ -20,6 +21,15 @@ on:
         description: 'Connector batch size for interview_records manual sync'
         required: false
         default: '10'
+      record_id_from:
+        description: 'Optional Kintone record ID range start for interview_records'
+        required: false
+      record_id_to:
+        description: 'Optional Kintone record ID range end for interview_records'
+        required: false
+      record_id_tail_size:
+        description: 'Optional newest Kintone record ID window size for interview_records'
+        required: false
 
 jobs:
   sync-people:
@@ -79,7 +89,7 @@ jobs:
           pnpm dlx tsx@4.20.3 scripts/sync-by-type.ts --type visas
 
   sync-interview-records:
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.sync_type == 'interview_records'
+    if: github.event_name == 'schedule' && github.event.schedule == '0 19 * * *' || github.event_name == 'workflow_dispatch' && github.event.inputs.sync_type == 'interview_records'
     runs-on: ubuntu-latest
     timeout-minutes: 360
     environment: Production
@@ -104,8 +114,23 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
           echo "🕐 Starting interview_records sync at $(date)"
-          cmd=(pnpm dlx tsx@4.20.3 scripts/sync-by-type.ts --type interview_records --all-batches)
-          if [ -n "${{ github.event.inputs.batch_size }}" ]; then
-            cmd+=(--limit "${{ github.event.inputs.batch_size }}")
+          cmd=(pnpm dlx tsx@4.20.3 scripts/sync-by-type.ts --type interview_records)
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            # 04:00 JST daily: small newest-record window, one connector at a time.
+            cmd+=(--all-batches --limit 1 --record-id-tail-size 2000)
+          else
+            cmd+=(--all-batches)
+            if [ -n "${{ github.event.inputs.batch_size }}" ]; then
+              cmd+=(--limit "${{ github.event.inputs.batch_size }}")
+            fi
+            if [ -n "${{ github.event.inputs.record_id_from }}" ]; then
+              cmd+=(--record-id-from "${{ github.event.inputs.record_id_from }}")
+            fi
+            if [ -n "${{ github.event.inputs.record_id_to }}" ]; then
+              cmd+=(--record-id-to "${{ github.event.inputs.record_id_to }}")
+            fi
+            if [ -n "${{ github.event.inputs.record_id_tail_size }}" ]; then
+              cmd+=(--record-id-tail-size "${{ github.event.inputs.record_id_tail_size }}")
+            fi
           fi
           "${cmd[@]}"

--- a/app/api/cron/sync-by-type/route.ts
+++ b/app/api/cron/sync-by-type/route.ts
@@ -5,9 +5,11 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { createSyncService } from '@/lib/sync/kintone-sync'
+import { createSyncService, parseKintoneSyncOptions } from '@/lib/sync/kintone-sync'
+import type { KintoneSyncOptions } from '@/lib/sync/kintone-sync'
 import { getConnector, setConnectorStatus } from '@/lib/db/connectors'
 import { buildConnectorBatchMetadata, parseConnectorBatchParams } from '@/lib/sync/connector-batch'
+import type { ConnectorBatchParams } from '@/lib/sync/connector-batch'
 import { createClient } from '@supabase/supabase-js'
 
 // Use Node.js runtime for crypto operations
@@ -51,10 +53,12 @@ async function handleSyncByType(request: NextRequest) {
     // Get target app type from query parameters
     const { searchParams } = new URL(request.url)
     const targetAppType = searchParams.get('type')
-    let batchParams
+    let batchParams: ConnectorBatchParams
+    let syncOptions: KintoneSyncOptions
 
     try {
       batchParams = parseConnectorBatchParams(searchParams)
+      syncOptions = parseKintoneSyncOptions(searchParams)
     } catch (error) {
       return NextResponse.json(
         { error: error instanceof Error ? error.message : 'Invalid batch parameters' },
@@ -69,7 +73,12 @@ async function handleSyncByType(request: NextRequest) {
       )
     }
 
-    console.log(`🕐 Starting scheduled sync process for ${targetAppType}`)
+    console.log(`🕐 Starting scheduled sync process for ${targetAppType}`, {
+      recordId: syncOptions.recordId || null,
+      recordIdFrom: syncOptions.recordIdFrom || null,
+      recordIdTo: syncOptions.recordIdTo || null,
+      recordIdTailSize: syncOptions.recordIdTailSize || null,
+    })
     
     const supabase = getServerClient()
     
@@ -141,7 +150,7 @@ async function handleSyncByType(request: NextRequest) {
         )
         
         // Perform sync for specific target app type
-        const result = await syncService.syncAll(undefined, targetAppType)
+        const result = await syncService.syncAll(undefined, targetAppType, syncOptions)
         
         console.log(`✅ Scheduled sync completed for ${connector.name} (${targetAppType}):`, result)
         
@@ -198,6 +207,10 @@ async function handleSyncByType(request: NextRequest) {
       targetAppType,
       totalSynced,
       requestedConnectorId: batchParams.connectorId,
+      recordId: syncOptions.recordId,
+      recordIdFrom: syncOptions.recordIdFrom,
+      recordIdTo: syncOptions.recordIdTo,
+      recordIdTailSize: syncOptions.recordIdTailSize,
       ...batchMetadata,
       successCount,
       failedCount,

--- a/lib/sync/kintone-sync.test.ts
+++ b/lib/sync/kintone-sync.test.ts
@@ -4,8 +4,10 @@ import test from 'node:test'
 import {
   applyFileFieldProcessResult,
   buildRecordIdQuery,
+  buildRecordIdTailQuery,
   combineKintoneQueries,
   buildPeopleImageStoragePath,
+  parseKintoneSyncOptions,
   shouldSkipMissingUpdateTarget,
 } from './kintone-sync'
 import { buildUpdateCondition, getKintoneRecordValue } from './update-key-utils'
@@ -107,6 +109,21 @@ test('buildRecordIdQuery supports bounded Kintone record id ranges', () => {
   )
 })
 
+test('buildRecordIdQuery rejects conflicting Kintone record filters', () => {
+  assert.throws(
+    () => buildRecordIdQuery({ recordId: '2447', recordIdFrom: '2400' }),
+    /recordId cannot be combined/
+  )
+  assert.throws(
+    () => buildRecordIdQuery({ recordIdFrom: '2500', recordIdTo: '2400' }),
+    /recordIdFrom must be less than or equal to recordIdTo/
+  )
+  assert.throws(
+    () => buildRecordIdQuery({ recordIdFrom: '2400', recordIdTailSize: 1000 }),
+    /recordIdTailSize cannot be combined/
+  )
+})
+
 test('buildRecordIdQuery rejects non-numeric record ids', () => {
   assert.throws(
     () => buildRecordIdQuery({ recordId: '2447 or status = "x"' }),
@@ -118,5 +135,34 @@ test('combineKintoneQueries preserves existing filters and adds record id filter
   assert.equal(
     combineKintoneQueries('status = "在籍中"', buildRecordIdQuery({ recordId: '2447' })),
     'status = "在籍中" and $id = 2447'
+  )
+})
+
+test('parseKintoneSyncOptions accepts newest record tail window', () => {
+  assert.deepEqual(
+    parseKintoneSyncOptions(new URLSearchParams({ recordIdTailSize: '2000' })),
+    { recordIdTailSize: 2000 }
+  )
+})
+
+test('parseKintoneSyncOptions rejects unsafe newest record tail window', () => {
+  assert.throws(
+    () => parseKintoneSyncOptions(new URLSearchParams({ recordIdTailSize: '0' })),
+    /recordIdTailSize must be between 1 and 5000/
+  )
+  assert.throws(
+    () => parseKintoneSyncOptions(new URLSearchParams({ recordIdTailSize: '5001' })),
+    /recordIdTailSize must be between 1 and 5000/
+  )
+})
+
+test('buildRecordIdTailQuery creates a bounded newest-record window', () => {
+  assert.equal(
+    buildRecordIdTailQuery(9288, 2000),
+    '$id >= 7289 and $id <= 9288'
+  )
+  assert.equal(
+    buildRecordIdTailQuery(1200, 2000),
+    '$id >= 1 and $id <= 1200'
   )
 })

--- a/lib/sync/kintone-sync.ts
+++ b/lib/sync/kintone-sync.ts
@@ -155,7 +155,10 @@ export interface KintoneSyncOptions {
   recordId?: string
   recordIdFrom?: string
   recordIdTo?: string
+  recordIdTailSize?: number
 }
+
+const MAX_RECORD_ID_TAIL_SIZE = 5000
 
 function assertKintoneRecordId(value: string, label: string): string {
   const trimmed = value.trim()
@@ -166,6 +169,14 @@ function assertKintoneRecordId(value: string, label: string): string {
 }
 
 export function buildRecordIdQuery(options: KintoneSyncOptions = {}): string {
+  if (options.recordId && (options.recordIdFrom || options.recordIdTo)) {
+    throw new Error('recordId cannot be combined with recordIdFrom or recordIdTo')
+  }
+
+  if (options.recordIdTailSize && (options.recordId || options.recordIdFrom || options.recordIdTo)) {
+    throw new Error('recordIdTailSize cannot be combined with explicit record id filters')
+  }
+
   if (options.recordId) {
     return `$id = ${assertKintoneRecordId(options.recordId, 'recordId')}`
   }
@@ -178,7 +189,79 @@ export function buildRecordIdQuery(options: KintoneSyncOptions = {}): string {
     conditions.push(`$id <= ${assertKintoneRecordId(options.recordIdTo, 'recordIdTo')}`)
   }
 
+  if (options.recordIdFrom && options.recordIdTo) {
+    const from = BigInt(options.recordIdFrom.trim())
+    const to = BigInt(options.recordIdTo.trim())
+    if (from > to) {
+      throw new Error('recordIdFrom must be less than or equal to recordIdTo')
+    }
+  }
+
   return conditions.join(' and ')
+}
+
+function parseOptionalRecordId(searchParams: URLSearchParams, name: string): string | undefined {
+  const value = searchParams.get(name)
+  if (!value || value.trim() === '') {
+    return undefined
+  }
+
+  return assertKintoneRecordId(value, name)
+}
+
+function parseOptionalRecordIdTailSize(searchParams: URLSearchParams): number | undefined {
+  const value = searchParams.get('recordIdTailSize')
+  if (!value || value.trim() === '') {
+    return undefined
+  }
+
+  if (!/^\d+$/.test(value.trim())) {
+    throw new Error('recordIdTailSize must be an integer')
+  }
+
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error('recordIdTailSize must be a safe integer')
+  }
+  if (parsed < 1 || parsed > MAX_RECORD_ID_TAIL_SIZE) {
+    throw new Error(`recordIdTailSize must be between 1 and ${MAX_RECORD_ID_TAIL_SIZE}`)
+  }
+
+  return parsed
+}
+
+export function parseKintoneSyncOptions(searchParams: URLSearchParams): KintoneSyncOptions {
+  const options: KintoneSyncOptions = {
+    recordId: parseOptionalRecordId(searchParams, 'recordId'),
+    recordIdFrom: parseOptionalRecordId(searchParams, 'recordIdFrom'),
+    recordIdTo: parseOptionalRecordId(searchParams, 'recordIdTo'),
+    recordIdTailSize: parseOptionalRecordIdTailSize(searchParams),
+  }
+
+  buildRecordIdQuery(options)
+
+  return Object.fromEntries(
+    Object.entries(options).filter(([, value]) => value !== undefined)
+  ) as KintoneSyncOptions
+}
+
+export function buildRecordIdTailQuery(maxRecordId: number, recordIdTailSize: number): string {
+  if (!Number.isSafeInteger(maxRecordId) || maxRecordId < 0) {
+    throw new Error('maxRecordId must be a safe integer greater than or equal to 0')
+  }
+  if (!Number.isSafeInteger(recordIdTailSize) || recordIdTailSize < 1 || recordIdTailSize > MAX_RECORD_ID_TAIL_SIZE) {
+    throw new Error(`recordIdTailSize must be between 1 and ${MAX_RECORD_ID_TAIL_SIZE}`)
+  }
+  if (maxRecordId === 0) {
+    return '$id <= 0'
+  }
+
+  const recordIdFrom = Math.max(1, maxRecordId - recordIdTailSize + 1)
+
+  return buildRecordIdQuery({
+    recordIdFrom: String(recordIdFrom),
+    recordIdTo: String(maxRecordId),
+  })
 }
 
 export function combineKintoneQueries(...queries: Array<string | null | undefined>): string {
@@ -502,6 +585,15 @@ export class KintoneDataSync {
     return maxRecordId
   }
 
+  private async buildRecordIdQueryForApp(sourceAppId: string, options: KintoneSyncOptions = {}): Promise<string> {
+    if (!options.recordIdTailSize) {
+      return buildRecordIdQuery(options)
+    }
+
+    const maxRecordId = await this.getMaxRecordId(sourceAppId)
+    return buildRecordIdTailQuery(maxRecordId, options.recordIdTailSize)
+  }
+
   /**
    * Build Kintone query from filter conditions
    */
@@ -602,7 +694,8 @@ export class KintoneDataSync {
         appMappingId,
         recordId: options.recordId,
         recordIdFrom: options.recordIdFrom,
-        recordIdTo: options.recordIdTo
+        recordIdTo: options.recordIdTo,
+        recordIdTailSize: options.recordIdTailSize,
       })
       // Start sync session
       sessionId = await this.syncLogger.startSession(
@@ -753,12 +846,13 @@ export class KintoneDataSync {
       for (const appMapping of appMappings) {
         // Build query using only database filter conditions
         const filterQuery = await this.buildFilterQuery(targetAppType, appMapping.id)
-        const recordIdQuery = buildRecordIdQuery(options)
+        const recordIdQuery = await this.buildRecordIdQueryForApp(appMapping.source_app_id, options)
         const query = combineKintoneQueries(filterQuery, recordIdQuery)
         console.log('[sync] kintone-query', {
           targetAppType,
           sourceAppId,
           appMappingId: appMapping.id,
+          recordIdTailSize: options.recordIdTailSize,
           query
         })
         
@@ -936,12 +1030,13 @@ export class KintoneDataSync {
       const filterQuery = buildInterviewRecordsQuery(
         await this.buildFilterQuery('interview_records', appMapping.id)
       )
-      const recordIdQuery = buildRecordIdQuery(options)
+      const recordIdQuery = await this.buildRecordIdQueryForApp(appMapping.source_app_id, options)
       const query = combineKintoneQueries(filterQuery, recordIdQuery)
 
       console.log('[sync] interview-records:kintone-query', {
         sourceAppId: appMapping.source_app_id,
         appMappingId: appMapping.id,
+        recordIdTailSize: options.recordIdTailSize,
         query,
       })
 

--- a/scripts/sync-by-type.ts
+++ b/scripts/sync-by-type.ts
@@ -1,5 +1,9 @@
 import { createClient } from '@supabase/supabase-js'
-import { createSyncService } from '@/lib/sync/kintone-sync'
+import {
+  createSyncService,
+  parseKintoneSyncOptions,
+} from '@/lib/sync/kintone-sync'
+import type { KintoneSyncOptions } from '@/lib/sync/kintone-sync'
 import {
   buildConnectorBatchMetadata,
   ConnectorBatchMetadata,
@@ -66,6 +70,21 @@ function parseBatchControls(): BatchControls {
     allBatches,
     batchParams: parseOptionalConnectorBatchParams(searchParams),
   }
+}
+
+function parseSyncOptions(): KintoneSyncOptions {
+  const searchParams = new URLSearchParams()
+  const recordId = getArgValue('--record-id') || process.env.SYNC_RECORD_ID
+  const recordIdFrom = getArgValue('--record-id-from') || process.env.SYNC_RECORD_ID_FROM
+  const recordIdTo = getArgValue('--record-id-to') || process.env.SYNC_RECORD_ID_TO
+  const recordIdTailSize = getArgValue('--record-id-tail-size') || process.env.SYNC_RECORD_ID_TAIL_SIZE
+
+  if (recordId) searchParams.set('recordId', recordId)
+  if (recordIdFrom) searchParams.set('recordIdFrom', recordIdFrom)
+  if (recordIdTo) searchParams.set('recordIdTo', recordIdTo)
+  if (recordIdTailSize) searchParams.set('recordIdTailSize', recordIdTailSize)
+
+  return parseKintoneSyncOptions(searchParams)
 }
 
 function getServerClient() {
@@ -166,12 +185,17 @@ async function fetchConnectors(
 
 async function runSyncByType(
   targetAppType: SyncTargetType,
-  batchParams: ConnectorBatchParams | null = null
+  batchParams: ConnectorBatchParams | null = null,
+  syncOptions: KintoneSyncOptions = {}
 ) {
   console.log(`🕐 Starting direct GitHub Actions sync for ${targetAppType}`, {
     connectorId: batchParams?.connectorId || null,
     limit: batchParams?.limit || null,
     offset: batchParams?.connectorId ? null : batchParams?.offset || null,
+    recordId: syncOptions.recordId || null,
+    recordIdFrom: syncOptions.recordIdFrom || null,
+    recordIdTo: syncOptions.recordIdTo || null,
+    recordIdTailSize: syncOptions.recordIdTailSize || null,
   })
 
   const {
@@ -225,7 +249,7 @@ async function runSyncByType(
         'scheduled'
       )
 
-      const result = await syncService.syncAll(undefined, targetAppType)
+      const result = await syncService.syncAll(undefined, targetAppType, syncOptions)
 
       results.push({
         connectorId: connector.id,
@@ -272,6 +296,10 @@ async function runSyncByType(
     success: failedCount === 0,
     targetAppType,
     requestedConnectorId,
+    recordId: syncOptions.recordId,
+    recordIdFrom: syncOptions.recordIdFrom,
+    recordIdTo: syncOptions.recordIdTo,
+    recordIdTailSize: syncOptions.recordIdTailSize,
     ...(batchMetadata || {}),
     connectorCount: connectors.length,
     successCount,
@@ -287,10 +315,11 @@ async function runSyncByType(
 
 async function runSyncByTypeInBatches(
   targetAppType: SyncTargetType,
-  initialBatchParams: ConnectorBatchParams
+  initialBatchParams: ConnectorBatchParams,
+  syncOptions: KintoneSyncOptions = {}
 ) {
   if (initialBatchParams.connectorId) {
-    return runSyncByType(targetAppType, initialBatchParams)
+    return runSyncByType(targetAppType, initialBatchParams, syncOptions)
   }
 
   let offset = initialBatchParams.offset
@@ -300,7 +329,7 @@ async function runSyncByTypeInBatches(
     const summary = await runSyncByType(targetAppType, {
       ...initialBatchParams,
       offset,
-    })
+    }, syncOptions)
 
     batchSummaries.push(summary)
 
@@ -329,6 +358,10 @@ async function runSyncByTypeInBatches(
     success: failedCount === 0,
     targetAppType,
     allBatches: true,
+    recordId: syncOptions.recordId,
+    recordIdFrom: syncOptions.recordIdFrom,
+    recordIdTo: syncOptions.recordIdTo,
+    recordIdTailSize: syncOptions.recordIdTailSize,
     batchLimit: initialBatchParams.limit,
     batchCount: batchSummaries.length,
     connectorCount: successCount + failedCount,
@@ -347,6 +380,7 @@ async function runSyncByTypeInBatches(
 async function main() {
   const syncType = parseSyncType()
   const { allBatches, batchParams } = parseBatchControls()
+  const syncOptions = parseSyncOptions()
   const targetTypes: SyncTargetType[] =
     syncType === 'both' ? ['people', 'visas'] : [syncType]
 
@@ -354,8 +388,8 @@ async function main() {
 
   for (const targetType of targetTypes) {
     const summary = allBatches && batchParams
-      ? await runSyncByTypeInBatches(targetType, batchParams)
-      : await runSyncByType(targetType, batchParams)
+      ? await runSyncByTypeInBatches(targetType, batchParams, syncOptions)
+      : await runSyncByType(targetType, batchParams, syncOptions)
 
     if (!summary.success) {
       hasFailure = true


### PR DESCRIPTION
Closes #103

## Summary
- Add a daily scheduled `interview_records` sync to the existing data sync workflow.
- Keep the scheduled run conservative: 04:00 JST, all connector batches one at a time, newest 2,000 Kintone record IDs only.
- Add manual dispatch controls for `record_id_from`, `record_id_to`, and `record_id_tail_size` so App 98 catch-up can be split safely.
- Reuse the same sync option parsing in the GitHub Actions runner and cron API route.

## Why
FunBase v2 now exposes App 98 interview/support records, so the data needs automatic refresh like `people` and `visas`. App 98 has many records, so a daily full sync is too risky for release operation.

## Operational note
The scheduled run is a newest-record-ID window, not an updated-time window. Old record edits may still need manual range/full catch-up. This is intentional to avoid turning release-day automation into a heavy full App 98 sync.

## Checks
- `pnpm dlx tsx@4.20.3 --test lib/sync/kintone-sync.test.ts lib/sync/connector-batch.test.ts`
- `pnpm dlx tsx@4.20.3 scripts/sync-by-type.ts --type interview_records --record-id-tail-size 0` validates the guard rejects unsafe tail size before touching Supabase/Kintone
- `git diff --check`
- YAML parse check for `.github/workflows/cron-sync.yml`

## Known baseline
- `pnpm typecheck` still fails on existing unrelated repo-wide TypeScript errors in connector/admin/demo files; no new changed file appeared in the reported failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added record ID range filtering for Kintone syncs: filter by specific ID range or tail size when syncing records.
  * Enhanced sync workflow with flexible scheduling and filtering parameters for interview-records synchronization.
  * Extended API and CLI sync commands to accept record filtering parameters for targeted syncing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->