### PR TITLE
Rename regular interview report label

### DIFF
--- a/app/interview-records/[id]/page.tsx
+++ b/app/interview-records/[id]/page.tsx
@@ -105,7 +105,7 @@ export default async function InterviewRecordDetailPage({ params }: InterviewRec
           <CardHeader>
             <div className="flex items-center gap-2">
               <FileText className="h-4 w-4 text-muted-foreground" />
-              <CardTitle className="text-base">企業提出用レポート</CardTitle>
+              <CardTitle className="text-base">定期面談レポート</CardTitle>
             </div>
           </CardHeader>
           <CardContent>
@@ -115,7 +115,7 @@ export default async function InterviewRecordDetailPage({ params }: InterviewRec
               </div>
             ) : (
               <p className="rounded-lg bg-muted/30 p-4 text-sm text-muted-foreground">
-                企業提出用レポートはありません
+                定期面談レポートはありません
               </p>
             )}
           </CardContent>

--- a/app/meetings/page.tsx
+++ b/app/meetings/page.tsx
@@ -104,11 +104,11 @@ function InterviewCard({ interview }: { interview: RegularInterview }) {
         </div>
       </CardHeader>
       <CardContent>
-        {/* 企業提出用レポート Preview - Main content for 定期面談 */}
+        {/* 定期面談レポート Preview - Main content for 定期面談 */}
         <div className="space-y-2">
           <div className="flex items-center gap-2">
             <FileText className="h-4 w-4 text-muted-foreground" />
-            <span className="text-sm font-medium">企業提出用レポート</span>
+            <span className="text-sm font-medium">定期面談レポート</span>
           </div>
           <div className={`bg-muted/30 rounded-lg p-3 text-sm whitespace-pre-wrap ${!expanded ? "line-clamp-3" : ""}`}>
             {interview.companyReport}
@@ -325,7 +325,7 @@ export default function MeetingsPage() {
         {/* Page Header */}
         <div>
           <h1 className="text-3xl font-bold text-foreground">面談一覧</h1>
-          <p className="text-muted-foreground mt-2">定期面談の記録と企業提出用レポートを管理</p>
+          <p className="text-muted-foreground mt-2">定期面談の記録と定期面談レポートを管理</p>
         </div>
 
         {/* Filters */}

--- a/components/person-detail-tabs.tsx
+++ b/components/person-detail-tabs.tsx
@@ -33,7 +33,7 @@ function getDailySupportTimelineTitle(record: DailySupportRecord): string {
   return `日々対応: ${visibleCategories}${categories.length > 3 ? "..." : ""}`
 }
 
-// Regular Interview Card Component - displays 企業提出用レポート as main content
+// Regular Interview Card Component - displays 定期面談レポート as main content
 function RegularInterviewCard({ interview }: { interview: RegularInterview }) {
   const [expanded, setExpanded] = useState(false)
   const detailHref = getInterviewRecordDetailPath(interview.id)
@@ -82,11 +82,11 @@ function RegularInterviewCard({ interview }: { interview: RegularInterview }) {
         </div>
       </CardHeader>
       <CardContent>
-        {/* 企業提出用レポート - Main Content */}
+        {/* 定期面談レポート - Main Content */}
         <div className="space-y-3">
           <div className="flex items-center gap-2">
             <FileText className="h-4 w-4 text-muted-foreground" />
-            <span className="text-sm font-medium">企業提出用レポート</span>
+            <span className="text-sm font-medium">定期面談レポート</span>
           </div>
           <div className={`bg-muted/30 rounded-lg p-4 text-sm whitespace-pre-wrap ${!expanded ? "line-clamp-6" : ""}`}>
             {interview.companyReport}

--- a/lib/kintone-data.ts
+++ b/lib/kintone-data.ts
@@ -75,7 +75,7 @@ async function fetchInterviewRecordRowsByType(recordType: "regular_interview" | 
 
 /**
  * Get all regular interview records (定期面談)
- * Main content: 企業提出用レポート (companyReport)
+ * Main content: 定期面談レポート (companyReport)
  */
 export async function getRegularInterviews(): Promise<RegularInterview[]> {
   const rows = await fetchInterviewRecordRowsByType("regular_interview")
@@ -200,7 +200,7 @@ export async function getDailySupportCategories(): Promise<{ dai: string; chu: s
 // Import and use ONLY in development/test environments.
 // ============================================================================
 
-// Sample 企業提出用レポート content
+// Sample 定期面談レポート content
 const sampleCompanyReports = [
   `【面談概要】
 本人の勤務状況は良好で、業務への適応も順調に進んでいる。

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -205,7 +205,7 @@ export type DailySupportEntry = {
   notes?: string // 備考
 }
 
-// Regular Interview Record (定期面談) - main content is 企業提出用レポート
+// Regular Interview Record (定期面談) - main content is 定期面談レポート
 export type RegularInterview = {
   id: string
   kintoneRecordId?: string
@@ -227,7 +227,7 @@ export type RegularInterview = {
   kintoneStatus?: KintoneInterviewStatus
   companyConfirmationStatus: CompanyConfirmationStatus
   // Main content for 定期面談
-  companyReport: string // 企業提出用レポート
+  companyReport: string // 定期面談レポート
   // Secondary (internal notes)
   internalNotes?: string // interview field - keep secondary
   createdAt: string


### PR DESCRIPTION
## Summary
- Rename customer-facing regular interview report label from 企業提出用レポート to 定期面談レポート
- Update the meetings list, interview detail page, and person detail tab labels
- Keep the Kintone source field name unchanged so sync mapping remains intact

## Verification
- pnpm run build