### PR TITLE
[codex] Improve tenant management search and loading states

### DIFF
--- a/app/admin/tenants/[tenantId]/page.tsx
+++ b/app/admin/tenants/[tenantId]/page.tsx
@@ -1,9 +1,11 @@
 "use client"
 
+import { useCallback, useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
-import { ArrowLeft } from "lucide-react"
+import { ArrowLeft, Building2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { TenantMembersPage } from "@/components/tenant/tenant-members-page"
+import { getTenantById, type Tenant } from "@/lib/supabase/tenants"
 
 interface AdminTenantMembersPageProps {
   params: {
@@ -13,6 +15,25 @@ interface AdminTenantMembersPageProps {
 
 export default function AdminTenantMembersPage({ params }: AdminTenantMembersPageProps) {
   const router = useRouter()
+  const [tenant, setTenant] = useState<Tenant | null>(null)
+  const [tenantLoading, setTenantLoading] = useState(true)
+
+  const fetchTenant = useCallback(async () => {
+    try {
+      setTenantLoading(true)
+      const tenantData = await getTenantById(params.tenantId)
+      setTenant(tenantData)
+    } catch (error) {
+      console.error("Error fetching tenant:", error)
+      setTenant(null)
+    } finally {
+      setTenantLoading(false)
+    }
+  }, [params.tenantId])
+
+  useEffect(() => {
+    fetchTenant()
+  }, [fetchTenant])
 
   return (
     <div className="p-6 space-y-6">
@@ -23,7 +44,20 @@ export default function AdminTenantMembersPage({ params }: AdminTenantMembersPag
         </Button>
         <div>
           <h1 className="text-3xl font-bold text-foreground">テナント管理</h1>
-          <p className="text-muted-foreground mt-1">メンバーと権限を管理します</p>
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
+            <p className="text-muted-foreground">メンバーと権限を管理します</p>
+            <div className="flex min-w-0 items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-sm">
+              <Building2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="shrink-0 text-muted-foreground">選択中の法人:</span>
+              {tenantLoading ? (
+                <span className="funbase-loader-shimmer h-4 w-32 rounded-full bg-muted" />
+              ) : (
+                <span className="min-w-0 truncate font-medium text-foreground">
+                  {tenant?.name || "不明な法人"}
+                </span>
+              )}
+            </div>
+          </div>
         </div>
       </div>
       <TenantMembersPage tenantId={params.tenantId} />

--- a/app/admin/tenants/page.tsx
+++ b/app/admin/tenants/page.tsx
@@ -5,9 +5,10 @@ import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
-import { ArrowLeft, Building2, Users, Plus, Trash2, Pencil } from "lucide-react"
+import { ArrowLeft, Building2, Search, Users, Plus, Trash2, Pencil, X } from "lucide-react"
 import { CreateTenantDialog } from "@/components/tenant/create-tenant-dialog"
 import { TenantEditDialog } from "@/components/tenant/tenant-edit-dialog"
 import { createTenantAction, getTenantsAction, isUserOwnerOfAnyTenant, type CreateTenantData } from "@/lib/actions/tenant-actions"
@@ -15,6 +16,7 @@ import { deleteTenant, updateTenant } from "@/lib/supabase/tenants"
 import { useAuth } from "@/contexts/auth-context"
 import { useToast } from "@/lib/hooks/use-toast"
 import { Tenant } from "@/tenant-management/types/tenant"
+import { TenantListLoadingSkeleton } from "@/components/ui/funbase-loading"
 
 export default function AdminTenantsPage() {
   const router = useRouter()
@@ -26,6 +28,7 @@ export default function AdminTenantsPage() {
   const [editingTenant, setEditingTenant] = useState<Tenant | null>(null)
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
   const [isOwner, setIsOwner] = useState(false)
+  const [searchQuery, setSearchQuery] = useState("")
 
   useEffect(() => {
     if (!authLoading && user) {
@@ -129,21 +132,13 @@ export default function AdminTenantsPage() {
     }
   }
 
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase()
+  const filteredTenants = normalizedSearchQuery
+    ? tenants.filter((tenant) => tenant.name.toLowerCase().includes(normalizedSearchQuery))
+    : tenants
+
   if (authLoading || loading) {
-    return (
-      <div className="p-6 space-y-6">
-        <div className="flex items-center gap-4">
-          <Button variant="ghost" size="sm" onClick={() => router.back()}>
-            <ArrowLeft className="h-4 w-4 mr-2" />
-            戻る
-          </Button>
-          <div>
-            <h1 className="text-3xl font-bold text-foreground">テナント管理</h1>
-            <p className="text-muted-foreground mt-2">読み込み中...</p>
-          </div>
-        </div>
-      </div>
-    )
+    return <TenantListLoadingSkeleton />
   }
 
   if (!user) {
@@ -185,9 +180,41 @@ export default function AdminTenantsPage() {
         )}
       </div>
 
+      {tenants.length > 0 && (
+        <div className="flex flex-col gap-2 sm:max-w-md">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              placeholder="法人名で検索"
+              className="pl-9 pr-10"
+              aria-label="法人名で検索"
+            />
+            {searchQuery && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 p-0"
+                onClick={() => setSearchQuery("")}
+                aria-label="検索条件をクリア"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+          {searchQuery && (
+            <p className="text-sm text-muted-foreground">
+              {filteredTenants.length}件の法人が見つかりました
+            </p>
+          )}
+        </div>
+      )}
+
       {/* Tenants List */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {tenants.map((tenant) => {
+        {filteredTenants.map((tenant) => {
           const userTenant = userTenants.find(ut => ut.tenant_id === tenant.id)
           const userRole = userTenant?.role || 'guest'
           
@@ -268,6 +295,23 @@ export default function AdminTenantsPage() {
           )
         })}
       </div>
+
+      {tenants.length > 0 && filteredTenants.length === 0 && (
+        <Card>
+          <CardContent className="pt-6">
+            <div className="text-center py-12">
+              <Search className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+              <h3 className="text-lg font-semibold mb-2">該当する法人がありません</h3>
+              <p className="text-muted-foreground mb-6">
+                検索条件を変えてもう一度お試しください。
+              </p>
+              <Button variant="outline" onClick={() => setSearchQuery("")}>
+                検索条件をクリア
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {tenants.length === 0 && (
         <Card>

--- a/components/tenant/tenant-members-page.tsx
+++ b/components/tenant/tenant-members-page.tsx
@@ -27,6 +27,7 @@ import {
 import { useAuth } from "@/contexts/auth-context"
 import { useToast } from "@/lib/hooks/use-toast"
 import { canManageCompanyContacts as canManageCompanyContactsForActor } from "@/lib/tenant-access"
+import { TenantMembersLoadingSkeleton } from "@/components/ui/funbase-loading"
 
 interface TenantMembersPageProps {
   tenantId: string
@@ -254,17 +255,7 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
     : "企業担当者を招待"
 
   if (loading) {
-    return (
-      <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">メンバー</h1>
-          <p className="text-muted-foreground">テナントのメンバーを管理します</p>
-        </div>
-        <div className="text-center py-8 text-muted-foreground">
-          読み込み中...
-        </div>
-      </div>
-    )
+    return <TenantMembersLoadingSkeleton />
   }
 
   return (

--- a/components/ui/funbase-loading.tsx
+++ b/components/ui/funbase-loading.tsx
@@ -191,3 +191,108 @@ export function ListPanelLoadingSkeleton() {
     </div>
   )
 }
+
+export function TenantListLoadingSkeleton() {
+  return (
+    <div className="p-6 space-y-6" role="status" aria-label="テナント一覧を読み込んでいます">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-4">
+          <div className="funbase-loader-shimmer h-9 w-20 shrink-0 rounded-md bg-muted" />
+          <div className="space-y-3">
+            <div className="funbase-loader-shimmer h-8 w-40 rounded-full bg-muted" />
+            <div className="funbase-loader-shimmer h-4 w-56 rounded-full bg-muted [animation-delay:120ms]" />
+          </div>
+        </div>
+        <div className="funbase-loader-shimmer hidden h-10 w-36 rounded-md bg-muted sm:block [animation-delay:180ms]" />
+      </div>
+
+      <div className="funbase-loader-shimmer h-9 w-full max-w-md rounded-md bg-muted [animation-delay:220ms]" />
+
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, cardIndex) => (
+          <div key={cardIndex} className="rounded-lg border border-border bg-card p-6 shadow-sm">
+            <div className="mb-6 flex items-start justify-between gap-4">
+              <div className="flex min-w-0 items-center gap-3">
+                <div className="funbase-loader-shimmer h-10 w-10 shrink-0 rounded-full bg-muted" />
+                <div className="space-y-2">
+                  <div className="funbase-loader-shimmer h-5 w-36 rounded-full bg-muted [animation-delay:120ms]" />
+                  <div className="funbase-loader-shimmer h-3 w-24 rounded-full bg-muted [animation-delay:200ms]" />
+                </div>
+              </div>
+              <div className="funbase-loader-shimmer h-8 w-16 rounded-md bg-muted [animation-delay:260ms]" />
+            </div>
+
+            <div className="space-y-4">
+              <div className="funbase-loader-shimmer h-4 w-4/5 rounded-full bg-muted [animation-delay:160ms]" />
+              <div className="flex items-center justify-between gap-4">
+                <div className="funbase-loader-shimmer h-6 w-20 rounded-full bg-muted [animation-delay:220ms]" />
+                <div className="funbase-loader-shimmer h-4 w-14 rounded-full bg-muted [animation-delay:280ms]" />
+              </div>
+              <div className="funbase-loader-shimmer h-9 w-full rounded-md bg-muted [animation-delay:340ms]" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function TenantMembersLoadingSkeleton() {
+  return (
+    <div className="space-y-6" role="status" aria-label="テナントメンバーを読み込んでいます">
+      <div className="space-y-3">
+        <div className="funbase-loader-shimmer h-8 w-28 rounded-full bg-muted" />
+        <div className="funbase-loader-shimmer h-4 w-56 rounded-full bg-muted [animation-delay:120ms]" />
+      </div>
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="funbase-loader-shimmer h-9 w-full max-w-sm rounded-md bg-muted [animation-delay:180ms]" />
+        <div className="flex flex-wrap items-center gap-2">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <div
+              key={index}
+              className="funbase-loader-shimmer h-9 w-28 rounded-md bg-muted"
+              style={{ animationDelay: `${220 + index * 60}ms` }}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <div className="funbase-loader-shimmer h-10 w-24 rounded-md bg-muted [animation-delay:160ms]" />
+        <div className="funbase-loader-shimmer h-10 w-28 rounded-md bg-muted [animation-delay:220ms]" />
+        <div className="funbase-loader-shimmer h-10 w-32 rounded-md bg-muted [animation-delay:280ms]" />
+      </div>
+
+      <div className="rounded-lg border border-border bg-card shadow-sm">
+        <div className="border-b border-border p-4">
+          <div className="grid grid-cols-4 gap-4">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div
+                key={index}
+                className="funbase-loader-shimmer h-4 rounded-full bg-muted"
+                style={{ width: `${64 + index * 16}px`, animationDelay: `${120 + index * 60}ms` }}
+              />
+            ))}
+          </div>
+        </div>
+        <div className="divide-y divide-border">
+          {Array.from({ length: 6 }).map((_, rowIndex) => (
+            <div key={rowIndex} className="grid grid-cols-1 gap-4 p-4 sm:grid-cols-4 sm:items-center">
+              <div className="flex items-center gap-3">
+                <div className="funbase-loader-shimmer h-9 w-9 shrink-0 rounded-full bg-muted" />
+                <div className="space-y-2">
+                  <div className="funbase-loader-shimmer h-4 w-40 rounded-full bg-muted [animation-delay:120ms]" />
+                  <div className="funbase-loader-shimmer h-3 w-28 rounded-full bg-muted [animation-delay:180ms]" />
+                </div>
+              </div>
+              <div className="funbase-loader-shimmer h-6 w-20 rounded-full bg-muted [animation-delay:220ms]" />
+              <div className="funbase-loader-shimmer h-6 w-24 rounded-full bg-muted [animation-delay:280ms]" />
+              <div className="funbase-loader-shimmer h-8 w-24 rounded-md bg-muted [animation-delay:340ms]" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add corporation-name search to the tenant management list page.
- Show the currently selected corporation name in the tenant member management header.
- Replace plain loading text with skeleton loading states for the tenant list and tenant member detail views.

## Background
Slack request: tenant admins need to quickly find corporations in the tenant list, and avoid sending email while viewing the wrong corporation's tenant management screen. Follow-up: make tenant management loading states feel consistent with the people list skeleton loading experience.

## Validation
- `git diff --check`
- `git diff --cached --check`

TypeScript/build checks were not run because this worktree does not have `node_modules`, and `npx tsc --noEmit` could not resolve the local TypeScript compiler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant search functionality with filtering by corporation name
  * Tenant name now displays dynamically in the admin members page header

* **Improvements**
  * Enhanced loading state indicators with shimmer effect animations
  * Added dedicated "no matching results" message for empty search results
  * Streamlined loading skeleton components across tenant pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->