### PR TITLE
[codex] Add person registration flow

### DIFF
--- a/app/api/people/[id]/route.ts
+++ b/app/api/people/[id]/route.ts
@@ -3,6 +3,40 @@ import { revalidatePath } from 'next/cache'
 import { createClient } from '@/lib/supabase/server'
 import type { Person } from '@/lib/models'
 import { getAccessiblePersonIdsForCurrentUser } from '@/lib/supabase/people-access'
+import { isManualPersonId } from '@/lib/person-source'
+import { deleteFileFromStorage, uploadFileToStorage } from '@/lib/storage/file-uploader'
+
+const PEOPLE_IMAGES_BUCKET = 'people-images'
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024
+const VALID_IMAGE_CONTENT_TYPES = ['image/png', 'image/jpeg', 'image/webp', 'image/heic', 'image/heif']
+
+function getRequestValue(body: Record<string, unknown> | FormData, field: string): unknown {
+  return body instanceof FormData ? body.get(field) : body[field]
+}
+
+function getRequestFile(body: Record<string, unknown> | FormData, field: string): File | null {
+  if (!(body instanceof FormData)) return null
+  const value = body.get(field)
+  return value instanceof File && value.size > 0 ? value : null
+}
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function getSafeImageExtension(file: File): string {
+  const extension = file.name.split('.').pop()?.toLowerCase()
+  if (extension && /^[a-z0-9]+$/.test(extension)) return extension
+
+  if (file.type === 'image/jpeg') return 'jpg'
+  if (file.type === 'image/png') return 'png'
+  if (file.type === 'image/webp') return 'webp'
+  if (file.type === 'image/heic') return 'heic'
+  if (file.type === 'image/heif') return 'heif'
+  return 'bin'
+}
 
 export async function PUT(
   request: NextRequest,
@@ -10,7 +44,10 @@ export async function PUT(
 ) {
   try {
     const { id } = params
-    const body = await request.json()
+    const contentType = request.headers.get('content-type') || ''
+    const body = contentType.includes('multipart/form-data')
+      ? await request.formData()
+      : await request.json()
 
     if (!id) {
       return NextResponse.json(
@@ -19,26 +56,28 @@ export async function PUT(
       )
     }
 
-    const {
-      employeeNumber, employmentNotificationDate, employmentChangeNotificationDate,
-      interviewDate, jobOfferDate, applicationNumber, departureProcedureStatus,
-      entryConfirmedDate, myNumber, joiningDate,
-      insuranceNumber, insuranceAcquiredDate, insuranceEnrollmentStatus
-    } = body
-
     // 文字列フィールドのバリデーション
-    const stringFields = [
+    const baseStringFields = [
       'employeeNumber', 'employmentNotificationDate', 'employmentChangeNotificationDate',
       'interviewDate', 'jobOfferDate', 'applicationNumber', 'departureProcedureStatus',
       'entryConfirmedDate', 'myNumber', 'joiningDate',
       'insuranceNumber', 'insuranceAcquiredDate'
     ] as const
+    const manualStringFields = [
+      'name', 'kana', 'nationality', 'dob', 'specificSkillField', 'phone',
+      'workingStatus', 'residenceCardNo', 'residenceCardExpiryDate',
+      'residenceCardIssuedDate', 'email', 'address', 'company', 'note',
+    ] as const
+    const stringFields = isManualPersonId(id)
+      ? [...baseStringFields, ...manualStringFields]
+      : [...baseStringFields]
     for (const field of stringFields) {
-      const value = body[field]
+      const value = getRequestValue(body, field)
       if (value !== undefined && value !== null && typeof value !== 'string') {
         return NextResponse.json({ error: `${field} must be a string or null` }, { status: 400 })
       }
     }
+    const insuranceEnrollmentStatus = getRequestValue(body, 'insuranceEnrollmentStatus')
     if (insuranceEnrollmentStatus !== undefined && insuranceEnrollmentStatus !== null && typeof insuranceEnrollmentStatus !== 'object') {
       return NextResponse.json({ error: 'insuranceEnrollmentStatus must be an object or null' }, { status: 400 })
     }
@@ -52,6 +91,43 @@ export async function PUT(
         { error: 'Person not found' },
         { status: 404 }
       )
+    }
+
+    const { data: currentPerson, error: currentPersonError } = await supabase
+      .from('people')
+      .select('id, tenant_id, image_path')
+      .eq('id', id)
+      .single()
+
+    if (currentPersonError || !currentPerson) {
+      return NextResponse.json(
+        { error: 'Person not found' },
+        { status: 404 }
+      )
+    }
+
+    const isManual = isManualPersonId(id)
+    const imageFile = getRequestFile(body, 'image')
+
+    if (isManual && getRequestValue(body, 'name') !== undefined && !normalizeString(getRequestValue(body, 'name'))) {
+      return NextResponse.json({ error: '氏名は必須です' }, { status: 400 })
+    }
+
+    if (imageFile && !isManual) {
+      return NextResponse.json(
+        { error: 'Kintone連携された人材の写真はこの画面では変更できません' },
+        { status: 403 }
+      )
+    }
+
+    if (imageFile) {
+      if (imageFile.size > MAX_IMAGE_SIZE) {
+        return NextResponse.json({ error: '写真は5MB以下にしてください' }, { status: 400 })
+      }
+
+      if (!VALID_IMAGE_CONTENT_TYPES.includes(imageFile.type)) {
+        return NextResponse.json({ error: '写真はPNG、JPEG、WebP、HEIC、HEIF形式で登録してください' }, { status: 400 })
+      }
     }
 
     // 更新対象のフィールドを構築
@@ -74,14 +150,56 @@ export async function PUT(
       insuranceNumber: 'insurance_number',
       insuranceAcquiredDate: 'insurance_acquired_date',
     }
-    for (const [camelKey, snakeKey] of Object.entries(fieldMapping)) {
-      const value = body[camelKey]
+    const manualFieldMapping: Record<string, string> = {
+      name: 'name',
+      kana: 'kana',
+      nationality: 'nationality',
+      dob: 'dob',
+      specificSkillField: 'specific_skill_field',
+      phone: 'phone',
+      workingStatus: 'working_status',
+      residenceCardNo: 'residence_card_no',
+      residenceCardExpiryDate: 'residence_card_expiry_date',
+      residenceCardIssuedDate: 'residence_card_issued_date',
+      email: 'email',
+      address: 'address',
+      company: 'company',
+      note: 'note',
+    }
+    const activeFieldMapping = isManual
+      ? { ...fieldMapping, ...manualFieldMapping }
+      : fieldMapping
+    for (const [camelKey, snakeKey] of Object.entries(activeFieldMapping)) {
+      const value = getRequestValue(body, camelKey)
       if (value !== undefined) {
         updateFields[snakeKey] = (typeof value === 'string' && value.trim()) ? value.trim() : null
       }
     }
     if (insuranceEnrollmentStatus !== undefined) {
       updateFields.insurance_enrollment_status = insuranceEnrollmentStatus || {}
+    }
+
+    let uploadedImagePath: string | null = null
+    if (imageFile) {
+      const extension = getSafeImageExtension(imageFile)
+      const filePath = `${currentPerson.tenant_id}/manual_people_image/${id}/profile.${extension}`
+      const uploadResult = await uploadFileToStorage(
+        PEOPLE_IMAGES_BUCKET,
+        filePath,
+        await imageFile.arrayBuffer(),
+        imageFile.type,
+        { upsert: true }
+      )
+
+      if (!uploadResult.success) {
+        return NextResponse.json(
+          { error: uploadResult.error || '写真のアップロードに失敗しました' },
+          { status: 500 }
+        )
+      }
+
+      uploadedImagePath = uploadResult.path || filePath
+      updateFields.image_path = uploadedImagePath
     }
 
     // 更新処理
@@ -96,11 +214,21 @@ export async function PUT(
       .single()
 
     if (error) {
+      if (uploadedImagePath) {
+        await deleteFileFromStorage(PEOPLE_IMAGES_BUCKET, uploadedImagePath)
+      }
       console.error('Error updating person:', error)
       return NextResponse.json(
         { error: 'Failed to update person' },
         { status: 500 }
       )
+    }
+
+    if (uploadedImagePath && currentPerson.image_path && currentPerson.image_path !== uploadedImagePath) {
+      const storageResult = await deleteFileFromStorage(PEOPLE_IMAGES_BUCKET, currentPerson.image_path)
+      if (!storageResult.success) {
+        console.error('Failed to delete old person image:', storageResult.error)
+      }
     }
 
     if (!data) {

--- a/app/api/people/route.ts
+++ b/app/api/people/route.ts
@@ -1,0 +1,265 @@
+import { NextRequest, NextResponse } from "next/server"
+import { revalidatePath } from "next/cache"
+import { createClient } from "@/lib/supabase/server"
+import type { Person } from "@/lib/models"
+import { MANUAL_PERSON_ID_PREFIX } from "@/lib/person-source"
+import { deleteFileFromStorage, uploadFileToStorage } from "@/lib/storage/file-uploader"
+
+const STRING_FIELDS = [
+  "name",
+  "kana",
+  "nationality",
+  "dob",
+  "specificSkillField",
+  "phone",
+  "employeeNumber",
+  "workingStatus",
+  "residenceCardNo",
+  "residenceCardExpiryDate",
+  "residenceCardIssuedDate",
+  "email",
+  "address",
+  "company",
+  "note",
+  "employmentNotificationDate",
+  "employmentChangeNotificationDate",
+  "interviewDate",
+  "jobOfferDate",
+  "applicationNumber",
+  "departureProcedureStatus",
+  "entryConfirmedDate",
+  "myNumber",
+  "joiningDate",
+  "insuranceNumber",
+  "insuranceAcquiredDate",
+] as const
+
+const PEOPLE_IMAGES_BUCKET = "people-images"
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024
+const VALID_IMAGE_CONTENT_TYPES = ["image/png", "image/jpeg", "image/webp", "image/heic", "image/heif"]
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function getRequestValue(body: Record<string, unknown> | FormData, field: string): unknown {
+  return body instanceof FormData ? body.get(field) : body[field]
+}
+
+function getRequestFile(body: Record<string, unknown> | FormData, field: string): File | null {
+  if (!(body instanceof FormData)) return null
+  const value = body.get(field)
+  return value instanceof File && value.size > 0 ? value : null
+}
+
+function getSafeImageExtension(file: File): string {
+  const extension = file.name.split(".").pop()?.toLowerCase()
+  if (extension && /^[a-z0-9]+$/.test(extension)) return extension
+
+  if (file.type === "image/jpeg") return "jpg"
+  if (file.type === "image/png") return "png"
+  if (file.type === "image/webp") return "webp"
+  if (file.type === "image/heic") return "heic"
+  if (file.type === "image/heif") return "heif"
+  return "bin"
+}
+
+function mapPerson(data: any): Person {
+  return {
+    id: data.id,
+    name: data.name,
+    kana: data.kana,
+    nationality: data.nationality,
+    dob: data.dob,
+    specificSkillField: data.specific_skill_field,
+    phone: data.phone,
+    employeeNumber: data.employee_number,
+    workingStatus: data.working_status,
+    residenceCardNo: data.residence_card_no,
+    residenceCardExpiryDate: data.residence_card_expiry_date,
+    residenceCardIssuedDate: data.residence_card_issued_date,
+    email: data.email,
+    address: data.address,
+    tenantName: data.tenant?.name,
+    company: data.company,
+    note: data.note,
+    visaId: data.visa_id,
+    externalId: data.external_id,
+    imagePath: data.image_path,
+    employmentNotificationDate: data.employment_notification_date,
+    employmentChangeNotificationDate: data.employment_change_notification_date,
+    interviewDate: data.interview_date,
+    jobOfferDate: data.job_offer_date,
+    applicationNumber: data.application_number,
+    departureProcedureStatus: data.departure_procedure_status,
+    entryConfirmedDate: data.entry_confirmed_date,
+    myNumber: data.my_number,
+    joiningDate: data.joining_date,
+    insuranceNumber: data.insurance_number,
+    insuranceAcquiredDate: data.insurance_acquired_date,
+    insuranceEnrollmentStatus: data.insurance_enrollment_status,
+    createdAt: data.created_at,
+    updatedAt: data.updated_at,
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const contentType = request.headers.get("content-type") || ""
+    const body = contentType.includes("multipart/form-data")
+      ? await request.formData()
+      : await request.json()
+
+    for (const field of STRING_FIELDS) {
+      const value = getRequestValue(body, field)
+      if (value !== undefined && value !== null && typeof value !== "string") {
+        return NextResponse.json({ error: `${field} must be a string or null` }, { status: 400 })
+      }
+    }
+
+    const name = normalizeString(getRequestValue(body, "name"))
+    const tenantId = normalizeString(getRequestValue(body, "tenantId"))
+    const imageFile = getRequestFile(body, "image")
+
+    if (!name) {
+      return NextResponse.json({ error: "氏名は必須です" }, { status: 400 })
+    }
+
+    if (!tenantId) {
+      return NextResponse.json({ error: "会社を選択してください" }, { status: 400 })
+    }
+
+    if (imageFile) {
+      if (imageFile.size > MAX_IMAGE_SIZE) {
+        return NextResponse.json({ error: "写真は5MB以下にしてください" }, { status: 400 })
+      }
+
+      if (!VALID_IMAGE_CONTENT_TYPES.includes(imageFile.type)) {
+        return NextResponse.json({ error: "写真はPNG、JPEG、WebP、HEIC、HEIF形式で登録してください" }, { status: 400 })
+      }
+    }
+
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser()
+
+    if (userError || !user) {
+      return NextResponse.json({ error: "認証が必要です" }, { status: 401 })
+    }
+
+    const { data: memberships, error: membershipError } = await supabase
+      .from("user_tenants")
+      .select("id, tenant_id, status")
+      .eq("user_id", user.id)
+      .eq("tenant_id", tenantId)
+      .eq("status", "active")
+      .limit(1)
+
+    if (membershipError) {
+      console.error("Error checking tenant membership:", membershipError)
+      return NextResponse.json({ error: "会社の確認に失敗しました" }, { status: 500 })
+    }
+
+    if (!memberships || memberships.length === 0) {
+      return NextResponse.json({ error: "この会社に人材を登録する権限がありません" }, { status: 403 })
+    }
+
+    const now = new Date().toISOString()
+    const personId = `${MANUAL_PERSON_ID_PREFIX}${crypto.randomUUID()}`
+    let imagePath: string | null = null
+
+    if (imageFile) {
+      const extension = getSafeImageExtension(imageFile)
+      const filePath = `${tenantId}/manual_people_image/${personId}/profile.${extension}`
+      const uploadResult = await uploadFileToStorage(
+        PEOPLE_IMAGES_BUCKET,
+        filePath,
+        await imageFile.arrayBuffer(),
+        imageFile.type,
+        { upsert: true }
+      )
+
+      if (!uploadResult.success) {
+        return NextResponse.json(
+          { error: uploadResult.error || "写真のアップロードに失敗しました" },
+          { status: 500 }
+        )
+      }
+
+      imagePath = uploadResult.path || filePath
+    }
+
+    const insertFields = {
+      id: personId,
+      tenant_id: tenantId,
+      name,
+      kana: normalizeString(getRequestValue(body, "kana")),
+      nationality: normalizeString(getRequestValue(body, "nationality")),
+      dob: normalizeString(getRequestValue(body, "dob")),
+      specific_skill_field: normalizeString(getRequestValue(body, "specificSkillField")),
+      phone: normalizeString(getRequestValue(body, "phone")),
+      employee_number: normalizeString(getRequestValue(body, "employeeNumber")),
+      working_status: normalizeString(getRequestValue(body, "workingStatus")) ?? "入社待ち",
+      residence_card_no: normalizeString(getRequestValue(body, "residenceCardNo")),
+      residence_card_expiry_date: normalizeString(getRequestValue(body, "residenceCardExpiryDate")),
+      residence_card_issued_date: normalizeString(getRequestValue(body, "residenceCardIssuedDate")),
+      email: normalizeString(getRequestValue(body, "email")),
+      address: normalizeString(getRequestValue(body, "address")),
+      company: normalizeString(getRequestValue(body, "company")),
+      note: normalizeString(getRequestValue(body, "note")),
+      image_path: imagePath,
+      employment_notification_date: normalizeString(getRequestValue(body, "employmentNotificationDate")),
+      employment_change_notification_date: normalizeString(getRequestValue(body, "employmentChangeNotificationDate")),
+      interview_date: normalizeString(getRequestValue(body, "interviewDate")),
+      job_offer_date: normalizeString(getRequestValue(body, "jobOfferDate")),
+      application_number: normalizeString(getRequestValue(body, "applicationNumber")),
+      departure_procedure_status: normalizeString(getRequestValue(body, "departureProcedureStatus")),
+      entry_confirmed_date: normalizeString(getRequestValue(body, "entryConfirmedDate")),
+      my_number: normalizeString(getRequestValue(body, "myNumber")),
+      joining_date: normalizeString(getRequestValue(body, "joiningDate")),
+      insurance_number: normalizeString(getRequestValue(body, "insuranceNumber")),
+      insurance_acquired_date: normalizeString(getRequestValue(body, "insuranceAcquiredDate")),
+      insurance_enrollment_status: {},
+      created_at: now,
+      updated_at: now,
+    }
+
+    const { data, error } = await supabase
+      .from("people")
+      .insert(insertFields)
+      .select(`
+        *,
+        tenant:tenant_id (id, name)
+      `)
+      .single()
+
+    if (error) {
+      if (imagePath) {
+        await deleteFileFromStorage(PEOPLE_IMAGES_BUCKET, imagePath)
+      }
+      console.error("Error creating person:", error)
+      return NextResponse.json({ error: "人材の登録に失敗しました" }, { status: 500 })
+    }
+
+    revalidatePath("/people", "page")
+    revalidatePath(`/people/${data.id}`, "page")
+
+    return NextResponse.json(
+      {
+        success: true,
+        person: mapPerson(data),
+      },
+      { status: 201 }
+    )
+  } catch (error) {
+    console.error("Error creating person:", error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "人材の登録に失敗しました" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/people/[id]/edit/page.tsx
+++ b/app/people/[id]/edit/page.tsx
@@ -8,10 +8,13 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
 import { FunBaseLoading } from "@/components/ui/funbase-loading"
+import { PersonAvatar } from "@/components/ui/person-avatar"
 import { useNavigationProgress } from "@/components/navigation-progress"
-import { ArrowLeft, Save, AlertTriangle, CheckCircle } from "lucide-react"
+import { ArrowLeft, Save, AlertTriangle, CheckCircle, Upload, X } from "lucide-react"
 import { getPersonById } from "@/lib/supabase/people"
+import { isManualPersonId } from "@/lib/person-source"
 import type { Person } from "@/lib/models"
 
 export default function EditPersonPage() {
@@ -27,6 +30,20 @@ export default function EditPersonPage() {
   const [success, setSuccess] = useState(false)
 
   // フォーム状態
+  const [name, setName] = useState('')
+  const [kana, setKana] = useState('')
+  const [nationality, setNationality] = useState('')
+  const [dob, setDob] = useState('')
+  const [specificSkillField, setSpecificSkillField] = useState('')
+  const [phone, setPhone] = useState('')
+  const [workingStatus, setWorkingStatus] = useState('')
+  const [residenceCardNo, setResidenceCardNo] = useState('')
+  const [residenceCardExpiryDate, setResidenceCardExpiryDate] = useState('')
+  const [residenceCardIssuedDate, setResidenceCardIssuedDate] = useState('')
+  const [email, setEmail] = useState('')
+  const [address, setAddress] = useState('')
+  const [company, setCompany] = useState('')
+  const [note, setNote] = useState('')
   const [employeeNumber, setEmployeeNumber] = useState('')
   const [employmentNotificationDate, setEmploymentNotificationDate] = useState('')
   const [employmentChangeNotificationDate, setEmploymentChangeNotificationDate] = useState('')
@@ -41,6 +58,8 @@ export default function EditPersonPage() {
   // 社会保険
   const [insuranceNumber, setInsuranceNumber] = useState('')
   const [insuranceAcquiredDate, setInsuranceAcquiredDate] = useState('')
+  const [imageFile, setImageFile] = useState<File | null>(null)
+  const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null)
 
   // 初期データ取得
   useEffect(() => {
@@ -53,6 +72,20 @@ export default function EditPersonPage() {
           return
         }
         setPerson(data)
+        setName(data.name || '')
+        setKana(data.kana || '')
+        setNationality(data.nationality || '')
+        setDob(data.dob || '')
+        setSpecificSkillField(data.specificSkillField || '')
+        setPhone(data.phone || '')
+        setWorkingStatus(data.workingStatus || '')
+        setResidenceCardNo(data.residenceCardNo || '')
+        setResidenceCardExpiryDate(data.residenceCardExpiryDate || '')
+        setResidenceCardIssuedDate(data.residenceCardIssuedDate || '')
+        setEmail(data.email || '')
+        setAddress(data.address || '')
+        setCompany(data.company || '')
+        setNote(data.note || '')
         setEmployeeNumber(data.employeeNumber || '')
         setEmploymentNotificationDate(data.employmentNotificationDate || '')
         setEmploymentChangeNotificationDate(data.employmentChangeNotificationDate || '')
@@ -74,6 +107,20 @@ export default function EditPersonPage() {
     fetchPerson()
   }, [id])
 
+  useEffect(() => {
+    if (!imageFile) {
+      setImagePreviewUrl(null)
+      return
+    }
+
+    const previewUrl = URL.createObjectURL(imageFile)
+    setImagePreviewUrl(previewUrl)
+
+    return () => {
+      URL.revokeObjectURL(previewUrl)
+    }
+  }, [imageFile])
+
   // 保存処理
   const handleSave = async () => {
     // 連打防止：既に保存中の場合は何もしない
@@ -86,24 +133,64 @@ export default function EditPersonPage() {
       setError(null)
       setSuccess(false)
 
+      const isManual = isManualPersonId(id)
+      const requestBody = isManual ? new FormData() : null
+      if (requestBody) {
+        const values: Record<string, string> = {
+          name,
+          kana,
+          nationality,
+          dob,
+          specificSkillField,
+          phone,
+          employeeNumber,
+          workingStatus,
+          residenceCardNo,
+          residenceCardExpiryDate,
+          residenceCardIssuedDate,
+          email,
+          address,
+          company,
+          note,
+          employmentNotificationDate,
+          employmentChangeNotificationDate,
+          interviewDate,
+          jobOfferDate,
+          applicationNumber,
+          departureProcedureStatus,
+          entryConfirmedDate,
+          joiningDate,
+          insuranceNumber,
+          insuranceAcquiredDate,
+        }
+        Object.entries(values).forEach(([key, value]) => requestBody.append(key, value))
+        if (imageFile) {
+          requestBody.append('image', imageFile)
+        }
+      }
+
       const response = await fetch(`/api/people/${id}`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          employeeNumber: employeeNumber.trim() || null,
-          employmentNotificationDate: employmentNotificationDate || null,
-          employmentChangeNotificationDate: employmentChangeNotificationDate || null,
-          interviewDate: interviewDate || null,
-          jobOfferDate: jobOfferDate || null,
-          applicationNumber: applicationNumber.trim() || null,
-          departureProcedureStatus: departureProcedureStatus.trim() || null,
-          entryConfirmedDate: entryConfirmedDate || null,
-          joiningDate: joiningDate || null,
-          insuranceNumber: insuranceNumber.trim() || null,
-          insuranceAcquiredDate: insuranceAcquiredDate || null,
-        }),
+        ...(requestBody
+          ? { body: requestBody }
+          : {
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                employeeNumber: employeeNumber.trim() || null,
+                employmentNotificationDate: employmentNotificationDate || null,
+                employmentChangeNotificationDate: employmentChangeNotificationDate || null,
+                interviewDate: interviewDate || null,
+                jobOfferDate: jobOfferDate || null,
+                applicationNumber: applicationNumber.trim() || null,
+                departureProcedureStatus: departureProcedureStatus.trim() || null,
+                entryConfirmedDate: entryConfirmedDate || null,
+                joiningDate: joiningDate || null,
+                insuranceNumber: insuranceNumber.trim() || null,
+                insuranceAcquiredDate: insuranceAcquiredDate || null,
+              }),
+            }),
       })
 
       if (!response.ok) {
@@ -154,6 +241,8 @@ export default function EditPersonPage() {
     return null
   }
 
+  const isManual = isManualPersonId(person.id)
+
   return (
     <div className="py-6 px-8 space-y-6 max-w-4xl mx-auto">
       {/* Header */}
@@ -171,7 +260,14 @@ export default function EditPersonPage() {
           </Button>
           <div>
             <h1 className="text-2xl font-bold">人物情報の編集</h1>
-            <p className="text-muted-foreground mt-1">{person.name} さんの情報を編集</p>
+            <div className="mt-1 flex items-center gap-2">
+              <p className="text-muted-foreground">{person.name} さんの情報を編集</p>
+              {isManual && (
+                <Badge variant="outline" className="border-amber-300 bg-amber-50 text-amber-700">
+                  手動登録
+                </Badge>
+              )}
+            </div>
           </div>
         </div>
       </div>
@@ -197,6 +293,55 @@ export default function EditPersonPage() {
 
       {/* Form */}
       <div className="space-y-6">
+        {isManual && (
+          <Card>
+            <CardHeader>
+              <CardTitle>写真</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-[150px_1fr] gap-4 items-start">
+                <Label htmlFor="image" className="text-right pt-2">写真</Label>
+                <div className="space-y-3">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                    <div className="flex h-20 w-20 shrink-0 items-center justify-center overflow-hidden rounded-full border bg-muted">
+                      {imagePreviewUrl ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img src={imagePreviewUrl} alt="選択中の写真" className="h-full w-full object-cover" />
+                      ) : person.imagePath ? (
+                        <PersonAvatar name={name || person.name} imagePath={person.imagePath} size="xl" />
+                      ) : (
+                        <Upload className="h-6 w-6 text-muted-foreground" />
+                      )}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Input
+                        id="image"
+                        type="file"
+                        accept="image/png,image/jpeg,image/webp,image/heic,image/heif"
+                        onChange={(event) => setImageFile(event.target.files?.[0] ?? null)}
+                        disabled={saving}
+                        className="max-w-sm"
+                      />
+                      {imageFile && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          onClick={() => setImageFile(null)}
+                          disabled={saving}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                  <p className="text-xs text-muted-foreground">PNG、JPEG、WebP、HEIC、HEIF形式。5MBまで。</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
         {/* 基本情報 */}
         <Card>
           <CardHeader>
@@ -207,8 +352,9 @@ export default function EditPersonPage() {
               <Label htmlFor="name" className="text-right">氏名</Label>
               <Input
                 id="name"
-                value={person.name || ''}
-                disabled
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                disabled={!isManual || saving}
               />
             </div>
 
@@ -216,8 +362,9 @@ export default function EditPersonPage() {
               <Label htmlFor="kana" className="text-right">フリガナ</Label>
               <Input
                 id="kana"
-                value={person.kana || ''}
-                disabled
+                value={kana}
+                onChange={(e) => setKana(e.target.value)}
+                disabled={!isManual || saving}
               />
             </div>
 
@@ -226,8 +373,9 @@ export default function EditPersonPage() {
               <Input
                 id="dob"
                 type="date"
-                value={person.dob || ''}
-                disabled
+                value={dob}
+                onChange={(e) => setDob(e.target.value)}
+                disabled={!isManual || saving}
                 className="w-full"
               />
             </div>
@@ -249,8 +397,9 @@ export default function EditPersonPage() {
               <Label htmlFor="nationality" className="text-right">国籍</Label>
               <Input
                 id="nationality"
-                value={person.nationality || ''}
-                disabled
+                value={nationality}
+                onChange={(e) => setNationality(e.target.value)}
+                disabled={!isManual || saving}
               />
             </div>
 
@@ -258,18 +407,20 @@ export default function EditPersonPage() {
               <Label htmlFor="workingStatus" className="text-right">ステータス</Label>
               <Input
                 id="workingStatus"
-                value={person.workingStatus || ''}
-                disabled
+                value={workingStatus}
+                onChange={(e) => setWorkingStatus(e.target.value)}
+                disabled={!isManual || saving}
               />
             </div>
 
-            {person.specificSkillField && (
+            {(isManual || person.specificSkillField) && (
               <div className="grid grid-cols-[150px_1fr] gap-4 items-center">
                 <Label htmlFor="specificSkillField" className="text-right">特定技能分野</Label>
                 <Input
                   id="specificSkillField"
-                  value={person.specificSkillField || ''}
-                  disabled
+                  value={specificSkillField}
+                  onChange={(e) => setSpecificSkillField(e.target.value)}
+                  disabled={!isManual || saving}
                 />
               </div>
             )}
@@ -286,8 +437,9 @@ export default function EditPersonPage() {
               <Label htmlFor="residenceCardNo" className="text-right">在留カード番号</Label>
               <Input
                 id="residenceCardNo"
-                value={person.residenceCardNo || ''}
-                disabled
+                value={residenceCardNo}
+                onChange={(e) => setResidenceCardNo(e.target.value)}
+                disabled={!isManual || saving}
               />
             </div>
 
@@ -296,20 +448,22 @@ export default function EditPersonPage() {
               <Input
                 id="residenceCardIssuedDate"
                 type="date"
-                value={person.residenceCardIssuedDate || ''}
-                disabled
+                value={residenceCardIssuedDate}
+                onChange={(e) => setResidenceCardIssuedDate(e.target.value)}
+                disabled={!isManual || saving}
                 className="w-full"
               />
             </div>
 
-            {person.residenceCardExpiryDate && (
+            {(isManual || person.residenceCardExpiryDate) && (
               <div className="grid grid-cols-[150px_1fr] gap-4 items-center">
                 <Label htmlFor="residenceCardExpiryDate" className="text-right">在留カード有効期限</Label>
                 <Input
                   id="residenceCardExpiryDate"
                   type="date"
-                  value={person.residenceCardExpiryDate || ''}
-                  disabled
+                  value={residenceCardExpiryDate}
+                  onChange={(e) => setResidenceCardExpiryDate(e.target.value)}
+                  disabled={!isManual || saving}
                   className="w-full"
                 />
               </div>
@@ -473,14 +627,15 @@ export default function EditPersonPage() {
             <CardTitle>連絡先情報</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            {person.email && (
+            {(isManual || person.email) && (
               <div className="grid grid-cols-[150px_1fr] gap-4 items-center">
                 <Label htmlFor="email" className="text-right">メールアドレス</Label>
                 <Input
                   id="email"
                   type="email"
-                  value={person.email || ''}
-                  disabled
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  disabled={!isManual || saving}
                 />
               </div>
             )}
@@ -489,8 +644,9 @@ export default function EditPersonPage() {
               <Label htmlFor="phone" className="text-right">電話番号</Label>
               <Input
                 id="phone"
-                value={person.phone || ''}
-                disabled
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                disabled={!isManual || saving}
               />
             </div>
 
@@ -498,8 +654,9 @@ export default function EditPersonPage() {
               <Label htmlFor="address" className="text-right pt-2">住所</Label>
               <Textarea
                 id="address"
-                value={person.address || ''}
-                disabled
+                value={address}
+                onChange={(e) => setAddress(e.target.value)}
+                disabled={!isManual || saving}
                 rows={3}
               />
             </div>
@@ -507,7 +664,7 @@ export default function EditPersonPage() {
         </Card>
 
         {/* 所属情報（非表示のフィールドがある場合のみ表示） */}
-        {(person.tenantName || person.company || person.note) && (
+        {(person.tenantName || person.company || person.note || isManual) && (
           <Card>
             <CardHeader>
               <CardTitle>所属情報</CardTitle>
@@ -524,24 +681,26 @@ export default function EditPersonPage() {
                 </div>
               )}
 
-              {person.company && (
+              {(person.company || isManual) && (
                 <div className="grid grid-cols-[150px_1fr] gap-4 items-center">
                   <Label htmlFor="company" className="text-right">所属先</Label>
                   <Input
                     id="company"
-                    value={person.company || ''}
-                    disabled
+                    value={company}
+                    onChange={(e) => setCompany(e.target.value)}
+                    disabled={!isManual || saving}
                   />
                 </div>
               )}
 
-              {person.note && (
+              {(person.note || isManual) && (
                 <div className="grid grid-cols-[150px_1fr] gap-4 items-start">
                   <Label htmlFor="note" className="text-right pt-2">メモ</Label>
                   <Textarea
                     id="note"
-                    value={person.note || ''}
-                    disabled
+                    value={note}
+                    onChange={(e) => setNote(e.target.value)}
+                    disabled={!isManual || saving}
                     rows={4}
                   />
                 </div>

--- a/app/people/[id]/page.tsx
+++ b/app/people/[id]/page.tsx
@@ -11,6 +11,7 @@ import { getPersonById } from "@/lib/supabase/people-server"
 import { getVisasByPersonId } from "@/lib/supabase/visas-server"
 import { getPersonDocumentsByPersonId } from "@/lib/supabase/person-documents-server"
 import { getRegularInterviewsByPersonId, getDailySupportRecordsByPersonId } from "@/lib/kintone-data-server"
+import { isManualPersonId } from "@/lib/person-source"
 import { formatDate, formatDateTime } from "@/lib/utils"
 import { Mail, Phone, MapPin, Building2, Calendar, User, IdCard, User2, Edit, FileText, Plane, Shield, Briefcase } from "lucide-react"
 
@@ -67,6 +68,11 @@ export default async function PersonDetailPage({ params }: PersonDetailPageProps
                   <h1 className="text-2xl font-bold">{person.name}</h1>
                   {person.kana && <p className="text-muted-foreground">{person.kana}</p>}
                   <div className="flex items-center gap-4 mt-2">
+                    {isManualPersonId(person.id) && (
+                      <Badge variant="outline" className="border-amber-300 bg-amber-50 text-amber-700">
+                        手動登録
+                      </Badge>
+                    )}
                     {person.nationality && (
                       <Badge variant="outline" className="gap-1">
                         <User className="h-3 w-3" />

--- a/app/people/new/page.tsx
+++ b/app/people/new/page.tsx
@@ -1,0 +1,661 @@
+"use client"
+
+import { FormEvent, useEffect, useMemo, useState } from "react"
+import { useRouter } from "next/navigation"
+import { AlertTriangle, ArrowLeft, CheckCircle, Save, Upload, X } from "lucide-react"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { FunBaseLoading } from "@/components/ui/funbase-loading"
+import { useNavigationProgress } from "@/components/navigation-progress"
+import { getCurrentUserTenants, getTenantOffices, type TenantOffice, type UserTenant } from "@/lib/supabase/tenants"
+
+const workingStatusOptions = ["入社待ち", "在籍中", "退職", "内定取消", "内定辞退", "支援終了"]
+
+type FormState = {
+  name: string
+  kana: string
+  tenantId: string
+  nationality: string
+  dob: string
+  employeeNumber: string
+  workingStatus: string
+  specificSkillField: string
+  residenceCardNo: string
+  residenceCardIssuedDate: string
+  residenceCardExpiryDate: string
+  email: string
+  phone: string
+  address: string
+  company: string
+  note: string
+  employmentNotificationDate: string
+  employmentChangeNotificationDate: string
+  interviewDate: string
+  jobOfferDate: string
+  applicationNumber: string
+  departureProcedureStatus: string
+  entryConfirmedDate: string
+  joiningDate: string
+  insuranceNumber: string
+  insuranceAcquiredDate: string
+}
+
+const initialForm: FormState = {
+  name: "",
+  kana: "",
+  tenantId: "",
+  nationality: "",
+  dob: "",
+  employeeNumber: "",
+  workingStatus: "入社待ち",
+  specificSkillField: "",
+  residenceCardNo: "",
+  residenceCardIssuedDate: "",
+  residenceCardExpiryDate: "",
+  email: "",
+  phone: "",
+  address: "",
+  company: "",
+  note: "",
+  employmentNotificationDate: "",
+  employmentChangeNotificationDate: "",
+  interviewDate: "",
+  jobOfferDate: "",
+  applicationNumber: "",
+  departureProcedureStatus: "",
+  entryConfirmedDate: "",
+  joiningDate: "",
+  insuranceNumber: "",
+  insuranceAcquiredDate: "",
+}
+
+export default function NewPersonPage() {
+  const router = useRouter()
+  const { startNavigation } = useNavigationProgress()
+  const [form, setForm] = useState<FormState>(initialForm)
+  const [tenants, setTenants] = useState<UserTenant[]>([])
+  const [offices, setOffices] = useState<TenantOffice[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+  const [imageFile, setImageFile] = useState<File | null>(null)
+  const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null)
+
+  const selectedTenant = useMemo(
+    () => tenants.find((tenant) => tenant.tenant_id === form.tenantId),
+    [form.tenantId, tenants]
+  )
+
+  useEffect(() => {
+    async function loadTenants() {
+      try {
+        setLoading(true)
+        setError(null)
+        const userTenants = await getCurrentUserTenants()
+        setTenants(userTenants)
+        if (userTenants.length === 1) {
+          setForm((current) => ({ ...current, tenantId: userTenants[0].tenant_id }))
+        }
+      } catch (err) {
+        console.error("Error loading tenants:", err)
+        setError(err instanceof Error ? err.message : "会社情報の取得に失敗しました")
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadTenants()
+  }, [])
+
+  useEffect(() => {
+    async function loadOffices() {
+      if (!form.tenantId) {
+        setOffices([])
+        return
+      }
+
+      try {
+        const tenantOffices = await getTenantOffices(form.tenantId)
+        setOffices(tenantOffices)
+      } catch (err) {
+        console.error("Error loading offices:", err)
+        setOffices([])
+      }
+    }
+
+    loadOffices()
+  }, [form.tenantId])
+
+  useEffect(() => {
+    if (!imageFile) {
+      setImagePreviewUrl(null)
+      return
+    }
+
+    const previewUrl = URL.createObjectURL(imageFile)
+    setImagePreviewUrl(previewUrl)
+
+    return () => {
+      URL.revokeObjectURL(previewUrl)
+    }
+  }, [imageFile])
+
+  const updateField = (field: keyof FormState, value: string) => {
+    setForm((current) => ({ ...current, [field]: value }))
+  }
+
+  const updateImageFile = (file: File | null) => {
+    setImageFile(file)
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (saving) return
+
+    try {
+      setSaving(true)
+      setError(null)
+      setSuccess(false)
+
+      const requestBody = new FormData()
+      Object.entries(form).forEach(([key, value]) => {
+        requestBody.append(key, value)
+      })
+      if (imageFile) {
+        requestBody.append("image", imageFile)
+      }
+
+      const response = await fetch("/api/people", {
+        method: "POST",
+        body: requestBody,
+      })
+      const result = await response.json()
+
+      if (!response.ok) {
+        throw new Error(result.error || "登録に失敗しました")
+      }
+
+      setSuccess(true)
+      startNavigation()
+      router.push(`/people/${result.person.id}`)
+      router.refresh()
+    } catch (err) {
+      console.error("Create person error:", err)
+      setError(err instanceof Error ? err.message : "登録に失敗しました")
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="p-6">
+        <FunBaseLoading
+          variant="inline"
+          title="登録画面を読み込み中"
+          description="会社情報を確認しています"
+        />
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="py-6 px-4 sm:px-8 space-y-6 max-w-4xl mx-auto">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={() => {
+              startNavigation()
+              router.push("/people")
+            }}
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <div>
+            <h1 className="text-2xl font-bold">人材の新規登録</h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              {selectedTenant?.tenant?.name ?? "登録先の会社"}に人材情報を追加します
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <Alert className="border-red-200 bg-red-50">
+          <AlertTriangle className="h-4 w-4 text-red-600" />
+          <AlertDescription className="text-red-800">{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {success && (
+        <Alert className="border-green-200 bg-green-50">
+          <CheckCircle className="h-4 w-4 text-green-600" />
+          <AlertDescription className="text-green-800">正常に登録されました</AlertDescription>
+        </Alert>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>基本情報</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-start">
+            <Label htmlFor="image" className="sm:text-right sm:pt-2">写真</Label>
+            <div className="space-y-3">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <div className="flex h-20 w-20 shrink-0 items-center justify-center overflow-hidden rounded-full border bg-muted">
+                  {imagePreviewUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={imagePreviewUrl} alt="選択中の写真" className="h-full w-full object-cover" />
+                  ) : (
+                    <Upload className="h-6 w-6 text-muted-foreground" />
+                  )}
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Input
+                    id="image"
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp,image/heic,image/heif"
+                    onChange={(event) => updateImageFile(event.target.files?.[0] ?? null)}
+                    disabled={saving}
+                    className="max-w-sm"
+                  />
+                  {imageFile && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      onClick={() => updateImageFile(null)}
+                      disabled={saving}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground">PNG、JPEG、WebP、HEIC、HEIF形式。5MBまで。</p>
+            </div>
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="name" className="sm:text-right">氏名</Label>
+            <Input
+              id="name"
+              value={form.name}
+              onChange={(event) => updateField("name", event.target.value)}
+              placeholder="氏名を入力"
+              required
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="kana" className="sm:text-right">フリガナ</Label>
+            <Input
+              id="kana"
+              value={form.kana}
+              onChange={(event) => updateField("kana", event.target.value)}
+              placeholder="フリガナを入力"
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="tenantId" className="sm:text-right">会社</Label>
+            <Select
+              value={form.tenantId}
+              onValueChange={(value) => updateField("tenantId", value)}
+              disabled={saving || tenants.length === 0}
+            >
+              <SelectTrigger id="tenantId" className="w-full">
+                <SelectValue placeholder="会社を選択" />
+              </SelectTrigger>
+              <SelectContent>
+                {tenants.map((tenant) => (
+                  <SelectItem key={tenant.tenant_id} value={tenant.tenant_id}>
+                    {tenant.tenant?.name ?? tenant.tenant_id}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="company" className="sm:text-right">所属先</Label>
+            <Input
+              id="company"
+              value={form.company}
+              onChange={(event) => updateField("company", event.target.value)}
+              placeholder={offices.length > 0 ? "所属先を入力または下から選択" : "所属先を入力"}
+              disabled={saving}
+              list="tenant-offices"
+            />
+            <datalist id="tenant-offices">
+              {offices.map((office) => (
+                <option key={office.id} value={office.name} />
+              ))}
+            </datalist>
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="workingStatus" className="sm:text-right">ステータス</Label>
+            <Select
+              value={form.workingStatus}
+              onValueChange={(value) => updateField("workingStatus", value)}
+              disabled={saving}
+            >
+              <SelectTrigger id="workingStatus" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {workingStatusOptions.map((status) => (
+                  <SelectItem key={status} value={status}>
+                    {status}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="nationality" className="sm:text-right">国籍</Label>
+            <Input
+              id="nationality"
+              value={form.nationality}
+              onChange={(event) => updateField("nationality", event.target.value)}
+              placeholder="国籍を入力"
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="dob" className="sm:text-right">生年月日</Label>
+            <Input
+              id="dob"
+              type="date"
+              value={form.dob}
+              onChange={(event) => updateField("dob", event.target.value)}
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="employeeNumber" className="sm:text-right">従業員番号</Label>
+            <Input
+              id="employeeNumber"
+              value={form.employeeNumber}
+              onChange={(event) => updateField("employeeNumber", event.target.value)}
+              placeholder="従業員番号を入力"
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="specificSkillField" className="sm:text-right">特定技能分野</Label>
+            <Input
+              id="specificSkillField"
+              value={form.specificSkillField}
+              onChange={(event) => updateField("specificSkillField", event.target.value)}
+              placeholder="特定技能分野を入力"
+              disabled={saving}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>在留カード情報</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="residenceCardNo" className="sm:text-right">在留カード番号</Label>
+            <Input
+              id="residenceCardNo"
+              value={form.residenceCardNo}
+              onChange={(event) => updateField("residenceCardNo", event.target.value)}
+              placeholder="在留カード番号を入力"
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="residenceCardIssuedDate" className="sm:text-right">在留カード発行日</Label>
+            <Input
+              id="residenceCardIssuedDate"
+              type="date"
+              value={form.residenceCardIssuedDate}
+              onChange={(event) => updateField("residenceCardIssuedDate", event.target.value)}
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="residenceCardExpiryDate" className="sm:text-right">在留カード有効期限</Label>
+            <Input
+              id="residenceCardExpiryDate"
+              type="date"
+              value={form.residenceCardExpiryDate}
+              onChange={(event) => updateField("residenceCardExpiryDate", event.target.value)}
+              disabled={saving}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>連絡先情報</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="email" className="sm:text-right">メールアドレス</Label>
+            <Input
+              id="email"
+              type="email"
+              value={form.email}
+              onChange={(event) => updateField("email", event.target.value)}
+              placeholder="メールアドレスを入力"
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="phone" className="sm:text-right">電話番号</Label>
+            <Input
+              id="phone"
+              value={form.phone}
+              onChange={(event) => updateField("phone", event.target.value)}
+              placeholder="電話番号を入力"
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-start">
+            <Label htmlFor="address" className="sm:text-right sm:pt-2">住所</Label>
+            <Textarea
+              id="address"
+              value={form.address}
+              onChange={(event) => updateField("address", event.target.value)}
+              placeholder="住所を入力"
+              disabled={saving}
+              rows={3}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>進捗情報</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="interviewDate" className="sm:text-right">面接日</Label>
+            <Input
+              id="interviewDate"
+              type="date"
+              value={form.interviewDate}
+              onChange={(event) => updateField("interviewDate", event.target.value)}
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="jobOfferDate" className="sm:text-right">内定日</Label>
+            <Input
+              id="jobOfferDate"
+              type="date"
+              value={form.jobOfferDate}
+              onChange={(event) => updateField("jobOfferDate", event.target.value)}
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="applicationNumber" className="sm:text-right">申請番号</Label>
+            <Input
+              id="applicationNumber"
+              value={form.applicationNumber}
+              onChange={(event) => updateField("applicationNumber", event.target.value)}
+              placeholder="申請番号を入力"
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="departureProcedureStatus" className="sm:text-right">出国手続きの状況</Label>
+            <Input
+              id="departureProcedureStatus"
+              value={form.departureProcedureStatus}
+              onChange={(event) => updateField("departureProcedureStatus", event.target.value)}
+              placeholder="出国手続きの状況を入力"
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="entryConfirmedDate" className="sm:text-right">入国確定日</Label>
+            <Input
+              id="entryConfirmedDate"
+              type="date"
+              value={form.entryConfirmedDate}
+              onChange={(event) => updateField("entryConfirmedDate", event.target.value)}
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="joiningDate" className="sm:text-right">入社日</Label>
+            <Input
+              id="joiningDate"
+              type="date"
+              value={form.joiningDate}
+              onChange={(event) => updateField("joiningDate", event.target.value)}
+              disabled={saving}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>届出・保険情報</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="employmentNotificationDate" className="sm:text-right">雇用状況届出日</Label>
+            <Input
+              id="employmentNotificationDate"
+              type="date"
+              value={form.employmentNotificationDate}
+              onChange={(event) => updateField("employmentNotificationDate", event.target.value)}
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="employmentChangeNotificationDate" className="sm:text-right">変更届出日</Label>
+            <Input
+              id="employmentChangeNotificationDate"
+              type="date"
+              value={form.employmentChangeNotificationDate}
+              onChange={(event) => updateField("employmentChangeNotificationDate", event.target.value)}
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="insuranceNumber" className="sm:text-right">保険番号</Label>
+            <Input
+              id="insuranceNumber"
+              value={form.insuranceNumber}
+              onChange={(event) => updateField("insuranceNumber", event.target.value)}
+              placeholder="保険番号を入力"
+              disabled={saving}
+            />
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-[150px_1fr] sm:items-center">
+            <Label htmlFor="insuranceAcquiredDate" className="sm:text-right">保険取得日</Label>
+            <Input
+              id="insuranceAcquiredDate"
+              type="date"
+              value={form.insuranceAcquiredDate}
+              onChange={(event) => updateField("insuranceAcquiredDate", event.target.value)}
+              disabled={saving}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>メモ</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Textarea
+            id="note"
+            value={form.note}
+            onChange={(event) => updateField("note", event.target.value)}
+            placeholder="メモを入力"
+            disabled={saving}
+            rows={4}
+          />
+        </CardContent>
+      </Card>
+
+      <div className="flex items-center justify-end gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => {
+            startNavigation()
+            router.push("/people")
+          }}
+          disabled={saving}
+        >
+          キャンセル
+        </Button>
+        <Button type="submit" disabled={saving || tenants.length === 0} className="min-w-[120px] gap-2">
+          <Save className="h-4 w-4" />
+          {saving ? "登録中..." : "登録"}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/app/people/page.tsx
+++ b/app/people/page.tsx
@@ -1,7 +1,10 @@
 "use client"
 import { useRouter, useSearchParams } from "next/navigation"
 import { useEffect, useState } from "react"
+import { Plus } from "lucide-react"
 import { DataTable, type Column } from "@/components/ui/data-table"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
 import { StatusBadge } from "@/components/ui/status-badge"
 import { DeadlineChip } from "@/components/ui/deadline-chip"
 import { PersonAvatar } from "@/components/ui/person-avatar"
@@ -9,6 +12,7 @@ import { useNavigationProgress } from "@/components/navigation-progress"
 import { getPeople } from "@/lib/supabase/people"
 import { getVisas } from "@/lib/supabase/visas"
 import { PERSON_SEARCH_KEYS } from "@/lib/person-search"
+import { isManualPersonId } from "@/lib/person-source"
 import type { Person } from "@/lib/models"
 
 interface PersonWithVisa extends Person {
@@ -145,7 +149,14 @@ export default function PeoplePage() {
             size="md"
           />
           <div>
-            <div className="font-medium">{value}</div>
+            <div className="flex items-center gap-2">
+              <span className="font-medium">{value}</span>
+              {isManualPersonId(row.id) && (
+                <Badge variant="outline" className="border-amber-300 bg-amber-50 text-amber-700">
+                  手動
+                </Badge>
+              )}
+            </div>
             {row.kana && <div className="text-xs text-muted-foreground">{row.kana}</div>}
           </div>
         </div>
@@ -278,6 +289,16 @@ export default function PeoplePage() {
           <h1 className="text-3xl font-bold text-foreground">人材一覧</h1>
           <p className="text-muted-foreground mt-2">人材の一覧と基本情報</p>
         </div>
+        <Button
+          className="gap-2"
+          onClick={() => {
+            startNavigation()
+            router.push("/people/new")
+          }}
+        >
+          <Plus className="h-4 w-4" />
+          新規登録
+        </Button>
       </div>
 
 

--- a/lib/access-logger.ts
+++ b/lib/access-logger.ts
@@ -24,6 +24,7 @@ export function getPageTitle(pathname: string): string {
   if (pathname === '/admin/tenants') return 'テナント管理'
   if (pathname.startsWith('/admin/connectors')) return 'コネクタ管理'
   if (pathname === '/admin/access-logs') return 'アクセスログ'
+  if (pathname === '/people/new') return '人材新規登録'
   if (pathname.match(/^\/people\/[^/]+\/edit$/)) return '人材編集'
   if (pathname.match(/^\/people\/[^/]+$/)) return '人材詳細'
   return pathname

--- a/lib/person-source.ts
+++ b/lib/person-source.ts
@@ -1,0 +1,5 @@
+export const MANUAL_PERSON_ID_PREFIX = "manual_"
+
+export function isManualPersonId(id: string | null | undefined): boolean {
+  return Boolean(id?.startsWith(MANUAL_PERSON_ID_PREFIX))
+}


### PR DESCRIPTION
## Summary
- add `/people/new` for manual person registration scoped to the selected tenant
- create manual people through `POST /api/people` with a clear `manual_` ID prefix so Kintone-linked records remain distinguishable
- support profile photo upload for manually registered people on create and edit
- allow full-profile editing for manual people while keeping Kintone-linked people on the existing limited edit surface
- hide photo registration for Kintone-linked people and reject non-manual image updates server-side
- show a `手動登録` badge in person list/detail/edit views

## Validation
- `git diff --check`
- `npm run typecheck -- --pretty false` (fails on existing repository errors in connector / tenant-management / sample data areas)
- `npm run typecheck -- --pretty false 2>&1 | rg "app/api/people/\[id\]/route|app/people/\[id\]/edit"` (no errors in latest touched edit/API files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new person registration page with tenant selection, optional profile photo upload, and live image preview.
  * Added support for editing and saving profile photos on manual person records.
  * Marked manual people with a visible badge in lists and profile pages, plus a new shortcut to create a person from the people list.

* **Bug Fixes**
  * Improved person save flows to handle different record types correctly and prevent photo changes where not allowed.
  * Enhanced validation and image handling for safer uploads and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->