### PR TITLE
[codex] Fix visa fetch scope for accessible people

### DIFF
--- a/app/people/page.tsx
+++ b/app/people/page.tsx
@@ -10,7 +10,7 @@ import { DeadlineChip } from "@/components/ui/deadline-chip"
 import { PersonAvatar } from "@/components/ui/person-avatar"
 import { useNavigationProgress } from "@/components/navigation-progress"
 import { getPeople } from "@/lib/supabase/people"
-import { getVisas } from "@/lib/supabase/visas"
+import { getVisasByPersonIds } from "@/lib/supabase/visas"
 import { PERSON_SEARCH_KEYS } from "@/lib/person-search"
 import { isManualPersonId } from "@/lib/person-source"
 import type { Person } from "@/lib/models"
@@ -71,9 +71,9 @@ export default function PeoplePage() {
     }
   }
 
-  // Load people data
+  // Load people and related visa data
   useEffect(() => {
-    async function fetchPeopleData() {
+    async function fetchData() {
       try {
         setLoading(true)
         setError(null)
@@ -81,6 +81,13 @@ export default function PeoplePage() {
         setPeople(peopleData)
         setDataSource('sample')
         console.log('PeoplePage: People data loaded', { count: peopleData.length })
+
+        try {
+          const visaData = await getVisasByPersonIds(peopleData.map((person) => person.id))
+          setVisas(visaData)
+        } catch (visaError) {
+          console.error('Error fetching visa data:', visaError)
+        }
       } catch (err) {
         console.error('Error fetching people data:', err)
         setError(err instanceof Error ? err.message : 'Failed to load people data')
@@ -88,20 +95,7 @@ export default function PeoplePage() {
         setLoading(false)
       }
     }
-    fetchPeopleData()
-  }, [])
-
-  // Load visa data (always from sample for now)
-  useEffect(() => {
-    async function fetchVisaData() {
-      try {
-        const visaData = await getVisas()
-        setVisas(visaData)
-      } catch (err) {
-        console.error('Error fetching visa data:', err)
-      }
-    }
-    fetchVisaData()
+    fetchData()
   }, [])
 
   // Combine people with their visa information

--- a/app/visas/page.tsx
+++ b/app/visas/page.tsx
@@ -12,7 +12,7 @@ import { BoardLoadingSkeleton } from "@/components/ui/funbase-loading"
 import { useNavigationProgress } from "@/components/navigation-progress"
 import { Search, Filter as FilterIcon, X, ChevronDown, ChevronUp, Building2 } from "lucide-react"
 import { getPeople } from "@/lib/supabase/people"
-import { getVisas } from "@/lib/supabase/visas"
+import { getVisasByPersonIds } from "@/lib/supabase/visas"
 import { matchesPersonSearch } from "@/lib/person-search"
 import { cn, formatDate, isExpiringSoon } from "@/lib/utils"
 import { toggleQueryMultiValue } from "@/lib/interview-list-query"
@@ -68,10 +68,8 @@ export default function VisasPage() {
     async function fetchData() {
       try {
         setLoading(true)
-        const [peopleData, visaData] = await Promise.all([
-          getPeople(),
-          getVisas()
-        ])
+        const peopleData = await getPeople()
+        const visaData = await getVisasByPersonIds(peopleData.map((person) => person.id))
         setPeople(peopleData)
         setVisas(visaData)
       } catch (err) {

--- a/lib/supabase/visas.ts
+++ b/lib/supabase/visas.ts
@@ -81,6 +81,38 @@ export async function getVisas(): Promise<Visa[]> {
   return rows.map(mapVisaRow)
 }
 
+export async function getVisasByPersonIds(personIds: string[]): Promise<Visa[]> {
+  const supabase = createClient()
+  const uniquePersonIds = Array.from(new Set(personIds.filter(Boolean)))
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'visas')
+  const accessiblePersonIdSet = new Set(accessiblePersonIds)
+  const filteredPersonIds = uniquePersonIds.filter((personId) => accessiblePersonIdSet.has(personId))
+
+  if (filteredPersonIds.length === 0) {
+    return []
+  }
+
+  const rows = (
+    await Promise.all(
+      chunkValues(filteredPersonIds, PERSON_ID_FILTER_CHUNK_SIZE).map((personIdChunk) =>
+        fetchAllSupabaseRows(() =>
+          applyVisaStatusExclusions(
+            supabase
+              .from('visas')
+              .select()
+              .in('person_id', personIdChunk)
+              .order('updated_at', { ascending: false })
+          )
+        )
+      )
+    )
+  )
+    .flat()
+    .sort((a: any, b: any) => (b.updated_at || '').localeCompare(a.updated_at || ''))
+
+  return rows.map(mapVisaRow)
+}
+
 export async function getVisaById(id: string): Promise<Visa | null> {
   const supabase = createClient()
   const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(supabase, 'visas')
@@ -103,28 +135,7 @@ export async function getVisaById(id: string): Promise<Visa | null> {
     return null
   }
   
-  return {
-    id: data.id,
-    personId: data.person_id,
-    status: data.status,
-    type: data.type,
-    expiryDate: data.expiry_date,
-    submittedAt: data.submitted_at,
-    resultAt: data.result_at,
-    manager: data.manager,
-    updatedAt: data.updated_at,
-    documentPreparationDate: data.document_preparation_date,
-    documentCreationDate: data.document_creation_date,
-    documentConfirmationDate: data.document_confirmation_date,
-    applicationPreparationDate: data.application_preparation_date,
-    visaApplicationPreparationDate: data.visa_application_preparation_date,
-    applicationDate: data.application_date,
-    additionalDocumentsDate: data.additional_documents_date,
-    visaAcquiredDate: data.visa_acquired_date,
-    receptionNumber: data.reception_number,
-    receptionDate: data.reception_date,
-    receptionApplicationNumber: data.reception_application_number
-  }
+  return mapVisaRow(data)
 }
 
 export async function getVisasByPersonId(personId: string): Promise<Visa[]> {
@@ -148,28 +159,7 @@ export async function getVisasByPersonId(personId: string): Promise<Visa[]> {
     throw error
   }
   
-  return data.map((visa: any) => ({
-    id: visa.id,
-    personId: visa.person_id,
-    status: visa.status,
-    type: visa.type,
-    expiryDate: visa.expiry_date,
-    submittedAt: visa.submitted_at,
-    resultAt: visa.result_at,
-    manager: visa.manager,
-    updatedAt: visa.updated_at,
-    documentPreparationDate: visa.document_preparation_date,
-    documentCreationDate: visa.document_creation_date,
-    documentConfirmationDate: visa.document_confirmation_date,
-    applicationPreparationDate: visa.application_preparation_date,
-    visaApplicationPreparationDate: visa.visa_application_preparation_date,
-    applicationDate: visa.application_date,
-    additionalDocumentsDate: visa.additional_documents_date,
-    visaAcquiredDate: visa.visa_acquired_date,
-    receptionNumber: visa.reception_number,
-    receptionDate: visa.reception_date,
-    receptionApplicationNumber: visa.reception_application_number
-  }))
+  return data.map(mapVisaRow)
 }
 
 export async function createVisa(visa: Omit<Visa, 'updatedAt'>): Promise<Visa> {
@@ -206,28 +196,7 @@ export async function createVisa(visa: Omit<Visa, 'updatedAt'>): Promise<Visa> {
     throw error
   }
   
-  return {
-    id: data.id,
-    personId: data.person_id,
-    status: data.status,
-    type: data.type,
-    expiryDate: data.expiry_date,
-    submittedAt: data.submitted_at,
-    resultAt: data.result_at,
-    manager: data.manager,
-    updatedAt: data.updated_at,
-    documentPreparationDate: data.document_preparation_date,
-    documentCreationDate: data.document_creation_date,
-    documentConfirmationDate: data.document_confirmation_date,
-    applicationPreparationDate: data.application_preparation_date,
-    visaApplicationPreparationDate: data.visa_application_preparation_date,
-    applicationDate: data.application_date,
-    additionalDocumentsDate: data.additional_documents_date,
-    visaAcquiredDate: data.visa_acquired_date,
-    receptionNumber: data.reception_number,
-    receptionDate: data.reception_date,
-    receptionApplicationNumber: data.reception_application_number
-  }
+  return mapVisaRow(data)
 }
 
 export async function updateVisa(id: string, updates: Partial<Omit<Visa, 'id' | 'updatedAt'>>): Promise<Visa> {


### PR DESCRIPTION
## Summary
- Fetch visas by the currently visible people IDs on `/visas` and `/people` instead of relying on a broad page-level visa load.
- Add `getVisasByPersonIds()` using the existing accessible-person guard, chunked person ID filters, and `fetchAllSupabaseRows()` so tenant data is not dropped by the default row cap.
- Keep `/people` resilient if visa loading fails after people data has already loaded.

## Root Cause
The reported Slack case showed 慈誠会 visas missing/stale in FunBase even though the people were visible. The visible symptom came from broad visa loading being capped or detached from the page's accessible people set. On latest `main`, `getVisas()` already scopes globally by accessible person IDs; this PR keeps that approach and adds a narrower helper for page joins that already have the people list.

## Production Recovery
- Manual 慈誠会 `visas` sync succeeded with 131 records.
- Manual 慈誠会 `people` sync succeeded with 81 records.
- The 慈誠会 connector `connection_status` was restored to `connected` with `last_error = null`.

## Validation
- `git diff --check origin/main...HEAD`
- `npx tsc --noEmit -p /private/tmp/fun-base-tsconfig-visas.json`
- `npm run typecheck` was attempted, but the repository currently has existing type errors outside this PR, mostly under connector/admin/tenant-management/sample-data areas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * People and visas pages now load related visa information in a more consistent, person-based flow.

* **Bug Fixes**
  * Improved access handling so visa results are limited to people the current user can view.
  * The people page now stays usable even if loading visa data fails, while still showing available people data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->