### PR TITLE
[codex] Add record list loading skeletons

### DIFF
--- a/app/meetings/loading.tsx
+++ b/app/meetings/loading.tsx
@@ -1,13 +1,13 @@
-import { ListPanelLoadingSkeleton } from "@/components/ui/funbase-loading"
+import { RecordListLoadingSkeleton } from "@/components/ui/funbase-loading"
 
 export default function Loading() {
   return (
     <div className="p-6 space-y-6">
       <div>
-        <h1 className="text-3xl font-bold text-foreground">面談記録</h1>
-        <p className="text-muted-foreground mt-2">面談の記録と内容を管理</p>
+        <h1 className="text-3xl font-bold text-foreground">面談一覧</h1>
+        <p className="text-muted-foreground mt-2">定期面談の記録と定期面談レポートを管理</p>
       </div>
-      <ListPanelLoadingSkeleton />
+      <RecordListLoadingSkeleton />
     </div>
   )
 }

--- a/app/meetings/page.tsx
+++ b/app/meetings/page.tsx
@@ -11,6 +11,7 @@ import { ResultCountBadge } from "@/components/ui/result-count-badge"
 import { Input } from "@/components/ui/input"
 import { FilterSelect } from "@/components/ui/filter-select"
 import { FilterMultiSelectPopover } from "@/components/ui/filter-multi-select-popover"
+import { RecordListLoadingSkeleton } from "@/components/ui/funbase-loading"
 import { getRegularInterviews } from "@/lib/kintone-data"
 import { getInterviewRecordDetailPath } from "@/lib/interview-record-links"
 import {
@@ -328,6 +329,10 @@ export default function MeetingsPage() {
           <p className="text-muted-foreground mt-2">定期面談の記録と定期面談レポートを管理</p>
         </div>
 
+        {loading ? (
+          <RecordListLoadingSkeleton />
+        ) : (
+          <>
         {/* Filters */}
         <div className="flex items-center gap-3 flex-wrap">
           <div className="relative">
@@ -387,13 +392,7 @@ export default function MeetingsPage() {
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
           {/* Interview List */}
           <div className="lg:col-span-3 space-y-4">
-            {loading ? (
-              <Card>
-                <CardContent className="flex items-center justify-center py-8">
-                  <p className="text-muted-foreground">読み込み中...</p>
-                </CardContent>
-              </Card>
-            ) : filteredInterviews.length === 0 ? (
+            {filteredInterviews.length === 0 ? (
               <Card>
                 <CardContent className="flex items-center justify-center py-8">
                   <p className="text-muted-foreground">
@@ -456,6 +455,8 @@ export default function MeetingsPage() {
             </Card>
           </div>
         </div>
+          </>
+        )}
       </div>
     </AuthGuard>
   )

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { FilterSelect } from "@/components/ui/filter-select"
 import { FilterMultiSelectPopover } from "@/components/ui/filter-multi-select-popover"
+import { RecordListLoadingSkeleton } from "@/components/ui/funbase-loading"
 import { getDailySupportRecords } from "@/lib/kintone-data"
 import { getInterviewRecordDetailPath } from "@/lib/interview-record-links"
 import {
@@ -351,6 +352,10 @@ export default function SupportPage() {
           <p className="text-muted-foreground mt-2">日々のサポート対応記録を管理</p>
         </div>
 
+        {loading ? (
+          <RecordListLoadingSkeleton />
+        ) : (
+          <>
         {/* Filters */}
         <div className="flex items-center gap-3 flex-wrap">
           <div className="relative">
@@ -402,13 +407,7 @@ export default function SupportPage() {
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
           {/* Record List */}
           <div className="lg:col-span-3 space-y-4">
-            {loading ? (
-              <Card>
-                <CardContent className="flex items-center justify-center py-8">
-                  <p className="text-muted-foreground">読み込み中...</p>
-                </CardContent>
-              </Card>
-            ) : error ? (
+            {error ? (
               <Card>
                 <CardContent className="flex items-center justify-center py-8">
                   <p className="text-destructive">{error}</p>
@@ -558,6 +557,8 @@ export default function SupportPage() {
             </Card>
           </div>
         </div>
+          </>
+        )}
       </div>
     </AuthGuard>
   )

--- a/app/timeline/loading.tsx
+++ b/app/timeline/loading.tsx
@@ -1,13 +1,13 @@
-import { ListPanelLoadingSkeleton } from "@/components/ui/funbase-loading"
+import { RecordListLoadingSkeleton } from "@/components/ui/funbase-loading"
 
 export default function Loading() {
   return (
     <div className="p-6 space-y-6">
       <div>
         <h1 className="text-3xl font-bold text-foreground">タイムライン</h1>
-        <p className="text-muted-foreground mt-2">すべての活動を時系列で確認</p>
+        <p className="text-muted-foreground mt-2">ビザ進捗、定期面談、日々対応を時系列で確認</p>
       </div>
-      <ListPanelLoadingSkeleton />
+      <RecordListLoadingSkeleton />
     </div>
   )
 }

--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -10,6 +10,7 @@ import { FilterSelect } from "@/components/ui/filter-select"
 import { Badge } from "@/components/ui/badge"
 import { ResultCountBadge } from "@/components/ui/result-count-badge"
 import { FilterMultiSelectPopover } from "@/components/ui/filter-multi-select-popover"
+import { RecordListLoadingSkeleton } from "@/components/ui/funbase-loading"
 import { formatDate } from "@/lib/utils"
 import { Search, Calendar, FileText, CheckSquare, ChevronRight, Filter } from "lucide-react"
 import { getPeople } from "@/lib/supabase/people"
@@ -317,11 +318,9 @@ export default function TimelinePage() {
         <div className="p-6 space-y-6">
           <div>
             <h1 className="text-3xl font-bold text-foreground">タイムライン</h1>
-            <p className="text-muted-foreground mt-2">すべての活動を時系列で確認</p>
+            <p className="text-muted-foreground mt-2">ビザ進捗、定期面談、日々対応を時系列で確認</p>
           </div>
-          <div className="flex items-center justify-center py-8">
-            <p className="text-muted-foreground">読み込み中...</p>
-          </div>
+          <RecordListLoadingSkeleton />
         </div>
       </AuthGuard>
     )

--- a/components/ui/funbase-loading.tsx
+++ b/components/ui/funbase-loading.tsx
@@ -192,6 +192,67 @@ export function ListPanelLoadingSkeleton() {
   )
 }
 
+export function RecordListLoadingSkeleton() {
+  return (
+    <div className="space-y-6" role="status" aria-label="一覧を読み込んでいます">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="funbase-loader-shimmer h-10 w-80 max-w-full rounded-md bg-muted" />
+        <div className="funbase-loader-shimmer h-10 w-36 rounded-md bg-muted [animation-delay:120ms]" />
+        <div className="funbase-loader-shimmer h-10 w-32 rounded-md bg-muted [animation-delay:180ms]" />
+        <div className="funbase-loader-shimmer h-10 w-36 rounded-md bg-muted [animation-delay:240ms]" />
+        <div className="funbase-loader-shimmer h-10 w-28 rounded-md bg-muted [animation-delay:300ms]" />
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-4">
+        <div className="space-y-4 lg:col-span-3">
+          {Array.from({ length: 3 }).map((_, cardIndex) => (
+            <div key={cardIndex} className="rounded-lg border border-border bg-card p-6 shadow-sm">
+              <div className="mb-5 flex items-start justify-between gap-4">
+                <div className="min-w-0 flex-1 space-y-3">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <div className="funbase-loader-shimmer h-5 w-44 rounded-full bg-muted" />
+                    <div className="funbase-loader-shimmer h-6 w-28 rounded-full bg-muted [animation-delay:120ms]" />
+                  </div>
+                  <div className="flex flex-wrap items-center gap-4">
+                    <div className="funbase-loader-shimmer h-4 w-24 rounded-full bg-muted [animation-delay:160ms]" />
+                    <div className="funbase-loader-shimmer h-4 w-40 rounded-full bg-muted [animation-delay:220ms]" />
+                    <div className="funbase-loader-shimmer h-4 w-28 rounded-full bg-muted [animation-delay:280ms]" />
+                    <div className="funbase-loader-shimmer h-4 w-32 rounded-full bg-muted [animation-delay:340ms]" />
+                  </div>
+                </div>
+                <div className="funbase-loader-shimmer h-9 w-20 shrink-0 rounded-md bg-muted [animation-delay:180ms]" />
+              </div>
+
+              <div className="space-y-3 rounded-lg bg-muted/30 p-4">
+                <div className="funbase-loader-shimmer h-4 w-36 rounded-full bg-muted [animation-delay:220ms]" />
+                <div className="funbase-loader-shimmer h-4 w-full rounded-full bg-muted [animation-delay:280ms]" />
+                <div className="funbase-loader-shimmer h-4 w-5/6 rounded-full bg-muted [animation-delay:340ms]" />
+                <div className="funbase-loader-shimmer h-4 w-2/3 rounded-full bg-muted [animation-delay:400ms]" />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="space-y-6">
+          {Array.from({ length: 2 }).map((_, cardIndex) => (
+            <div key={cardIndex} className="rounded-lg border border-border bg-card p-6 shadow-sm">
+              <div className="funbase-loader-shimmer mb-5 h-5 w-28 rounded-full bg-muted" />
+              <div className="space-y-4">
+                {Array.from({ length: 3 }).map((__, rowIndex) => (
+                  <div key={rowIndex} className="flex items-center justify-between gap-4">
+                    <div className="funbase-loader-shimmer h-4 w-24 rounded-full bg-muted" />
+                    <div className="funbase-loader-shimmer h-6 w-12 rounded-full bg-muted" />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export function TenantListLoadingSkeleton() {
   return (
     <div className="p-6 space-y-6" role="status" aria-label="テナント一覧を読み込んでいます">


### PR DESCRIPTION
## Summary
- Add a reusable record-list skeleton that matches the current card list plus sidebar layout.
- Replace client-side `読み込み中...` states on the current 面談一覧, サポート記録, and タイムライン pages.
- Update route-level loading screens for 面談一覧 and タイムライン to use the same skeleton and current page copy.

## Impact
The visible loading state now appears on the actual current routes shown in the sidebar: `/meetings`, `/support`, and `/timeline`.

## Validation
- `git diff --check origin/main` passed.
- Not run: TypeScript/build checks because this worktree does not have local dependencies installed (`node_modules/.bin` missing / `tsc` unavailable).