### PR TITLE
fix: fetch all accessible people and visas

### DIFF
--- a/lib/supabase/paginated-query.test.ts
+++ b/lib/supabase/paginated-query.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest"
+
+import { fetchAllSupabaseRows } from "./paginated-query"
+
+type RangeCall = { from: number; to: number }
+
+function createRows(count: number) {
+  return Array.from({ length: count }, (_, index) => ({ id: index + 1 }))
+}
+
+describe("fetchAllSupabaseRows", () => {
+  test("fetches every page until the final partial page", async () => {
+    const rows = createRows(205)
+    const ranges: RangeCall[] = []
+
+    const result = await fetchAllSupabaseRows(
+      () => ({
+        async range(from: number, to: number) {
+          ranges.push({ from, to })
+          return { data: rows.slice(from, to + 1), error: null }
+        },
+      }),
+      { pageSize: 100 }
+    )
+
+    expect(result).toEqual(rows)
+    expect(ranges).toEqual([
+      { from: 0, to: 99 },
+      { from: 100, to: 199 },
+      { from: 200, to: 299 },
+    ])
+  })
+
+  test("continues past Supabase's default 1000 row response window", async () => {
+    const rows = createRows(1380)
+
+    const result = await fetchAllSupabaseRows(
+      () => ({
+        async range(from: number, to: number) {
+          return { data: rows.slice(from, to + 1), error: null }
+        },
+      }),
+      { pageSize: 1000 }
+    )
+
+    expect(result).toHaveLength(1380)
+    expect(result.at(-1)).toEqual({ id: 1380 })
+  })
+
+  test("throws the Supabase error from any page", async () => {
+    await expect(
+      fetchAllSupabaseRows(
+        () => ({
+          async range(from: number) {
+            if (from >= 100) {
+              return { data: null, error: new Error("boom") }
+            }
+            return { data: createRows(100), error: null }
+          },
+        }),
+        { pageSize: 100 }
+      )
+    ).rejects.toThrow("boom")
+  })
+})

--- a/lib/supabase/paginated-query.ts
+++ b/lib/supabase/paginated-query.ts
@@ -1,0 +1,37 @@
+type SupabaseRangeResult<TRow> = {
+  data: TRow[] | null
+  error: Error | { message?: string } | null
+}
+
+type SupabaseRangeQuery<TRow> = {
+  range(from: number, to: number): PromiseLike<SupabaseRangeResult<TRow>>
+}
+
+const DEFAULT_PAGE_SIZE = 1000
+
+function normalizeSupabaseError(error: Error | { message?: string }): Error {
+  return error instanceof Error ? error : new Error(error.message || "Supabase query failed")
+}
+
+export async function fetchAllSupabaseRows<TRow>(
+  createQuery: () => SupabaseRangeQuery<TRow>,
+  options: { pageSize?: number } = {}
+): Promise<TRow[]> {
+  const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE
+  const rows: TRow[] = []
+
+  for (let offset = 0; ; offset += pageSize) {
+    const { data, error } = await createQuery().range(offset, offset + pageSize - 1)
+
+    if (error) {
+      throw normalizeSupabaseError(error)
+    }
+
+    const page = data ?? []
+    rows.push(...page)
+
+    if (page.length < pageSize) {
+      return rows
+    }
+  }
+}

--- a/lib/supabase/people-access.ts
+++ b/lib/supabase/people-access.ts
@@ -2,6 +2,7 @@ import {
   hasTenantFeatureAccess,
   type TenantFeaturePermission,
 } from "@/lib/tenant-access"
+import { fetchAllSupabaseRows } from "./paginated-query"
 
 type TenantMembership = {
   id?: string | null
@@ -319,24 +320,25 @@ export async function getAccessiblePersonIdsForUser(
   feature: TenantFeaturePermission = "people"
 ): Promise<string[]> {
   const access = await getCompanyAccessForUser(supabase, userId, feature)
-  const query = applyPeopleAccessFilter(
-    supabase
-      .from("people")
-      .select("id, tenant_id, company"),
-    access
-  )
+  if (!access.hasActiveMembership) return []
 
-  if (!query) {
-    return []
-  }
+  const data = await fetchAllSupabaseRows(() => {
+    const query = applyPeopleAccessFilter(
+      supabase
+        .from("people")
+        .select("id, tenant_id, company")
+        .order("id"),
+      access
+    )
 
-  const { data, error } = await query
+    if (!query) {
+      throw new Error("No accessible people query could be built")
+    }
 
-  if (error) {
-    throw error
-  }
+    return query
+  })
 
-  return (data || [])
+  return data
     .filter((person: any) => canAccessPersonByCompany(person, access))
     .map((person: any) => person.id)
     .filter((id: unknown): id is string => typeof id === "string")

--- a/lib/supabase/people.ts
+++ b/lib/supabase/people.ts
@@ -6,6 +6,7 @@ import {
   getCompanyAccessForUser,
   type CompanyAccess,
 } from './people-access'
+import { fetchAllSupabaseRows } from './paginated-query'
 
 async function getCurrentUserCompanyAccess(): Promise<CompanyAccess> {
   const supabase = createClient()
@@ -68,26 +69,30 @@ function mapPersonRow(person: any, tenantName?: string): Person {
 export async function getPeople(): Promise<Person[]> {
   const supabase = createClient()
   const companyAccess = await getCurrentUserCompanyAccess()
-  const query = applyPeopleAccessFilter(
+  if (!companyAccess.hasActiveMembership) return []
+
+  const createQuery = () => applyPeopleAccessFilter(
     supabase
       .from('people')
       .select(`
         *,
         tenant:tenant_id (id, name)
-      `),
+      `)
+      .order('created_at', { ascending: false }),
     companyAccess
   )
 
-  if (!query) return []
+  if (!createQuery()) return []
 
-  const { data, error } = await query.order('created_at', { ascending: false })
+  const data = await fetchAllSupabaseRows(() => {
+    const query = createQuery()
+    if (!query) {
+      throw new Error('No accessible people query could be built')
+    }
+    return query
+  })
 
-  if (error) {
-    console.error('Error fetching people:', error)
-    throw error
-  }
-
-  if (!data || data.length === 0) return []
+  if (data.length === 0) return []
 
   return data
     .filter((person: any) => canAccessPersonByCompany(person, companyAccess))

--- a/lib/supabase/visas.ts
+++ b/lib/supabase/visas.ts
@@ -1,6 +1,7 @@
 import { createClient } from './client'
 import type { Visa, VisaStatus } from '@/lib/models'
 import { getAccessiblePersonIdsForCurrentUser } from './people-access'
+import { fetchAllSupabaseRows } from './paginated-query'
 
 export interface VisaListResponse {
   visas: Visa[]
@@ -14,9 +15,41 @@ export interface VisaStatusCounts {
 }
 
 const EXCLUDED_VISA_STATUSES = ["内定取消", "内定辞退", "退職"]
+const PERSON_ID_FILTER_CHUNK_SIZE = 500
 
 const applyVisaStatusExclusions = (query: ReturnType<typeof createClient>["from"]) => {
   return query.not('status', 'in', `(${EXCLUDED_VISA_STATUSES.map((status) => `"${status}"`).join(',')})`)
+}
+
+const mapVisaRow = (visa: any): Visa => ({
+  id: visa.id,
+  personId: visa.person_id,
+  status: visa.status,
+  type: visa.type,
+  expiryDate: visa.expiry_date,
+  submittedAt: visa.submitted_at,
+  resultAt: visa.result_at,
+  manager: visa.manager,
+  updatedAt: visa.updated_at,
+  documentPreparationDate: visa.document_preparation_date,
+  documentCreationDate: visa.document_creation_date,
+  documentConfirmationDate: visa.document_confirmation_date,
+  applicationPreparationDate: visa.application_preparation_date,
+  visaApplicationPreparationDate: visa.visa_application_preparation_date,
+  applicationDate: visa.application_date,
+  additionalDocumentsDate: visa.additional_documents_date,
+  visaAcquiredDate: visa.visa_acquired_date,
+  receptionNumber: visa.reception_number,
+  receptionDate: visa.reception_date,
+  receptionApplicationNumber: visa.reception_application_number
+})
+
+function chunkValues<T>(values: T[], chunkSize: number): T[][] {
+  const chunks: T[][] = []
+  for (let index = 0; index < values.length; index += chunkSize) {
+    chunks.push(values.slice(index, index + chunkSize))
+  }
+  return chunks
 }
 
 export async function getVisas(): Promise<Visa[]> {
@@ -26,43 +59,26 @@ export async function getVisas(): Promise<Visa[]> {
   if (accessiblePersonIds.length === 0) {
     return []
   }
-  
-  const { data, error } = await applyVisaStatusExclusions(
-    supabase
-    .from('visas')
-    .select()
-    .in('person_id', accessiblePersonIds)
-    .order('updated_at', { ascending: false })
+
+  const rows = (
+    await Promise.all(
+      chunkValues(accessiblePersonIds, PERSON_ID_FILTER_CHUNK_SIZE).map((personIds) =>
+        fetchAllSupabaseRows(() =>
+          applyVisaStatusExclusions(
+            supabase
+              .from('visas')
+              .select()
+              .in('person_id', personIds)
+              .order('updated_at', { ascending: false })
+          )
+        )
+      )
+    )
   )
-  
-  if (error) {
-    console.error('Error fetching visas:', error)
-    throw error
-  }
-  
-  // SupabaseのデータをVisa型に変換
-  return data.map((visa: any) => ({
-    id: visa.id,
-    personId: visa.person_id,
-    status: visa.status,
-    type: visa.type,
-    expiryDate: visa.expiry_date,
-    submittedAt: visa.submitted_at,
-    resultAt: visa.result_at,
-    manager: visa.manager,
-    updatedAt: visa.updated_at,
-    documentPreparationDate: visa.document_preparation_date,
-    documentCreationDate: visa.document_creation_date,
-    documentConfirmationDate: visa.document_confirmation_date,
-    applicationPreparationDate: visa.application_preparation_date,
-    visaApplicationPreparationDate: visa.visa_application_preparation_date,
-    applicationDate: visa.application_date,
-    additionalDocumentsDate: visa.additional_documents_date,
-    visaAcquiredDate: visa.visa_acquired_date,
-    receptionNumber: visa.reception_number,
-    receptionDate: visa.reception_date,
-    receptionApplicationNumber: visa.reception_application_number
-  }))
+    .flat()
+    .sort((a: any, b: any) => (b.updated_at || '').localeCompare(a.updated_at || ''))
+
+  return rows.map(mapVisaRow)
 }
 
 export async function getVisaById(id: string): Promise<Visa | null> {


### PR DESCRIPTION
## Summary
- Add a reusable Supabase range pagination helper to fetch beyond the default 1,000-row response window.
- Update people list loading to page through all accessible people, so company filter candidates include tenants beyond the first 1,000 rows.
- Update accessible person-id loading and visa list loading to page through all accessible rows; visa queries are chunked by person IDs to avoid oversized filters.

## Context
西村さんアカウントでは accessible people が 1,380 件あり、医療法人社団慈誠会の人材 81 件は created_at 順で 1,298 番目以降だったため、先頭 1,000 件だけの取得では会社フィルター候補にも出ませんでした。

## Verification
- ✅ `npm test -- lib/supabase/paginated-query.test.ts`
- ✅ `npm test -- lib/supabase/people-access.test.ts lib/supabase/paginated-query.test.ts lib/tenant-access.test.ts`
- ⚠️ `npm test` は既存の `node:test` TAP系ファイルが Vitest から “No test suite found” 扱いになり失敗（今回変更外）
- ⚠️ `npm run typecheck` は既存の connector/tenant-management 等の型エラー多数で失敗（今回変更外）
- ⚠️ Codex review は利用上限で実行不可


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved loading of people and visa records by fetching larger result sets in pages, helping return complete lists even when there are many matches.

* **Bug Fixes**
  * Fixed cases where some people or visas could be missing from results due to query size limits.
  * Added safer handling for empty results and query errors.
  * Access checks now return no results sooner when the user lacks active membership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->