### PR TITLE
文字列を大文字にする関数を追加して

### DIFF
--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict"
+import { test } from "vitest"
+
+import { toUpperCaseString } from "@/lib/utils"
+
+test("toUpperCaseString converts alphabetic characters to uppercase", () => {
+  assert.equal(toUpperCaseString("funbase"), "FUNBASE")
+  assert.equal(toUpperCaseString("FunBase 123"), "FUNBASE 123")
+})
+
+test("toUpperCaseString preserves non-alphabetic and already uppercase characters", () => {
+  assert.equal(toUpperCaseString("ＦｕｎＢａｓｅ-日本語"), "ＦＵＮＢＡＳＥ-日本語")
+  assert.equal(toUpperCaseString(""), "")
+})

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -16,6 +16,10 @@ export function slugify(text: string): string {
     .trim()
 }
 
+export function toUpperCaseString(text: string): string {
+  return text.toUpperCase()
+}
+
 // Date formatting utilities for Japanese locale
 export function formatDate(date: string | Date, options?: Intl.DateTimeFormatOptions): string {
   const dateObj = typeof date === "string" ? new Date(date) : date


### PR DESCRIPTION
自動生成 (Hermes + Codex)

## 依頼
文字列を大文字にする関数を追加して

## Codexの作業
追加しました。

[lib/utils.ts](/Users/nishimuratomooakira/.hermes/worktrees/fun-base-20260616-172628/lib/utils.ts:19) に `toUpperCaseString(text: string): string` を追加し、[lib/utils.test.ts](/Users/nishimuratomooakira/.hermes/worktrees/fun-base-20260616-172628/lib/utils.test.ts:1) に基本ケースのテストを追加しています。

検証は実行しましたが、このワークツリーに `node_modules` が無いため失敗しました。

- `npm test -- lib/utils.test.ts`: `vitest/config` が見つからず失敗
- `npm run typecheck`: React/Vitest など依存型が見つからず失敗
- `pnpm install --offline --frozen-lockfile`: ローカルストアに `@hookform/resolvers` が無く失敗

依存関係が入れば `npm test -- lib/utils.test.ts` で確認できます。