### PR TITLE
add a utility function reverseString that reverses a string, with te…

### DIFF
--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+
+import { reverseString } from "@/lib/utils"
+
+describe("reverseString", () => {
+  it("reverses a string", () => {
+    expect(reverseString("hello")).toBe("olleh")
+  })
+
+  it("returns an empty string for empty input", () => {
+    expect(reverseString("")).toBe("")
+  })
+
+  it("preserves whitespace while reversing", () => {
+    expect(reverseString("abc def")).toBe("fed cba")
+  })
+
+  it("keeps surrogate pairs intact", () => {
+    expect(reverseString("a🙂b")).toBe("b🙂a")
+  })
+})

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -16,6 +16,10 @@ export function slugify(text: string): string {
     .trim()
 }
 
+export function reverseString(text: string): string {
+  return Array.from(text).reverse().join("")
+}
+
 // Date formatting utilities for Japanese locale
 export function formatDate(date: string | Date, options?: Intl.DateTimeFormatOptions): string {
   const dateObj = typeof date === "string" ? new Date(date) : date


### PR DESCRIPTION
自動生成 (Hermes + Codex)

## 依頼
add a utility function reverseString that reverses a string, with tests

## Codexの作業
Implemented `reverseString` in [lib/utils.ts](/Users/nishimuratomooakira/.hermes/worktrees/fun-base-20260616-171828/lib/utils.ts:19), using `Array.from` so surrogate pairs like emoji stay intact.

Added focused Vitest coverage in [lib/utils.test.ts](/Users/nishimuratomooakira/.hermes/worktrees/fun-base-20260616-171828/lib/utils.test.ts:1) for normal strings, empty input, whitespace, and emoji.

Validation:
- `git diff --check` passed.
- `npm test -- lib/utils.test.ts` could not run because dependencies are not installed: `vitest: command not found`.
- `pnpm install --offline` also could not complete because the pnpm store is missing `@hookform/resolvers@3.10.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for string utilities, including edge cases for empty strings, whitespace preservation, and special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->