### PR TITLE
[codex] Add tenant feature permissions

### DIFF
--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/lib/supabase/server"
 import { createAdminClient } from "@/lib/supabase/client"
+import { TENANT_INVITABLE_ROLES } from "@/lib/tenant-access"
 
 export async function POST(request: NextRequest) {
   try {
@@ -20,6 +21,13 @@ export async function POST(request: NextRequest) {
     if (!email || !password || !tenantId || !role) {
       return NextResponse.json(
         { error: "Email, password, tenantId, and role are required" },
+        { status: 400 }
+      )
+    }
+
+    if (typeof role !== "string" || !TENANT_INVITABLE_ROLES.includes(role as any)) {
+      return NextResponse.json(
+        { error: "Invalid role" },
         { status: 400 }
       )
     }
@@ -95,7 +103,7 @@ export async function POST(request: NextRequest) {
         user_id: newUser.user.id,
         tenant_id: tenantId,
         email: email.toLowerCase().trim(),
-        role: role, // 'owner', 'admin', 'member', 'guest'
+        role: role, // 'admin', 'member', 'guest'
         status: 'active',
         joined_at: new Date().toISOString()
       })
@@ -128,4 +136,3 @@ export async function POST(request: NextRequest) {
     )
   }
 }
-

--- a/app/api/funedu/sso/start/route.ts
+++ b/app/api/funedu/sso/start/route.ts
@@ -7,6 +7,7 @@ import {
   getSafeFunEduNextPath,
   signFunEduSsoToken,
 } from "@/lib/funedu-sso"
+import { hasAnyTenantFeatureAccess } from "@/lib/tenant-access"
 
 export async function GET(request: NextRequest) {
   const funEduBaseUrl = getFunEduBaseUrl()
@@ -37,6 +38,27 @@ export async function GET(request: NextRequest) {
     loginUrl.search = ""
     loginUrl.searchParams.set("next", `${request.nextUrl.pathname}${request.nextUrl.search}`)
     return NextResponse.redirect(loginUrl)
+  }
+
+  const { data: memberships, error: membershipsError } = await supabase
+    .from("user_tenants")
+    .select("role, status, feature_permissions")
+    .eq("user_id", user.id)
+    .eq("status", "active")
+
+  if (membershipsError) {
+    console.error("Error checking FunEdu feature access:", membershipsError)
+    return NextResponse.json(
+      { error: "Failed to verify FunEdu access" },
+      { status: 500 },
+    )
+  }
+
+  if (!hasAnyTenantFeatureAccess(memberships || [], "funedu")) {
+    return NextResponse.json(
+      { error: "FunEdu access is not allowed for this account" },
+      { status: 403 },
+    )
   }
 
   const nextPath = getSafeFunEduNextPath(request.nextUrl.searchParams.get("next"))

--- a/app/api/people/[id]/documents/[documentId]/route.ts
+++ b/app/api/people/[id]/documents/[documentId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { revalidatePath } from 'next/cache'
 import { createClient } from '@/lib/supabase/server'
+import { getAccessiblePersonIdsForCurrentUser } from '@/lib/supabase/people-access'
 import { deleteFileFromStorage } from '@/lib/storage/file-uploader'
 import { normalizeDocumentNote } from '@/lib/document-notes'
 
@@ -32,6 +33,14 @@ export async function PATCH(
     }
 
     const supabase = await createClient()
+    const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'documents')
+
+    if (!accessiblePersonIds.includes(personId)) {
+      return NextResponse.json(
+        { error: 'Document not found' },
+        { status: 404 }
+      )
+    }
 
     const { data: document, error: fetchError } = await supabase
       .from('person_documents')
@@ -133,6 +142,14 @@ export async function DELETE(
     }
 
     const supabase = await createClient()
+    const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'documents')
+
+    if (!accessiblePersonIds.includes(personId)) {
+      return NextResponse.json(
+        { error: 'Document not found' },
+        { status: 404 }
+      )
+    }
 
     // Query the document and validate it belongs to the person
     const { data: document, error: fetchError } = await supabase

--- a/app/api/people/[id]/documents/route.ts
+++ b/app/api/people/[id]/documents/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { revalidatePath } from 'next/cache'
 import { createClient } from '@/lib/supabase/server'
+import { getAccessiblePersonIdsForCurrentUser } from '@/lib/supabase/people-access'
 import { uploadFileToStorage, generateFilePath, deleteFileFromStorage } from '@/lib/storage/file-uploader'
 import { normalizeDocumentNote, resolveReplacementDocumentNote } from '@/lib/document-notes'
 
@@ -36,6 +37,14 @@ export async function GET(
     }
 
     const supabase = await createClient()
+    const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'documents')
+
+    if (!accessiblePersonIds.includes(personId)) {
+      return NextResponse.json(
+        { error: 'Person not found' },
+        { status: 404 }
+      )
+    }
 
     const { data, error } = await supabase
       .from('person_documents')
@@ -132,6 +141,14 @@ export async function POST(
     }
 
     const supabase = await createClient()
+    const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'documents')
+
+    if (!accessiblePersonIds.includes(personId)) {
+      return NextResponse.json(
+        { error: 'Person not found' },
+        { status: 404 }
+      )
+    }
 
     // Get authenticated user
     const { data: { user }, error: authError } = await supabase.auth.getUser()

--- a/app/api/people/[id]/route.ts
+++ b/app/api/people/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { revalidatePath } from 'next/cache'
 import { createClient } from '@/lib/supabase/server'
 import type { Person } from '@/lib/models'
+import { getAccessiblePersonIdsForCurrentUser } from '@/lib/supabase/people-access'
 
 export async function PUT(
   request: NextRequest,
@@ -44,6 +45,14 @@ export async function PUT(
 
     // サーバー側のSupabaseクライアントを使用
     const supabase = await createClient()
+    const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase)
+
+    if (!accessiblePersonIds.includes(id)) {
+      return NextResponse.json(
+        { error: 'Person not found' },
+        { status: 404 }
+      )
+    }
 
     // 更新対象のフィールドを構築
     const updateFields: Record<string, any> = {
@@ -156,4 +165,3 @@ export async function PUT(
     )
   }
 }
-

--- a/app/api/tenants/[tenantId]/invite-links/route.ts
+++ b/app/api/tenants/[tenantId]/invite-links/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/lib/supabase/server"
 import { createAdminClient } from "@/lib/supabase/client"
-import { canManageTenant } from "@/lib/tenant-access"
+import { canManageTenant, TENANT_INVITABLE_ROLES } from "@/lib/tenant-access"
 
 export async function POST(
   request: NextRequest,
@@ -35,7 +35,7 @@ export async function POST(
     const body = await request.json()
     const { defaultRole = "member", expiresInDays } = body
 
-    if (!["admin", "member", "guest"].includes(defaultRole)) {
+    if (!TENANT_INVITABLE_ROLES.includes(defaultRole)) {
       return NextResponse.json({ error: "Invalid role" }, { status: 400 })
     }
 

--- a/app/api/tenants/[tenantId]/members/[memberId]/route.ts
+++ b/app/api/tenants/[tenantId]/members/[memberId]/route.ts
@@ -4,10 +4,12 @@ import {
   canManageTenant,
   getTenantMemberRemovalError,
   getTenantMemberRoleUpdateError,
+  TENANT_MANAGEABLE_ROLES,
+  TENANT_FEATURE_PERMISSION_KEYS,
+  type TenantFeaturePermissions,
 } from "@/lib/tenant-access"
 
-const MANAGEABLE_ROLES = ["owner", "admin", "member", "guest"] as const
-type ManageableRole = (typeof MANAGEABLE_ROLES)[number]
+type ManageableRole = (typeof TENANT_MANAGEABLE_ROLES)[number]
 
 function normalizeOfficeIds(value: unknown): string[] | null {
   if (typeof value === "undefined") {
@@ -26,6 +28,28 @@ function normalizeOfficeIds(value: unknown): string[] | null {
   return Array.from(new Set(normalizedIds))
 }
 
+function normalizeFeaturePermissions(value: unknown): TenantFeaturePermissions | null {
+  if (typeof value === "undefined") {
+    return null
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null
+  }
+
+  const input = value as Record<string, unknown>
+  const permissions: TenantFeaturePermissions = {}
+
+  for (const key of TENANT_FEATURE_PERMISSION_KEYS) {
+    const permissionValue = input[key]
+    if (typeof permissionValue === "boolean") {
+      permissions[key] = permissionValue
+    }
+  }
+
+  return permissions
+}
+
 export async function PATCH(
   request: NextRequest,
   { params }: { params: { tenantId: string; memberId: string } }
@@ -41,17 +65,19 @@ export async function PATCH(
     const body = await request.json()
     const { role } = body
     const officeIds = normalizeOfficeIds(body.officeIds)
+    const featurePermissions = normalizeFeaturePermissions(body.featurePermissions)
     const hasRoleUpdate = typeof role !== "undefined"
     const hasOfficeUpdate = typeof body.officeIds !== "undefined"
+    const hasFeaturePermissionsUpdate = typeof body.featurePermissions !== "undefined"
 
-    if (!hasRoleUpdate && !hasOfficeUpdate) {
+    if (!hasRoleUpdate && !hasOfficeUpdate && !hasFeaturePermissionsUpdate) {
       return NextResponse.json(
-        { error: "Role or officeIds is required" },
+        { error: "Role, officeIds, or featurePermissions is required" },
         { status: 400 }
       )
     }
 
-    if (hasRoleUpdate && (typeof role !== "string" || !MANAGEABLE_ROLES.includes(role as ManageableRole))) {
+    if (hasRoleUpdate && (typeof role !== "string" || !TENANT_MANAGEABLE_ROLES.includes(role as ManageableRole))) {
       return NextResponse.json(
         { error: "Invalid role" },
         { status: 400 }
@@ -61,6 +87,13 @@ export async function PATCH(
     if (hasOfficeUpdate && officeIds === null) {
       return NextResponse.json(
         { error: "Invalid officeIds" },
+        { status: 400 }
+      )
+    }
+
+    if (hasFeaturePermissionsUpdate && featurePermissions === null) {
+      return NextResponse.json(
+        { error: "Invalid featurePermissions" },
         { status: 400 }
       )
     }
@@ -144,6 +177,13 @@ export async function PATCH(
       )
     }
 
+    if (hasFeaturePermissionsUpdate && !canManageTenant(memberships)) {
+      return NextResponse.json(
+        { error: "機能権限を変更する権限がありません" },
+        { status: 403 }
+      )
+    }
+
     if (hasRoleUpdate) {
       const { error: updateError } = await supabase
         .from("user_tenants")
@@ -155,6 +195,22 @@ export async function PATCH(
         console.error("Error updating member role:", updateError)
         return NextResponse.json(
           { error: "Failed to update member role" },
+          { status: 500 }
+        )
+      }
+    }
+
+    if (hasFeaturePermissionsUpdate) {
+      const { error: updateError } = await supabase
+        .from("user_tenants")
+        .update({ feature_permissions: featurePermissions })
+        .eq("id", params.memberId)
+        .eq("tenant_id", params.tenantId)
+
+      if (updateError) {
+        console.error("Error updating feature permissions:", updateError)
+        return NextResponse.json(
+          { error: "Failed to update feature permissions" },
           { status: 500 }
         )
       }

--- a/app/api/tenants/[tenantId]/members/add/route.ts
+++ b/app/api/tenants/[tenantId]/members/add/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/lib/supabase/server"
 import { createAdminClient } from "@/lib/supabase/client"
-import { canManageTenant } from "@/lib/tenant-access"
+import { canManageTenant, TENANT_INVITABLE_ROLES } from "@/lib/tenant-access"
 
 function normalizeOfficeIds(value: unknown): string[] {
   if (!Array.isArray(value)) {
@@ -74,6 +74,13 @@ export async function POST(
     if (!userId || !role) {
       return NextResponse.json(
         { error: "UserId and role are required" },
+        { status: 400 }
+      )
+    }
+
+    if (typeof role !== "string" || !TENANT_INVITABLE_ROLES.includes(role as any)) {
+      return NextResponse.json(
+        { error: "Invalid role" },
         { status: 400 }
       )
     }

--- a/app/api/tenants/[tenantId]/members/invite/route.ts
+++ b/app/api/tenants/[tenantId]/members/invite/route.ts
@@ -2,9 +2,12 @@ import { NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/lib/supabase/server"
 import { createAdminClient } from "@/lib/supabase/client"
 import { getInviteRedirectUrl } from "@/lib/supabase/invite-redirect"
-import { canManageTenant } from "@/lib/tenant-access"
+import {
+  canManageTenant,
+  TENANT_INVITABLE_ROLES,
+} from "@/lib/tenant-access"
 
-const INVITABLE_ROLES = new Set(["admin", "member", "guest"])
+const INVITABLE_ROLES = new Set(TENANT_INVITABLE_ROLES)
 
 function normalizeOfficeIds(value: unknown): string[] {
   if (!Array.isArray(value)) {

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -27,6 +27,8 @@ import {
   markAllAnnouncementsAsRead,
 } from "@/lib/supabase/announcements"
 import { getPeople } from "@/lib/supabase/people"
+import { getCurrentUserTenants } from "@/lib/supabase/tenants"
+import { hasAnyTenantFeatureAccess } from "@/lib/tenant-access"
 import { matchesPersonSearch, normalizePersonSearchText as normalizeSearchText } from "@/lib/person-search"
 import type { Announcement, Person } from "@/lib/models"
 
@@ -57,6 +59,7 @@ export function Header() {
   const { startNavigation } = useNavigationProgress()
   const [searchQuery, setSearchQuery] = useState("")
   const [people, setPeople] = useState<Person[]>([])
+  const [canViewPeopleData, setCanViewPeopleData] = useState(true)
   const [searchOpen, setSearchOpen] = useState(false)
   const [searchHistory, setSearchHistory] = useState<SearchHistoryItem[]>([])
   const [announcements, setAnnouncements] = useState<Announcement[]>([])
@@ -108,9 +111,22 @@ export function Header() {
 
     let cancelled = false
 
-    getPeople()
-      .then((items) => {
-        if (!cancelled) setPeople(items)
+    getCurrentUserTenants()
+      .then(async (memberships) => {
+        if (cancelled) return
+
+        const canView = hasAnyTenantFeatureAccess(memberships, "people")
+        setCanViewPeopleData(canView)
+
+        if (!canView) {
+          setPeople([])
+          return
+        }
+
+        const items = await getPeople()
+        if (!cancelled) {
+          setPeople(items)
+        }
       })
       .catch((err) => {
         console.debug("Failed to load search suggestions:", err)
@@ -130,6 +146,7 @@ export function Header() {
         target?.isContentEditable
 
       if (event.key === "/" && !isTyping) {
+        if (!canViewPeopleData) return
         event.preventDefault()
         document.getElementById("global-search-input")?.focus()
         setSearchOpen(true)
@@ -138,7 +155,7 @@ export function Header() {
 
     window.addEventListener("keydown", handleKeyDown)
     return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [])
+  }, [canViewPeopleData])
 
   const searchText = normalizeSearchText(searchQuery)
 
@@ -323,6 +340,7 @@ export function Header() {
     <header className="flex h-14 items-center justify-between border-b border-border bg-card px-4 md:px-6">
       {/* Search and Company Switcher */}
       <div className="flex items-center gap-4 flex-1">
+        {canViewPeopleData ? (
         <div className="relative max-w-md">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
@@ -466,6 +484,7 @@ export function Header() {
             </div>
           )}
         </div>
+        ) : null}
 
       </div>
 

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -1,12 +1,26 @@
 "use client"
 
+import { useEffect, useState } from "react"
 import Link from "next/link"
 import Image from "next/image"
 import { usePathname } from "next/navigation"
+import { Calendar, CheckSquare, Clock, ExternalLink, FileText, FolderOpen, Home, Users, type LucideIcon } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { Calendar, CheckSquare, Clock, Home, Users, FileText, FolderOpen, ExternalLink } from "lucide-react"
+import { getCurrentUserTenants } from "@/lib/supabase/tenants"
+import {
+  hasAnyTenantFeatureAccess,
+  type TenantFeaturePermission,
+  type TenantRoleMembership,
+} from "@/lib/tenant-access"
 
-const navigation = [
+type NavigationItem = {
+  name: string
+  href: string
+  icon: LucideIcon
+  feature?: TenantFeaturePermission
+}
+
+const navigation: NavigationItem[] = [
   {
     name: "ホーム",
     href: "/dashboard",
@@ -16,50 +30,77 @@ const navigation = [
     name: "人材一覧",
     href: "/people",
     icon: Users,
+    feature: "people",
   },
   {
     name: "ビザ進捗管理",
     href: "/visas",
     icon: FileText,
+    feature: "visas",
   },
   {
     name: "面談一覧",
     href: "/meetings",
     icon: Calendar,
+    feature: "meetings",
   },
   {
     name: "サポート記録",
     href: "/support",
     icon: CheckSquare,
+    feature: "support_actions",
   },
   {
     name: "タイムライン",
     href: "/timeline",
     icon: Clock,
+    feature: "support_actions",
   },
   {
     name: "書類管理",
     href: "/documents",
     icon: FolderOpen,
+    feature: "documents",
   },
 ]
 
 export function Sidebar() {
   const pathname = usePathname()
+  const [memberships, setMemberships] = useState<TenantRoleMembership[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+
+    getCurrentUserTenants()
+      .then((currentMemberships) => {
+        if (cancelled) return
+        setMemberships(currentMemberships)
+      })
+      .catch((error) => {
+        console.debug("Failed to load sidebar feature scope:", error)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const visibleNavigation = navigation.filter(
+    (item) => !item.feature || hasAnyTenantFeatureAccess(memberships, item.feature)
+  )
+  const canOpenFunEdu = hasAnyTenantFeatureAccess(memberships, "funedu")
 
   return (
     <div className="flex h-full w-60 shrink-0 flex-col bg-sidebar border-r border-sidebar-border">
-      {/* Logo */}
       <div className="flex h-14 items-center px-4">
         <div className="flex items-center gap-2">
           <Image src="/funstudio-logo.webp" alt="FunBase" width={120} height={32} className="h-8 w-auto" />
         </div>
       </div>
 
-      {/* Navigation */}
       <nav className="flex-1 px-3 pt-2">
         <ul className="space-y-1">
-          {navigation.map((item) => {
+          {visibleNavigation.map((item) => {
             const isActive = pathname === item.href || pathname.startsWith(item.href + "/")
             return (
               <li key={item.name}>
@@ -81,27 +122,28 @@ export function Sidebar() {
         </ul>
       </nav>
 
-      {/* Footer */}
       <div className="border-t border-sidebar-border p-4">
-        <a
-          href="/api/funedu/sso/start"
-          target="_blank"
-          rel="noreferrer"
-          className="mb-3 flex items-center gap-3 rounded-lg border border-sidebar-border bg-background px-3 py-2.5 text-sm transition-colors hover:bg-muted"
-        >
-          <Image
-            src="/funedu_logo_symbol.svg"
-            alt=""
-            width={32}
-            height={32}
-            className="h-8 w-8 shrink-0 rounded-md object-contain"
-          />
-          <span className="min-w-0 flex-1">
-            <span className="block font-medium leading-5">FunEdu</span>
-            <span className="block truncate text-xs text-muted-foreground">ログイン連携で開く</span>
-          </span>
-          <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground" />
-        </a>
+        {canOpenFunEdu && (
+          <a
+            href="/api/funedu/sso/start"
+            target="_blank"
+            rel="noreferrer"
+            className="mb-3 flex items-center gap-3 rounded-lg border border-sidebar-border bg-background px-3 py-2.5 text-sm transition-colors hover:bg-muted"
+          >
+            <Image
+              src="/funedu_logo_symbol.svg"
+              alt=""
+              width={32}
+              height={32}
+              className="h-8 w-8 shrink-0 rounded-md object-contain"
+            />
+            <span className="min-w-0 flex-1">
+              <span className="block font-medium leading-5">FunEdu</span>
+              <span className="block truncate text-xs text-muted-foreground">ログイン連携で開く</span>
+            </span>
+            <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground" />
+          </a>
+        )}
         <div className="text-xs text-muted-foreground">FunBase v1.0</div>
       </div>
     </div>

--- a/components/tenant/add-existing-member-dialog.tsx
+++ b/components/tenant/add-existing-member-dialog.tsx
@@ -19,6 +19,8 @@ import { CheckCircle, Search, Loader2 } from "lucide-react"
 import { useToast } from "@/lib/hooks/use-toast"
 import type { TenantOffice } from "@/lib/supabase/tenants"
 
+type InvitableRole = 'admin' | 'member' | 'guest'
+
 interface AddExistingMemberDialogProps {
   tenantId: string
   open: boolean
@@ -45,7 +47,7 @@ export function AddExistingMemberDialog({
   const [searchQuery, setSearchQuery] = useState("")
   const [searchResults, setSearchResults] = useState<SearchUser[]>([])
   const [selectedUser, setSelectedUser] = useState<SearchUser | null>(null)
-  const [role, setRole] = useState<'admin' | 'member' | 'guest'>('member')
+  const [role, setRole] = useState<InvitableRole>('member')
   const [selectedOfficeIds, setSelectedOfficeIds] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
   const [searching, setSearching] = useState(false)
@@ -280,7 +282,7 @@ export function AddExistingMemberDialog({
             {selectedUser && (
               <div className="grid gap-2">
                 <Label htmlFor="role">ロール</Label>
-                <Select value={role} onValueChange={(value: 'admin' | 'member' | 'guest') => setRole(value)}>
+                <Select value={role} onValueChange={(value: InvitableRole) => setRole(value)}>
                   <SelectTrigger>
                     <SelectValue />
                   </SelectTrigger>

--- a/components/tenant/create-user-dialog.tsx
+++ b/components/tenant/create-user-dialog.tsx
@@ -16,6 +16,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useToast } from "@/lib/hooks/use-toast"
 import { Eye, EyeOff } from "lucide-react"
 
+type InvitableRole = 'admin' | 'member' | 'guest'
+
 interface CreateUserDialogProps {
   tenantId: string
   open: boolean
@@ -32,7 +34,7 @@ export function CreateUserDialog({
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
-  const [role, setRole] = useState<'admin' | 'member' | 'guest'>('member')
+  const [role, setRole] = useState<InvitableRole>('member')
   const [showPassword, setShowPassword] = useState(false)
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
   const [errors, setErrors] = useState<Record<string, string>>({})
@@ -205,7 +207,7 @@ export function CreateUserDialog({
 
             <div className="grid gap-2">
               <Label htmlFor="role">ロール</Label>
-              <Select value={role} onValueChange={(value: 'admin' | 'member' | 'guest') => setRole(value)}>
+              <Select value={role} onValueChange={(value: InvitableRole) => setRole(value)}>
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
@@ -230,4 +232,3 @@ export function CreateUserDialog({
     </Dialog>
   )
 }
-

--- a/components/tenant/invite-link-dialog.tsx
+++ b/components/tenant/invite-link-dialog.tsx
@@ -23,8 +23,21 @@ interface InviteLinkDialogProps {
   onOpenChange: (open: boolean) => void
 }
 
+type InvitableRole = 'admin' | 'member' | 'guest'
+
+function getRoleLabel(role: InvitableRole) {
+  switch (role) {
+    case 'admin':
+      return 'Admin'
+    case 'member':
+      return 'Member'
+    case 'guest':
+      return 'Guest'
+  }
+}
+
 export function InviteLinkDialog({ tenantId, open, onOpenChange }: InviteLinkDialogProps) {
-  const [defaultRole, setDefaultRole] = useState<'admin' | 'member' | 'guest'>('member')
+  const [defaultRole, setDefaultRole] = useState<InvitableRole>('member')
   const [hasExpiration, setHasExpiration] = useState(false)
   const [expirationDays, setExpirationDays] = useState(7)
   const [generatedLink, setGeneratedLink] = useState("")
@@ -108,7 +121,7 @@ export function InviteLinkDialog({ tenantId, open, onOpenChange }: InviteLinkDia
 
             <div className="grid gap-2">
               <Label htmlFor="defaultRole">デフォルトロール</Label>
-              <Select value={defaultRole} onValueChange={(value: 'admin' | 'member' | 'guest') => setDefaultRole(value)}>
+              <Select value={defaultRole} onValueChange={(value: InvitableRole) => setDefaultRole(value)}>
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
@@ -174,7 +187,7 @@ export function InviteLinkDialog({ tenantId, open, onOpenChange }: InviteLinkDia
             <div className="rounded-lg bg-muted p-3">
               <h4 className="font-medium text-sm mb-2">リンクの詳細</h4>
               <div className="space-y-1 text-sm text-muted-foreground">
-                <p>デフォルトロール: {defaultRole === 'admin' ? 'Admin' : defaultRole === 'member' ? 'Member' : 'Guest'}</p>
+                <p>デフォルトロール: {getRoleLabel(defaultRole)}</p>
                 {hasExpiration && <p>有効期限: {expirationDays}日</p>}
               </div>
             </div>

--- a/components/tenant/invite-member-dialog.tsx
+++ b/components/tenant/invite-member-dialog.tsx
@@ -17,6 +17,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useToast } from "@/lib/hooks/use-toast"
 import type { TenantOffice } from "@/lib/supabase/tenants"
 
+type InvitableRole = 'admin' | 'member' | 'guest'
+
 interface InviteMemberDialogProps {
   tenantId: string
   open: boolean
@@ -42,7 +44,7 @@ export function InviteMemberDialog({
 }: InviteMemberDialogProps) {
   const [name, setName] = useState("")
   const [email, setEmail] = useState("")
-  const [role, setRole] = useState<'admin' | 'member' | 'guest'>('member')
+  const [role, setRole] = useState<InvitableRole>('member')
   const [selectedOfficeIds, setSelectedOfficeIds] = useState<string[]>([])
   const [errors, setErrors] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(false)
@@ -179,7 +181,7 @@ export function InviteMemberDialog({
             {canChooseRole ? (
               <div className="grid gap-2">
                 <Label htmlFor="role">ロール</Label>
-                <Select value={role} onValueChange={(value: 'admin' | 'member' | 'guest') => setRole(value)}>
+                <Select value={role} onValueChange={(value: InvitableRole) => setRole(value)}>
                   <SelectTrigger>
                     <SelectValue />
                   </SelectTrigger>

--- a/components/tenant/members-table.tsx
+++ b/components/tenant/members-table.tsx
@@ -16,21 +16,39 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { RoleBadge } from "./role-badge"
 import { StatusBadge } from "./status-badge"
 import type { UserTenant } from "@/lib/supabase/tenants"
+import {
+  normalizeTenantFeaturePermissions,
+  TENANT_FEATURE_PERMISSION_KEYS,
+  TENANT_FEATURE_PERMISSION_LABELS,
+  type TenantFeaturePermission,
+  type TenantFeaturePermissions,
+} from "@/lib/tenant-access"
 
-type DisplayRole = 'owner' | 'admin' | 'member' | 'guest'
+type DisplayRole = "owner" | "admin" | "member" | "guest"
+const ROLE_OPTIONS: Array<{ value: DisplayRole; label: string }> = [
+  { value: "owner", label: "オーナー" },
+  { value: "admin", label: "管理者" },
+  { value: "member", label: "メンバー" },
+  { value: "guest", label: "ゲスト" },
+]
 
 interface MembersTableProps {
   members: UserTenant[]
   selectedMembers: string[]
   onSelectMember: (memberId: string, selected: boolean) => void
   onSelectAll: (memberIds: string[], selected: boolean) => void
-  onChangeRole: (memberId: string, role: 'owner' | 'admin' | 'member' | 'guest') => void
+  onChangeRole: (memberId: string, role: DisplayRole) => void
+  onChangeFeaturePermissions: (memberId: string, permissions: TenantFeaturePermissions) => void
   onDeleteMember: (memberId: string) => void
   onEditOffices?: (member: UserTenant) => void
   onResendInvite?: (memberId: string) => void
   onReinviteMember?: (member: UserTenant) => void
-  currentUserRole: 'owner' | 'admin' | 'member' | 'guest'
+  currentUserRole: DisplayRole
   currentUserId?: string
+}
+
+function isManagerRole(role: UserTenant["role"] | DisplayRole): boolean {
+  return role === "owner" || role === "admin"
 }
 
 export function MembersTable({
@@ -39,6 +57,7 @@ export function MembersTable({
   onSelectMember,
   onSelectAll,
   onChangeRole,
+  onChangeFeaturePermissions,
   onDeleteMember,
   onEditOffices,
   onResendInvite,
@@ -46,8 +65,7 @@ export function MembersTable({
   currentUserRole,
   currentUserId,
 }: MembersTableProps) {
-  const canBulkDeleteMembers =
-    currentUserRole === "owner" || currentUserRole === "admin"
+  const canBulkDeleteMembers = isManagerRole(currentUserRole)
 
   const formatLastActive = (joinedAt?: string) => {
     if (!joinedAt) return "-"
@@ -62,35 +80,32 @@ export function MembersTable({
   const getDisplayRole = (role: UserTenant["role"]): DisplayRole =>
     role === "supporter" ? "member" : role
 
-  // Permission checks
   const canChangeRole = (targetMember: UserTenant) => {
-    if (currentUserRole === 'guest' || currentUserRole === 'member') return false
-    if (targetMember.user_id === currentUserId) return false // Can't change own role
-    if (targetMember.role === 'owner' && currentUserRole !== 'owner') return false
+    if (!isManagerRole(currentUserRole)) return false
+    if (targetMember.user_id === currentUserId) return false
+    if (targetMember.role === "owner" && currentUserRole !== "owner") return false
     return true
   }
 
+  const canChangeFeaturePermissions = (targetMember: UserTenant) =>
+    isManagerRole(currentUserRole) &&
+    targetMember.user_id !== currentUserId &&
+    targetMember.role !== "owner" &&
+    targetMember.role !== "admin"
+
   const canDeleteMember = (targetMember: UserTenant) => {
     if (targetMember.user_id === currentUserId) return false
-
-    if (currentUserRole === "owner" || currentUserRole === "admin") {
+    if (isManagerRole(currentUserRole)) {
       return targetMember.role !== "owner"
     }
-
     return false
   }
 
-  const canResendInvite = (targetMember: UserTenant) => {
-    if (!onResendInvite || targetMember.status !== "pending" || !targetMember.email) {
-      return false
-    }
-
-    if (currentUserRole === "owner" || currentUserRole === "admin") {
-      return true
-    }
-
-    return false
-  }
+  const canResendInvite = (targetMember: UserTenant) =>
+    Boolean(onResendInvite) &&
+    targetMember.status === "pending" &&
+    Boolean(targetMember.email) &&
+    isManagerRole(currentUserRole)
 
   const canReinviteMember = (targetMember: UserTenant) =>
     Boolean(onReinviteMember) &&
@@ -100,7 +115,7 @@ export function MembersTable({
 
   const canEditOffices = (targetMember: UserTenant) =>
     Boolean(onEditOffices) &&
-    (currentUserRole === "owner" || currentUserRole === "admin") &&
+    isManagerRole(currentUserRole) &&
     targetMember.user_id !== currentUserId
 
   const canSelectMember = (targetMember: UserTenant) =>
@@ -134,9 +149,21 @@ export function MembersTable({
     canEditOffices(targetMember) ||
     (targetMember.status !== "pending" && canDeleteMember(targetMember))
 
-  const handleRoleChange = (member: UserTenant, newRole: 'owner' | 'admin' | 'member' | 'guest') => {
+  const handleRoleChange = (member: UserTenant, newRole: DisplayRole) => {
     if (!canChangeRole(member)) return
     onChangeRole(member.id, newRole)
+  }
+
+  const handleFeaturePermissionChange = (
+    member: UserTenant,
+    feature: TenantFeaturePermission,
+    checked: boolean
+  ) => {
+    if (!canChangeFeaturePermissions(member)) return
+    onChangeFeaturePermissions(member.id, {
+      ...normalizeTenantFeaturePermissions(member.feature_permissions),
+      [feature]: checked,
+    })
   }
 
   const handleDeleteMember = (member: UserTenant) => {
@@ -179,6 +206,7 @@ export function MembersTable({
             ) : null}
             <TableHead>メール</TableHead>
             <TableHead>ロール</TableHead>
+            <TableHead>機能権限</TableHead>
             <TableHead>所属先</TableHead>
             <TableHead>ステータス</TableHead>
             <TableHead>参加日</TableHead>
@@ -188,7 +216,9 @@ export function MembersTable({
         <TableBody>
           {members.map((member) => {
             const isCurrentUser = member.user_id === currentUserId
-            const email = member.email || ''
+            const email = member.email || ""
+            const permissions = normalizeTenantFeaturePermissions(member.feature_permissions)
+            const featurePermissionsLocked = !canChangeFeaturePermissions(member)
 
             return (
               <TableRow key={member.id}>
@@ -222,7 +252,46 @@ export function MembersTable({
                   </div>
                 </TableCell>
                 <TableCell>
-                  <RoleBadge role={getDisplayRole(member.role)} />
+                  <div className="flex items-center gap-2">
+                    <RoleBadge role={getDisplayRole(member.role)} />
+                    {canChangeRole(member) && (
+                      <select
+                        aria-label={`${email}のロールを変更`}
+                        value={getDisplayRole(member.role)}
+                        onChange={(event) =>
+                          handleRoleChange(member, event.target.value as DisplayRole)
+                        }
+                        className="h-7 rounded-md border border-input bg-background px-2 text-xs shadow-sm transition-colors hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                      >
+                        {ROLE_OPTIONS.map((roleOption) => (
+                          <option key={roleOption.value} value={roleOption.value}>
+                            {roleOption.label}
+                          </option>
+                        ))}
+                      </select>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex max-w-[30rem] flex-wrap gap-x-3 gap-y-2">
+                    {isManagerRole(member.role) ? (
+                      <Badge variant="secondary">全機能</Badge>
+                    ) : (
+                      TENANT_FEATURE_PERMISSION_KEYS.map((feature) => (
+                        <label key={feature} className="flex items-center gap-1.5 text-xs">
+                          <Checkbox
+                            checked={permissions[feature] !== false}
+                            disabled={featurePermissionsLocked}
+                            onCheckedChange={(checked) =>
+                              handleFeaturePermissionChange(member, feature, checked === true)
+                            }
+                            aria-label={`${email}の${TENANT_FEATURE_PERMISSION_LABELS[feature]}権限`}
+                          />
+                          <span>{TENANT_FEATURE_PERMISSION_LABELS[feature]}</span>
+                        </label>
+                      ))
+                    )}
+                  </div>
                 </TableCell>
                 <TableCell>
                   <div className="flex items-center gap-2">
@@ -312,31 +381,23 @@ export function MembersTable({
                         <DropdownMenuContent align="end">
                           {canChangeRole(member) && (
                             <>
-                              {member.role !== 'owner' && (
-                                <DropdownMenuItem
-                                  onClick={() => handleRoleChange(member, 'owner')}
-                                >
+                              {member.role !== "owner" && (
+                                <DropdownMenuItem onClick={() => handleRoleChange(member, "owner")}>
                                   Ownerに変更
                                 </DropdownMenuItem>
                               )}
-                              {member.role !== 'admin' && (
-                                <DropdownMenuItem
-                                  onClick={() => handleRoleChange(member, 'admin')}
-                                >
+                              {member.role !== "admin" && (
+                                <DropdownMenuItem onClick={() => handleRoleChange(member, "admin")}>
                                   Adminに変更
                                 </DropdownMenuItem>
                               )}
-                              {member.role !== 'member' && (
-                                <DropdownMenuItem
-                                  onClick={() => handleRoleChange(member, 'member')}
-                                >
+                              {member.role !== "member" && (
+                                <DropdownMenuItem onClick={() => handleRoleChange(member, "member")}>
                                   Memberに変更
                                 </DropdownMenuItem>
                               )}
-                              {member.role !== 'guest' && (
-                                <DropdownMenuItem
-                                  onClick={() => handleRoleChange(member, 'guest')}
-                                >
+                              {member.role !== "guest" && (
+                                <DropdownMenuItem onClick={() => handleRoleChange(member, "guest")}>
                                   Guestに変更
                                 </DropdownMenuItem>
                               )}

--- a/components/tenant/tenant-members-page.tsx
+++ b/components/tenant/tenant-members-page.tsx
@@ -18,6 +18,7 @@ import {
   getTenantMembers, 
   getTenantOffices,
   resendTenantInvitation,
+  updateUserTenantFeaturePermissions,
   updateUserTenantRole,
   updateUserTenantOffices,
   removeUserFromTenant,
@@ -27,6 +28,7 @@ import {
 import { useAuth } from "@/contexts/auth-context"
 import { useToast } from "@/lib/hooks/use-toast"
 import { canManageCompanyContacts as canManageCompanyContactsForActor } from "@/lib/tenant-access"
+import type { TenantFeaturePermissions } from "@/lib/tenant-access"
 import { TenantMembersLoadingSkeleton } from "@/components/ui/funbase-loading"
 
 interface TenantMembersPageProps {
@@ -154,6 +156,27 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
       await fetchData()
     } catch (error) {
       console.error('Error updating role:', error)
+    }
+  }
+
+  const handleChangeFeaturePermissions = async (
+    memberId: string,
+    permissions: TenantFeaturePermissions
+  ) => {
+    try {
+      await updateUserTenantFeaturePermissions(tenantId, memberId, permissions)
+      await fetchData()
+      toast({
+        title: "完了",
+        description: "機能権限を更新しました",
+      })
+    } catch (error) {
+      console.error('Error updating feature permissions:', error)
+      toast({
+        title: "エラー",
+        description: error instanceof Error ? error.message : "機能権限の更新に失敗しました",
+        variant: "destructive",
+      })
     }
   }
 
@@ -403,6 +426,7 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
               onSelectMember={handleSelectMember}
               onSelectAll={handleSelectAll}
               onChangeRole={handleChangeRole}
+              onChangeFeaturePermissions={handleChangeFeaturePermissions}
               onDeleteMember={showDeleteConfirm}
               onEditOffices={setOfficeEditingMember}
               onResendInvite={handleResendInvite}
@@ -425,6 +449,7 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
               onSelectMember={handleSelectMember}
               onSelectAll={handleSelectAll}
               onChangeRole={handleChangeRole}
+              onChangeFeaturePermissions={handleChangeFeaturePermissions}
               onDeleteMember={showDeleteConfirm}
               onEditOffices={setOfficeEditingMember}
               onResendInvite={handleResendInvite}
@@ -447,6 +472,7 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
               onSelectMember={handleSelectMember}
               onSelectAll={handleSelectAll}
               onChangeRole={handleChangeRole}
+              onChangeFeaturePermissions={handleChangeFeaturePermissions}
               onDeleteMember={showDeleteConfirm}
               onEditOffices={setOfficeEditingMember}
               onResendInvite={handleResendInvite}
@@ -568,6 +594,16 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
                 <li>✓ データの閲覧のみ</li>
                 <li>✗ データの編集不可</li>
                 <li>✗ メンバー管理不可</li>
+              </ul>
+            </div>
+
+            {/* Feature permissions */}
+            <div className="space-y-2 border-t pt-3">
+              <h3 className="font-semibold">機能権限</h3>
+              <ul className="text-sm space-y-1">
+                <li>✓ メンバー・ゲストごとに人材一覧、ビザ、面談、サポート記録、書類、FunEduを個別にON/OFFできます</li>
+                <li>✓ 未設定の機能は既存ユーザー互換のためONとして扱います</li>
+                <li>✗ オーナー・管理者は管理維持のため全機能アクセスです</li>
               </ul>
             </div>
           </div>

--- a/components/tenant/tenant-members-section.tsx
+++ b/components/tenant/tenant-members-section.tsx
@@ -160,7 +160,7 @@ export function TenantMembersSection({ tenantId, currentUserRole }: TenantMember
                         <Badge variant={getRoleBadgeVariant(member.role)}>
                           {member.role === 'owner' ? 'オーナー' : 
                            member.role === 'admin' ? '管理者' :
-                           member.role === 'member' ? 'メンバー' : 'ゲスト'}
+                           member.role === 'member' ? 'メンバー' :'ゲスト'}
                         </Badge>
                       </div>
                     </TableCell>
@@ -247,7 +247,7 @@ export function TenantMembersSection({ tenantId, currentUserRole }: TenantMember
                         <Badge variant={getRoleBadgeVariant(member.role)}>
                           {member.role === 'owner' ? 'オーナー' : 
                            member.role === 'admin' ? '管理者' :
-                           member.role === 'member' ? 'メンバー' : 'ゲスト'}
+                           member.role === 'member' ? 'メンバー' :'ゲスト'}
                         </Badge>
                       </div>
                     </TableCell>

--- a/lib/actions/tenant-actions.ts
+++ b/lib/actions/tenant-actions.ts
@@ -5,6 +5,7 @@ import { createAdminClient } from "@/lib/supabase/client"
 import { revalidatePath } from "next/cache"
 import { redirect } from "next/navigation"
 import { Tenant } from "@/tenant-management/types/tenant"
+import { TENANT_INVITABLE_ROLES, TENANT_MANAGEABLE_ROLES } from "@/lib/tenant-access"
 
 export interface CreateTenantData {
   name: string
@@ -225,6 +226,10 @@ export async function inviteMemberAction(data: InviteMemberData) {
     throw new Error('認証が必要です')
   }
 
+  if (!TENANT_INVITABLE_ROLES.includes(data.role)) {
+    throw new Error('無効なロールです')
+  }
+
   // Check if user has permission to invite
   const { data: userTenant } = await supabase
     .from('user_tenants')
@@ -285,6 +290,10 @@ export async function updateMemberRoleAction(data: UpdateMemberRoleData) {
   const { data: { user }, error: authError } = await supabase.auth.getUser()
   if (authError || !user) {
     throw new Error('認証が必要です')
+  }
+
+  if (!TENANT_MANAGEABLE_ROLES.includes(data.role)) {
+    throw new Error('無効なロールです')
   }
 
   // Get current user's role in the tenant

--- a/lib/supabase/meetings.ts
+++ b/lib/supabase/meetings.ts
@@ -1,8 +1,14 @@
 import { createClient } from './client'
 import type { Meeting, MeetingNote } from '@/lib/models'
+import { getAccessiblePersonIdsForCurrentUser } from './people-access'
 
 export async function getMeetings(): Promise<Meeting[]> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'meetings')
+
+  if (accessiblePersonIds.length === 0) {
+    return []
+  }
   
   const { data, error } = await supabase
     .from('meetings')
@@ -16,6 +22,7 @@ export async function getMeetings(): Promise<Meeting[]> {
         detail
       )
     `)
+    .in('person_id', accessiblePersonIds)
     .order('datetime', { ascending: false })
   
   if (error) {
@@ -24,7 +31,7 @@ export async function getMeetings(): Promise<Meeting[]> {
   }
   
   // SupabaseのデータをMeeting型に変換
-  return data.map(meeting => ({
+  return data.map((meeting: any) => ({
     id: meeting.id,
     personId: meeting.person_id,
     kind: meeting.kind,
@@ -46,6 +53,11 @@ export async function getMeetings(): Promise<Meeting[]> {
 
 export async function getMeetingById(id: string): Promise<Meeting | null> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'meetings')
+
+  if (accessiblePersonIds.length === 0) {
+    return null
+  }
   
   const { data, error } = await supabase
     .from('meetings')
@@ -60,6 +72,7 @@ export async function getMeetingById(id: string): Promise<Meeting | null> {
       )
     `)
     .eq('id', id)
+    .in('person_id', accessiblePersonIds)
     .single()
   
   if (error) {
@@ -89,6 +102,11 @@ export async function getMeetingById(id: string): Promise<Meeting | null> {
 
 export async function getMeetingsByPersonId(personId: string): Promise<Meeting[]> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'meetings')
+
+  if (!accessiblePersonIds.includes(personId)) {
+    return []
+  }
   
   const { data, error } = await supabase
     .from('meetings')
@@ -110,7 +128,7 @@ export async function getMeetingsByPersonId(personId: string): Promise<Meeting[]
     throw error
   }
   
-  return data.map(meeting => ({
+  return data.map((meeting: any) => ({
     id: meeting.id,
     personId: meeting.person_id,
     kind: meeting.kind,

--- a/lib/supabase/people-access.test.ts
+++ b/lib/supabase/people-access.test.ts
@@ -69,4 +69,20 @@ describe("people company access", () => {
 
     expect(canAccessPersonByCompany({ tenant_id: "tenant-1", company: "名谷病院" }, access)).toBe(false)
   })
+
+  test("denies people access when the people feature is disabled", () => {
+    const access = buildCompanyAccess([
+      {
+        id: "membership-1",
+        tenant_id: "tenant-1",
+        role: "member",
+        status: "active",
+        feature_permissions: { people: false },
+        offices: [{ name: "名谷病院" }],
+      },
+    ])
+
+    expect(canAccessPersonByCompany({ tenant_id: "tenant-1", company: "名谷病院" }, access)).toBe(false)
+    expect(canAccessPersonByCompany({ tenant_id: "tenant-1", company: "天王寺特別養護老人ホーム" }, access)).toBe(false)
+  })
 })

--- a/lib/supabase/people-access.ts
+++ b/lib/supabase/people-access.ts
@@ -1,8 +1,14 @@
+import {
+  hasTenantFeatureAccess,
+  type TenantFeaturePermission,
+} from "@/lib/tenant-access"
+
 type TenantMembership = {
   id?: string | null
   tenant_id?: string | null
   role?: string | null
   status?: string | null
+  feature_permissions?: unknown
   offices?: Array<{ name?: string | null }> | null
   [key: string]: unknown
 }
@@ -127,7 +133,10 @@ function membershipHasAllCompanyAccess(membership: TenantMembership): boolean {
   })
 }
 
-export function buildCompanyAccess(memberships: TenantMembership[]): CompanyAccess {
+export function buildCompanyAccess(
+  memberships: TenantMembership[],
+  feature: TenantFeaturePermission = "people"
+): CompanyAccess {
   const access: CompanyAccess = {
     fullTenantIds: new Set(),
     restrictedTenantCompanies: new Map(),
@@ -139,6 +148,19 @@ export function buildCompanyAccess(memberships: TenantMembership[]): CompanyAcce
     .forEach((membership) => {
       access.hasActiveMembership = true
       const tenantId = membership.tenant_id as string
+
+      if (
+        !hasTenantFeatureAccess(
+          {
+            role: membership.role as any,
+            status: membership.status,
+            feature_permissions: membership.feature_permissions as any,
+          },
+          feature
+        )
+      ) {
+        return
+      }
 
       if (FULL_ACCESS_ROLES.has(membership.role ?? "") || membershipHasAllCompanyAccess(membership)) {
         access.fullTenantIds.add(tenantId)
@@ -168,7 +190,8 @@ export function buildCompanyAccess(memberships: TenantMembership[]): CompanyAcce
 
 export async function getCompanyAccessForUser(
   supabase: any,
-  userId: string
+  userId: string,
+  feature: TenantFeaturePermission = "people"
 ): Promise<CompanyAccess> {
   const { data: memberships, error: membershipsError } = await supabase
     .from("user_tenants")
@@ -186,7 +209,7 @@ export async function getCompanyAccessForUser(
     .filter((id): id is string => Boolean(id))
 
   if (membershipIds.length === 0) {
-    return buildCompanyAccess(membershipRecords)
+    return buildCompanyAccess(membershipRecords, feature)
   }
 
   const { data: assignments, error: assignmentsError } = await supabase
@@ -239,7 +262,8 @@ export async function getCompanyAccessForUser(
       offices: membership.id
         ? officeNamesByMembershipId.get(membership.id) || []
         : [],
-    }))
+    })),
+    feature
   )
 }
 
@@ -287,4 +311,45 @@ export function applyPeopleAccessFilter<TQuery extends { or: (filters: string) =
   const filter = buildPeopleAccessOrFilter(access)
   if (!filter) return null
   return query.or(filter)
+}
+
+export async function getAccessiblePersonIdsForUser(
+  supabase: any,
+  userId: string,
+  feature: TenantFeaturePermission = "people"
+): Promise<string[]> {
+  const access = await getCompanyAccessForUser(supabase, userId, feature)
+  const query = applyPeopleAccessFilter(
+    supabase
+      .from("people")
+      .select("id, tenant_id, company"),
+    access
+  )
+
+  if (!query) {
+    return []
+  }
+
+  const { data, error } = await query
+
+  if (error) {
+    throw error
+  }
+
+  return (data || [])
+    .filter((person: any) => canAccessPersonByCompany(person, access))
+    .map((person: any) => person.id)
+    .filter((id: unknown): id is string => typeof id === "string")
+}
+
+export async function getAccessiblePersonIdsForCurrentUser(
+  supabase: any,
+  feature: TenantFeaturePermission = "people"
+): Promise<string[]> {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return []
+  }
+
+  return getAccessiblePersonIdsForUser(supabase, user.id, feature)
 }

--- a/lib/supabase/person-documents.ts
+++ b/lib/supabase/person-documents.ts
@@ -1,6 +1,7 @@
 import { createClient } from './client'
 import type { PersonDocument } from '@/lib/models'
 import { resolveReplacementDocumentNote } from '@/lib/document-notes'
+import { getAccessiblePersonIdsForCurrentUser } from './people-access'
 
 const REMOVED_DOCUMENT_TYPE = 'resident_card_copy'
 const VALID_DOCUMENT_TYPES = [
@@ -19,6 +20,12 @@ const VALID_DOCUMENT_TYPES = [
 
 export async function getPersonDocuments(personId: string): Promise<PersonDocument[]> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'documents')
+
+  if (!accessiblePersonIds.includes(personId)) {
+    return []
+  }
+
   const { data, error } = await supabase
     .from('person_documents')
     .select('*')
@@ -41,9 +48,16 @@ export type PersonDocumentWithPerson = PersonDocument & {
 
 export async function getAllPersonDocuments(): Promise<PersonDocumentWithPerson[]> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'documents')
+
+  if (accessiblePersonIds.length === 0) {
+    return []
+  }
+
   const { data, error } = await supabase
     .from('person_documents')
     .select('*, people(name, kana)')
+    .in('person_id', accessiblePersonIds)
     .neq('document_type', REMOVED_DOCUMENT_TYPE)
     .order('created_at', { ascending: false })
 
@@ -95,6 +109,11 @@ export async function uploadDocumentDirect(
   }
 
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'documents')
+
+  if (!accessiblePersonIds.includes(personId)) {
+    return { success: false, error: '人材情報が見つかりません' }
+  }
 
   // Get person's tenant_id
   const { data: person, error: personError } = await supabase

--- a/lib/supabase/support-actions.ts
+++ b/lib/supabase/support-actions.ts
@@ -1,12 +1,19 @@
 import { createClient } from './client'
 import type { SupportAction } from '@/lib/models'
+import { getAccessiblePersonIdsForCurrentUser } from './people-access'
 
 export async function getSupportActions(): Promise<SupportAction[]> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'support_actions')
+
+  if (accessiblePersonIds.length === 0) {
+    return []
+  }
   
   const { data, error } = await supabase
     .from('support_actions')
     .select()
+    .in('person_id', accessiblePersonIds)
     .order('created_at', { ascending: false })
   
   if (error) {
@@ -15,7 +22,7 @@ export async function getSupportActions(): Promise<SupportAction[]> {
   }
   
   // SupabaseのデータをSupportAction型に変換
-  return data.map(action => ({
+  return data.map((action: any) => ({
     id: action.id,
     personId: action.person_id,
     category: action.category,
@@ -31,11 +38,17 @@ export async function getSupportActions(): Promise<SupportAction[]> {
 
 export async function getSupportActionById(id: string): Promise<SupportAction | null> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'support_actions')
+
+  if (accessiblePersonIds.length === 0) {
+    return null
+  }
   
   const { data, error } = await supabase
     .from('support_actions')
     .select()
     .eq('id', id)
+    .in('person_id', accessiblePersonIds)
     .single()
   
   if (error) {
@@ -59,6 +72,11 @@ export async function getSupportActionById(id: string): Promise<SupportAction | 
 
 export async function getSupportActionsByPersonId(personId: string): Promise<SupportAction[]> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'support_actions')
+
+  if (!accessiblePersonIds.includes(personId)) {
+    return []
+  }
   
   const { data, error } = await supabase
     .from('support_actions')
@@ -71,7 +89,7 @@ export async function getSupportActionsByPersonId(personId: string): Promise<Sup
     throw error
   }
   
-  return data.map(action => ({
+  return data.map((action: any) => ({
     id: action.id,
     personId: action.person_id,
     category: action.category,
@@ -87,11 +105,17 @@ export async function getSupportActionsByPersonId(personId: string): Promise<Sup
 
 export async function getSupportActionsByCategory(category: string): Promise<SupportAction[]> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'support_actions')
+
+  if (accessiblePersonIds.length === 0) {
+    return []
+  }
   
   const { data, error } = await supabase
     .from('support_actions')
     .select()
     .eq('category', category)
+    .in('person_id', accessiblePersonIds)
     .order('created_at', { ascending: false })
   
   if (error) {
@@ -99,7 +123,7 @@ export async function getSupportActionsByCategory(category: string): Promise<Sup
     throw error
   }
   
-  return data.map(action => ({
+  return data.map((action: any) => ({
     id: action.id,
     personId: action.person_id,
     category: action.category,
@@ -115,11 +139,17 @@ export async function getSupportActionsByCategory(category: string): Promise<Sup
 
 export async function getSupportActionsByStatus(status: 'open' | 'in_progress' | 'done'): Promise<SupportAction[]> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'support_actions')
+
+  if (accessiblePersonIds.length === 0) {
+    return []
+  }
   
   const { data, error } = await supabase
     .from('support_actions')
     .select()
     .eq('status', status)
+    .in('person_id', accessiblePersonIds)
     .order('created_at', { ascending: false })
   
   if (error) {
@@ -127,7 +157,7 @@ export async function getSupportActionsByStatus(status: 'open' | 'in_progress' |
     throw error
   }
   
-  return data.map(action => ({
+  return data.map((action: any) => ({
     id: action.id,
     personId: action.person_id,
     category: action.category,
@@ -143,6 +173,11 @@ export async function getSupportActionsByStatus(status: 'open' | 'in_progress' |
 
 export async function createSupportAction(action: Omit<SupportAction, 'createdAt' | 'updatedAt'>): Promise<SupportAction> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'support_actions')
+
+  if (!accessiblePersonIds.includes(action.personId)) {
+    throw new Error('Person not found')
+  }
   
   const { data, error } = await supabase
     .from('support_actions')
@@ -180,6 +215,11 @@ export async function createSupportAction(action: Omit<SupportAction, 'createdAt
 
 export async function updateSupportAction(id: string, updates: Partial<Omit<SupportAction, 'id' | 'createdAt' | 'updatedAt'>>): Promise<SupportAction> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'support_actions')
+
+  if (accessiblePersonIds.length === 0 || (updates.personId && !accessiblePersonIds.includes(updates.personId))) {
+    throw new Error('Support action not found')
+  }
   
   const { data, error } = await supabase
     .from('support_actions')
@@ -193,6 +233,7 @@ export async function updateSupportAction(id: string, updates: Partial<Omit<Supp
       due_date: updates.due
     })
     .eq('id', id)
+    .in('person_id', accessiblePersonIds)
     .select()
     .single()
   
@@ -217,16 +258,20 @@ export async function updateSupportAction(id: string, updates: Partial<Omit<Supp
 
 export async function deleteSupportAction(id: string): Promise<void> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'support_actions')
+
+  if (accessiblePersonIds.length === 0) {
+    return
+  }
   
   const { error } = await supabase
     .from('support_actions')
     .delete()
     .eq('id', id)
+    .in('person_id', accessiblePersonIds)
   
   if (error) {
     console.error('Error deleting support action:', error)
     throw error
   }
 }
-
-

--- a/lib/supabase/tenants.ts
+++ b/lib/supabase/tenants.ts
@@ -1,4 +1,5 @@
 import { createClient, createAdminClient } from './client'
+import type { TenantFeaturePermissions } from '@/lib/tenant-access'
 
 export interface Tenant {
   id: string
@@ -35,6 +36,7 @@ export interface UserTenant {
     }
   }
   role: 'owner' | 'admin' | 'member' | 'guest' | 'supporter'
+  feature_permissions?: TenantFeaturePermissions | null
   status: 'active' | 'pending' | 'suspended'
   invited_by?: string
   invited_at?: string
@@ -121,6 +123,7 @@ export async function getCurrentUserTenants(): Promise<UserTenant[]> {
     tenant_id: ut.tenant_id,
     email: ut.email,
     role: ut.role,
+    feature_permissions: ut.feature_permissions,
     status: ut.status,
     created_at: ut.created_at,
     updated_at: ut.updated_at,
@@ -376,6 +379,26 @@ export async function updateUserTenantRole(
 
   if (!response.ok) {
     throw new Error(result.error || 'Failed to update user tenant role')
+  }
+}
+
+export async function updateUserTenantFeaturePermissions(
+  tenantId: string,
+  userTenantId: string,
+  featurePermissions: TenantFeaturePermissions
+): Promise<void> {
+  const response = await fetch(`/api/tenants/${tenantId}/members/${userTenantId}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ featurePermissions }),
+  })
+
+  const result = await response.json()
+
+  if (!response.ok) {
+    throw new Error(result.error || 'Failed to update feature permissions')
   }
 }
 

--- a/lib/supabase/visas.ts
+++ b/lib/supabase/visas.ts
@@ -1,5 +1,6 @@
 import { createClient } from './client'
 import type { Visa, VisaStatus } from '@/lib/models'
+import { getAccessiblePersonIdsForCurrentUser } from './people-access'
 
 export interface VisaListResponse {
   visas: Visa[]
@@ -20,11 +21,17 @@ const applyVisaStatusExclusions = (query: ReturnType<typeof createClient>["from"
 
 export async function getVisas(): Promise<Visa[]> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'visas')
+
+  if (accessiblePersonIds.length === 0) {
+    return []
+  }
   
   const { data, error } = await applyVisaStatusExclusions(
     supabase
     .from('visas')
     .select()
+    .in('person_id', accessiblePersonIds)
     .order('updated_at', { ascending: false })
   )
   
@@ -34,7 +41,7 @@ export async function getVisas(): Promise<Visa[]> {
   }
   
   // SupabaseのデータをVisa型に変換
-  return data.map(visa => ({
+  return data.map((visa: any) => ({
     id: visa.id,
     personId: visa.person_id,
     status: visa.status,
@@ -60,12 +67,18 @@ export async function getVisas(): Promise<Visa[]> {
 
 export async function getVisaById(id: string): Promise<Visa | null> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'visas')
+
+  if (accessiblePersonIds.length === 0) {
+    return null
+  }
   
   const { data, error } = await applyVisaStatusExclusions(
     supabase
     .from('visas')
     .select()
     .eq('id', id)
+    .in('person_id', accessiblePersonIds)
     .single()
   )
   
@@ -100,6 +113,11 @@ export async function getVisaById(id: string): Promise<Visa | null> {
 
 export async function getVisasByPersonId(personId: string): Promise<Visa[]> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'visas')
+
+  if (!accessiblePersonIds.includes(personId)) {
+    return []
+  }
   
   const { data, error } = await applyVisaStatusExclusions(
     supabase
@@ -269,22 +287,10 @@ export async function deleteVisa(id: string): Promise<void> {
 }
 
 export async function getVisaStatusCounts(): Promise<VisaStatusCounts> {
-  const supabase = createClient()
-  
-  const { data, error } = await applyVisaStatusExclusions(
-    supabase
-    .from('visas')
-    .select('status')
-  )
-
-  if (error) {
-    console.error('Error fetching visa status counts:', error)
-    throw error
-  }
-  
-  // Count occurrences of each status
   const counts: VisaStatusCounts = {}
-  data.forEach(visa => {
+
+  const visas = await getVisas()
+  visas.forEach(visa => {
     counts[visa.status] = (counts[visa.status] || 0) + 1
   })
   
@@ -297,6 +303,16 @@ export async function getVisasPaginated(
   pageSize: number = 20
 ): Promise<VisaListResponse> {
   const supabase = createClient()
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'visas')
+  
+  if (accessiblePersonIds.length === 0) {
+    return {
+      visas: [],
+      totalCount: 0,
+      hasNextPage: false,
+      hasPrevPage: false,
+    }
+  }
   
   const offset = (page - 1) * pageSize
   
@@ -312,6 +328,7 @@ export async function getVisasPaginated(
         tenant_id
       )
     `, { count: 'exact' })
+    .in('person_id', accessiblePersonIds)
     .order('updated_at', { ascending: false })
     .range(offset, offset + pageSize - 1)
 
@@ -328,7 +345,7 @@ export async function getVisasPaginated(
     throw error
   }
   
-  const visas: (Visa & { person: any })[] = data.map(item => ({
+  const visas: (Visa & { person: any })[] = data.map((item: any) => ({
     id: item.id,
     personId: item.person_id,
     status: item.status,

--- a/lib/tenant-access.test.ts
+++ b/lib/tenant-access.test.ts
@@ -1,47 +1,80 @@
-import assert from "node:assert/strict"
-import test from "node:test"
+import { describe, expect, test } from "vitest"
 
 import {
   canManageCompanyContacts,
+  hasTenantFeatureAccess,
   isCompanyContactEmail,
   isCompanyContactRole,
   isInternalStaffEmail,
+  normalizeTenantFeaturePermissions,
 } from "./tenant-access"
 
-test("internal active member cannot manage company contacts without admin role", () => {
-  const result = canManageCompanyContacts([{ role: "member" }], "sales@funtoco.jp")
+describe("tenant access", () => {
+  test("member cannot manage company contacts without admin role", () => {
+    const result = canManageCompanyContacts([{ role: "member" }], "sales@funtoco.jp")
 
-  assert.equal(result, false)
-})
+    expect(result).toBe(false)
+  })
 
-test("external member cannot manage company contacts", () => {
-  const result = canManageCompanyContacts([{ role: "member" }], "pic@company.jp")
+  test("external member cannot manage company contacts", () => {
+    const result = canManageCompanyContacts([{ role: "member" }], "pic@company.jp")
 
-  assert.equal(result, false)
-})
+    expect(result).toBe(false)
+  })
 
-test("guest cannot manage company contacts even with internal email", () => {
-  const result = canManageCompanyContacts([{ role: "guest" }], "sales@funtoco.jp")
+  test("guest cannot manage company contacts even with internal email", () => {
+    const result = canManageCompanyContacts([{ role: "guest" }], "sales@funtoco.jp")
 
-  assert.equal(result, false)
-})
+    expect(result).toBe(false)
+  })
 
-test("owner and admin retain company contact management access", () => {
-  assert.equal(canManageCompanyContacts([{ role: "owner" }], "owner@funtoco.jp"), true)
-  assert.equal(canManageCompanyContacts([{ role: "admin" }], "admin@funtoco.jp"), true)
-})
+  test("owner and admin retain company contact management access", () => {
+    expect(canManageCompanyContacts([{ role: "owner" }], "owner@funtoco.jp")).toBe(true)
+    expect(canManageCompanyContacts([{ role: "admin" }], "admin@funtoco.jp")).toBe(true)
+  })
 
-test("company contact detection distinguishes internal and external emails", () => {
-  assert.equal(isInternalStaffEmail("member@funtoco.jp"), true)
-  assert.equal(isInternalStaffEmail(" Member@FUNToco.jp "), true)
-  assert.equal(isCompanyContactEmail("member@funtoco.jp"), false)
-  assert.equal(isCompanyContactEmail("contact@example.com"), true)
-  assert.equal(isCompanyContactEmail(" contact@example.com "), true)
-})
+  test("company contact detection distinguishes internal and external emails", () => {
+    expect(isInternalStaffEmail("member@funtoco.jp")).toBe(true)
+    expect(isInternalStaffEmail(" Member@FUNToco.jp ")).toBe(true)
+    expect(isCompanyContactEmail("member@funtoco.jp")).toBe(false)
+    expect(isCompanyContactEmail("contact@example.com")).toBe(true)
+    expect(isCompanyContactEmail(" contact@example.com ")).toBe(true)
+  })
 
-test("company contact role is limited to member and guest", () => {
-  assert.equal(isCompanyContactRole("member"), true)
-  assert.equal(isCompanyContactRole("guest"), true)
-  assert.equal(isCompanyContactRole("admin"), false)
-  assert.equal(isCompanyContactRole("supporter"), false)
+  test("company contact role is limited to member and guest", () => {
+    expect(isCompanyContactRole("member")).toBe(true)
+    expect(isCompanyContactRole("guest")).toBe(true)
+    expect(isCompanyContactRole("admin")).toBe(false)
+    expect(isCompanyContactRole("supporter")).toBe(false)
+  })
+
+  test("feature permissions default to allowed for backward compatibility", () => {
+    expect(hasTenantFeatureAccess({ role: "member" }, "people")).toBe(true)
+    expect(hasTenantFeatureAccess({ role: "guest", feature_permissions: {} }, "meetings")).toBe(true)
+  })
+
+  test("feature permissions can deny individual features", () => {
+    expect(
+      hasTenantFeatureAccess(
+        { role: "member", feature_permissions: { people: false, meetings: true } },
+        "people"
+      )
+    ).toBe(false)
+    expect(
+      hasTenantFeatureAccess(
+        { role: "member", feature_permissions: { people: false, meetings: true } },
+        "meetings"
+      )
+    ).toBe(true)
+  })
+
+  test("owner and admin always keep feature access", () => {
+    expect(hasTenantFeatureAccess({ role: "owner", feature_permissions: { people: false } }, "people")).toBe(true)
+    expect(hasTenantFeatureAccess({ role: "admin", feature_permissions: { funedu: false } }, "funedu")).toBe(true)
+  })
+
+  test("normalizes persisted feature permission values", () => {
+    expect(normalizeTenantFeaturePermissions('{"people":false,"unknown":true}')).toEqual({ people: false })
+    expect(normalizeTenantFeaturePermissions({ documents: true, visas: "no" } as any)).toEqual({ documents: true })
+  })
 })

--- a/lib/tenant-access.ts
+++ b/lib/tenant-access.ts
@@ -5,8 +5,51 @@ export type TenantAccessRole =
   | "guest"
   | "supporter"
 
+export type TenantFeaturePermission =
+  | "people"
+  | "visas"
+  | "meetings"
+  | "support_actions"
+  | "documents"
+  | "funedu"
+
+export type TenantFeaturePermissions = Partial<Record<TenantFeaturePermission, boolean>>
+
 export interface TenantRoleMembership {
   role: TenantAccessRole | null
+  status?: string | null
+  feature_permissions?: TenantFeaturePermissions | string | null
+}
+
+export const TENANT_MANAGEABLE_ROLES = [
+  "owner",
+  "admin",
+  "member",
+  "guest",
+] as const satisfies readonly Exclude<TenantAccessRole, "supporter">[]
+
+export const TENANT_INVITABLE_ROLES = [
+  "admin",
+  "member",
+  "guest",
+] as const satisfies readonly Exclude<TenantAccessRole, "owner" | "supporter">[]
+
+export const TENANT_FEATURE_PERMISSION_KEYS = [
+  "people",
+  "visas",
+  "meetings",
+  "support_actions",
+  "documents",
+  "funedu",
+] as const satisfies readonly TenantFeaturePermission[]
+
+export const TENANT_FEATURE_PERMISSION_LABELS: Record<TenantFeaturePermission, string> = {
+  people: "人材一覧",
+  visas: "ビザ",
+  meetings: "面談",
+  support_actions: "サポート記録",
+  documents: "書類",
+  funedu: "FunEdu",
 }
 
 const INTERNAL_STAFF_EMAIL_DOMAIN = "@funtoco.jp"
@@ -25,6 +68,55 @@ export function canManageTenant(memberships: TenantRoleMembership[]): boolean {
     (membership) =>
       membership.role === "owner" || membership.role === "admin"
   )
+}
+
+export function normalizeTenantFeaturePermissions(
+  permissions: TenantRoleMembership["feature_permissions"]
+): TenantFeaturePermissions {
+  if (!permissions) {
+    return {}
+  }
+
+  if (typeof permissions === "string") {
+    try {
+      return normalizeTenantFeaturePermissions(JSON.parse(permissions))
+    } catch {
+      return {}
+    }
+  }
+
+  const normalized: TenantFeaturePermissions = {}
+  for (const key of TENANT_FEATURE_PERMISSION_KEYS) {
+    const value = permissions[key]
+    if (typeof value === "boolean") {
+      normalized[key] = value
+    }
+  }
+
+  return normalized
+}
+
+export function hasTenantFeatureAccess(
+  membership: TenantRoleMembership,
+  feature: TenantFeaturePermission
+): boolean {
+  if (membership.status && membership.status !== "active") {
+    return false
+  }
+
+  if (membership.role === "owner" || membership.role === "admin") {
+    return true
+  }
+
+  const permissions = normalizeTenantFeaturePermissions(membership.feature_permissions)
+  return permissions[feature] !== false
+}
+
+export function hasAnyTenantFeatureAccess(
+  memberships: TenantRoleMembership[],
+  feature: TenantFeaturePermission
+): boolean {
+  return memberships.some((membership) => hasTenantFeatureAccess(membership, feature))
 }
 
 export function isInternalStaffEmail(email?: string | null): boolean {

--- a/run/setup.sh
+++ b/run/setup.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKTREE_PATH="${CODEX_WORKTREE_PATH:-$(pwd)}"
+MAIN_CHECKOUT_PATH="${FUN_BASE_MAIN_CHECKOUT_PATH:-/Users/nishimuratomooakira/workspace/funtoco/fun-base}"
+
+cd "$WORKTREE_PATH"
+
+echo "==> Preparing FunBase worktree: $WORKTREE_PATH"
+
+echo "==> Fetching latest origin/main for this worktree"
+git fetch origin main
+
+worktree_status="$(git status --porcelain)"
+if git merge-base --is-ancestor HEAD origin/main; then
+  has_local_commits=no
+else
+  has_local_commits=yes
+fi
+
+if [ -z "$worktree_status" ] && [ "$has_local_commits" = "no" ]; then
+  git merge --ff-only origin/main
+else
+  echo "==> Skipping worktree fast-forward (dirty=$([ -n "$worktree_status" ] && echo yes || echo no), has-local-commits=$has_local_commits)"
+fi
+
+if [ -d "$MAIN_CHECKOUT_PATH/.git" ] || git -C "$MAIN_CHECKOUT_PATH" rev-parse --git-dir >/dev/null 2>&1; then
+  echo "==> Refreshing main checkout: $MAIN_CHECKOUT_PATH"
+  git -C "$MAIN_CHECKOUT_PATH" fetch origin main
+
+  main_branch="$(git -C "$MAIN_CHECKOUT_PATH" branch --show-current || true)"
+  main_status="$(git -C "$MAIN_CHECKOUT_PATH" status --porcelain)"
+  if [ "$main_branch" = "main" ] && [ -z "$main_status" ]; then
+    git -C "$MAIN_CHECKOUT_PATH" pull --ff-only origin main
+  else
+    echo "==> Skipping main checkout pull (branch=$main_branch, dirty=$([ -n "$main_status" ] && echo yes || echo no))"
+  fi
+
+  for env_file in .env.local .env; do
+    source_env="$MAIN_CHECKOUT_PATH/$env_file"
+    target_env="$WORKTREE_PATH/$env_file"
+    if [ -f "$source_env" ]; then
+      cp -p "$source_env" "$target_env"
+      echo "==> Copied $env_file from main checkout"
+    fi
+  done
+else
+  echo "==> Main checkout not found at $MAIN_CHECKOUT_PATH; skipping env sync"
+fi
+
+echo "==> Initializing submodules"
+git submodule update --init --recursive
+
+echo "==> Setup complete"


### PR DESCRIPTION
## Summary
- Replace the fixed `field_staff` approach with per-member feature permissions for people, visas, meetings, support actions, documents, and FunEdu.
- Add feature permission controls directly in tenant member management.
- Hide sidebar/search/FunEdu entry points based on each feature permission.
- Scope people-related data reads and API checks by feature-specific access.
- Reject direct FunEdu SSO start requests server-side when the current user lacks the `funedu` feature permission.
- Add `run/setup.sh` so Codex worktree setup fetches latest `origin/main`, safely fast-forwards clean worktrees, copies local env files from the main checkout, and initializes submodules.
- Update the `supabase` submodule pointer to funtoco/fun-base-infra#61 for DB/RLS support.

Refs #117
Depends on funtoco/fun-base-infra#61

## Validation
- `bash -n run/setup.sh`
- `./run/setup.sh`
- Applied `supabase/migrations/20260629000000_add_user_tenant_feature_permissions.sql` to local `supabase_db_fun-studio-v0` via container `psql` after local migration history was inconsistent.
- Verified local DB has `user_tenants.feature_permissions`, `public.user_tenant_feature_enabled(...)`, and 13 feature-scoped RLS policies.
- Verified local REST schema cache returns `status 200` for `user_tenants?select=feature_permissions&limit=1`.
- `curl -i http://127.0.0.1:3000/api/funedu/sso/start` compiles the route and returns the expected local 503 because `FUNEDU_URL` / `NEXT_PUBLIC_FUNEDU_URL` is not set in `.env.local`.
- `npx tsc --noEmit --pretty false 2>&1 | rg "app/api/funedu/sso/start|lib/tenant-access"` produced no matching errors.
- `npm test -- --run lib/supabase/people-access.test.ts lib/tenant-access.test.ts`
- Targeted `npx tsc --noEmit --pretty false ... | rg "(components/layout/header|components/layout/sidebar|components/tenant/(members-table|tenant-members-page|role-badge|invite|add-existing|create-user)|lib/supabase/(people-access|visas|meetings|person-documents|support-actions|tenants)|lib/tenant-access|app/api/(people|tenants|admin/users)|app/invite)"` produced no errors.
- Full `npx tsc --noEmit --pretty false` is still blocked by existing unrelated connector, mock data, crypto, and tenant-management type errors.
- Full `npm test` is still blocked by existing unrelated Vitest discovery failures for legacy `node:test` files; targeted tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant feature permissions, including per-feature access control and member updates in the tenant management UI.
  * Expanded member invite and role selection flows with consistent role options.
  * Added support for updating feature permissions directly from tenant member lists.

* **Bug Fixes**
  * Restricted access to people, documents, meetings, visas, support actions, and FunEdu SSO based on tenant permissions.
  * Prevented invalid roles from being used in invites and member creation/update actions.
  * Hidden search and navigation items when the current user lacks access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->