### PR TITLE
[codex] Remove tenant member limit copy

### DIFF
--- a/app/admin/tenants/page.tsx
+++ b/app/admin/tenants/page.tsx
@@ -274,9 +274,6 @@ export default function AdminTenantsPage() {
                          userRole === 'member' ? 'メンバー' : 'ゲスト'}
                       </Badge>
                     </div>
-                    <div className="text-sm text-muted-foreground">
-                      {tenant.max_members}人まで
-                    </div>
                   </div>
 
                   <Button 

--- a/components/tenant/tenant-members-section.tsx
+++ b/components/tenant/tenant-members-section.tsx
@@ -103,7 +103,7 @@ export function TenantMembersSection({ tenantId, currentUserRole }: TenantMember
             <div>
               <CardTitle>チームメンバー</CardTitle>
               <CardDescription>
-                {activeMembers.length} of {activeMembers.length} seats used. (10 max)
+                {activeMembers.length}名が所属中
               </CardDescription>
             </div>
             {canManageMembers && (


### PR DESCRIPTION
## Summary
- Remove the tenant card text that displayed a member upper limit.
- Replace the team member seat-limit copy with a simple active-member count.

## Why
The app does not enforce a 10-member tenant-membership limit, so the UI should not imply a cap.

## Validation
- Searched for remaining 10-member/seat-limit copy in app, components, lib, tenant-management, and supabase paths.
- `npx tsc --noEmit` could not run because this checkout does not have `node_modules/.bin/tsc` installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed maximum member capacity text from tenant cards in the admin tenant listing view
  * Updated Team Members card to display only the count of active members in Japanese format, replacing the previous 'seats used / maximum' information display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->