### PR TITLE
Restrict company-scoped activity records

### DIFF
--- a/app/actions/page.tsx
+++ b/app/actions/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { AuthGuard } from "@/components/auth-guard"
 import { DataTable, type Column } from "@/components/ui/data-table"
 import { StatusBadge } from "@/components/ui/status-badge"
@@ -8,19 +8,42 @@ import { DeadlineChip } from "@/components/ui/deadline-chip"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { people } from "@/data/people"
-import { supportActions } from "@/data/support-actions"
-import type { SupportAction } from "@/lib/models"
+import { ListPanelLoadingSkeleton } from "@/components/ui/funbase-loading"
+import { getPeople } from "@/lib/supabase/people"
+import { getSupportActions } from "@/lib/supabase/support-actions"
+import type { Person, SupportAction } from "@/lib/models"
 
 interface SupportActionWithPerson extends SupportAction {
   personName?: string
 }
 
 export default function ActionsPage() {
-  const [sortConfig, setSortConfig] = useState<{
-    key: string
-    direction: "asc" | "desc"
-  }>({ key: "due", direction: "asc" })
+  const [people, setPeople] = useState<Person[]>([])
+  const [supportActions, setSupportActions] = useState<SupportAction[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        setLoading(true)
+        setError(null)
+        const [peopleData, supportActionsData] = await Promise.all([
+          getPeople(),
+          getSupportActions(),
+        ])
+        setPeople(peopleData)
+        setSupportActions(supportActionsData)
+      } catch (err) {
+        console.error("Error fetching support actions data:", err)
+        setError("データの取得に失敗しました")
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+  }, [])
 
   // Combine support actions with person information
   const actionsWithPeople: SupportActionWithPerson[] = supportActions.map((action) => {
@@ -128,6 +151,36 @@ export default function ActionsPage() {
       const now = new Date()
       return dueDate < now && a.status !== "done"
     }).length,
+  }
+
+  if (loading) {
+    return (
+      <AuthGuard>
+        <div className="p-6 space-y-6">
+          <div>
+            <h1 className="text-3xl font-bold text-foreground">サポート記録</h1>
+            <p className="text-muted-foreground mt-2">サポートアクションの一覧と進捗管理</p>
+          </div>
+          <ListPanelLoadingSkeleton />
+        </div>
+      </AuthGuard>
+    )
+  }
+
+  if (error) {
+    return (
+      <AuthGuard>
+        <div className="p-6 space-y-6">
+          <div>
+            <h1 className="text-3xl font-bold text-foreground">サポート記録</h1>
+            <p className="text-muted-foreground mt-2">サポートアクションの一覧と進捗管理</p>
+          </div>
+          <div className="flex items-center justify-center py-8">
+            <div className="text-red-500">{error}</div>
+          </div>
+        </div>
+      </AuthGuard>
+    )
   }
 
   return (

--- a/lib/kintone-data-server.ts
+++ b/lib/kintone-data-server.ts
@@ -1,6 +1,8 @@
 import type { DailySupportRecord, RegularInterview } from "@/lib/models"
 import { FUNBASE_REGULAR_MEETING_START_DATE } from "@/lib/meeting-scope"
 import { createClient } from "@/lib/supabase/server"
+import { getAccessiblePersonIdsForCurrentUser } from "@/lib/supabase/people-access"
+import type { TenantFeaturePermission } from "@/lib/tenant-access"
 import {
   INTERVIEW_RECORD_SELECT_COLUMNS_WITH_PERSON,
   isMissingInterviewRecordsTableError,
@@ -13,6 +15,12 @@ import {
 export type InterviewRecordDetail =
   | { recordType: "regular_interview"; record: RegularInterview }
   | { recordType: "daily_support"; record: DailySupportRecord }
+
+type InterviewRecordType = "regular_interview" | "daily_support"
+
+function getFeatureForInterviewRecordType(recordType: InterviewRecordType): TenantFeaturePermission {
+  return recordType === "regular_interview" ? "meetings" : "support_actions"
+}
 
 function handleInterviewRecordsFetchError<T>(context: string, error: { code?: string; message?: string }): T[] {
   if (isMissingInterviewRecordsTableError(error)) {
@@ -34,6 +42,21 @@ function handleInterviewRecordFetchError(context: string, error: { code?: string
   throw error
 }
 
+async function canAccessInterviewRecordPerson(
+  supabase: any,
+  recordType: InterviewRecordType,
+  personId: string | null | undefined
+): Promise<boolean> {
+  if (!personId) return false
+
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(
+    supabase,
+    getFeatureForInterviewRecordType(recordType)
+  )
+
+  return accessiblePersonIds.includes(personId)
+}
+
 export async function getInterviewRecordDetailById(recordId: string): Promise<InterviewRecordDetail | null> {
   const supabase = await createClient()
   const { data, error } = await supabase
@@ -51,6 +74,7 @@ export async function getInterviewRecordDetailById(recordId: string): Promise<In
   const row = data as unknown as InterviewRecordRow
   if (row.record_type === "regular_interview") {
     if (row.interview_date < FUNBASE_REGULAR_MEETING_START_DATE) return null
+    if (!(await canAccessInterviewRecordPerson(supabase, "regular_interview", row.person_id))) return null
 
     return {
       recordType: "regular_interview",
@@ -59,6 +83,8 @@ export async function getInterviewRecordDetailById(recordId: string): Promise<In
   }
 
   if (row.record_type === "daily_support") {
+    if (!(await canAccessInterviewRecordPerson(supabase, "daily_support", row.person_id))) return null
+
     const record = mapInterviewRecordToDailySupportRecord(row)
     if (record.dailyEntries.length === 0) return null
 
@@ -74,6 +100,10 @@ export async function getInterviewRecordDetailById(recordId: string): Promise<In
 
 export async function getRegularInterviewsByPersonId(personId: string): Promise<RegularInterview[]> {
   const supabase = await createClient()
+  if (!(await canAccessInterviewRecordPerson(supabase, "regular_interview", personId))) {
+    return []
+  }
+
   console.log("[interview-records] getRegularInterviewsByPersonId fetch start", { personId })
   const { data, error } = await supabase
     .from("interview_records")
@@ -95,6 +125,10 @@ export async function getRegularInterviewsByPersonId(personId: string): Promise<
 
 export async function getDailySupportRecordsByPersonId(personId: string): Promise<DailySupportRecord[]> {
   const supabase = await createClient()
+  if (!(await canAccessInterviewRecordPerson(supabase, "daily_support", personId))) {
+    return []
+  }
+
   console.log("[interview-records] getDailySupportRecordsByPersonId fetch start", { personId })
   const { data, error } = await supabase
     .from("interview_records")

--- a/lib/kintone-data.ts
+++ b/lib/kintone-data.ts
@@ -85,6 +85,9 @@ async function fetchInterviewRecordRowsByType(
 
   for (const personIdChunk of chunkPersonIds(personIds)) {
     let offset = 0
+    const pageSize = options.limit
+      ? Math.min(INTERVIEW_RECORD_PAGE_SIZE, Math.max(options.limit, 1))
+      : INTERVIEW_RECORD_PAGE_SIZE
 
     while (true) {
       let query = supabase
@@ -100,7 +103,7 @@ async function fetchInterviewRecordRowsByType(
       const { data, error } = await query
         .order("interview_date", { ascending: false })
         .order("created_at", { ascending: false })
-        .range(offset, offset + INTERVIEW_RECORD_PAGE_SIZE - 1)
+        .range(offset, offset + pageSize - 1)
 
       if (error) {
         return handleInterviewRecordsFetchError(`fetch ${recordType} records`, error)
@@ -109,8 +112,8 @@ async function fetchInterviewRecordRowsByType(
       const batch = (data || []) as InterviewRecordRow[]
       rows.push(...batch)
 
-      if (batch.length < INTERVIEW_RECORD_PAGE_SIZE) break
-      offset += INTERVIEW_RECORD_PAGE_SIZE
+      if (options.limit || batch.length < pageSize) break
+      offset += pageSize
     }
   }
 

--- a/lib/kintone-data.ts
+++ b/lib/kintone-data.ts
@@ -8,6 +8,8 @@
 import type { CompanyConfirmationStatus, RegularInterview, DailySupportRecord, DailySupportEntry } from "@/lib/models"
 import { FUNBASE_REGULAR_MEETING_START_DATE } from "@/lib/meeting-scope"
 import { createClient } from "@/lib/supabase/client"
+import { getAccessiblePersonIdsForCurrentUser } from "@/lib/supabase/people-access"
+import type { TenantFeaturePermission } from "@/lib/tenant-access"
 import {
   DEFAULT_COMPANY_CONFIRMATION_STATUS,
   ELIGIBLE_REGULAR_INTERVIEW_KINTONE_STATUS,
@@ -28,6 +30,32 @@ import {
 // ============================================================================
 
 const INTERVIEW_RECORD_PAGE_SIZE = 1000
+const PERSON_ID_FILTER_CHUNK_SIZE = 500
+
+type InterviewRecordType = "regular_interview" | "daily_support"
+
+function getFeatureForInterviewRecordType(recordType: InterviewRecordType): TenantFeaturePermission {
+  return recordType === "regular_interview" ? "meetings" : "support_actions"
+}
+
+function chunkPersonIds(personIds: string[]): string[][] {
+  const chunks: string[][] = []
+
+  for (let index = 0; index < personIds.length; index += PERSON_ID_FILTER_CHUNK_SIZE) {
+    chunks.push(personIds.slice(index, index + PERSON_ID_FILTER_CHUNK_SIZE))
+  }
+
+  return chunks
+}
+
+function sortInterviewRecordRows(rows: InterviewRecordRow[]): InterviewRecordRow[] {
+  return [...rows].sort((a, b) => {
+    const interviewDateOrder = (b.interview_date || "").localeCompare(a.interview_date || "")
+    if (interviewDateOrder !== 0) return interviewDateOrder
+
+    return (b.created_at || "").localeCompare(a.created_at || "")
+  })
+}
 
 function handleInterviewRecordsFetchError<T>(context: string, error: { code?: string; message?: string }): T[] {
   if (isMissingInterviewRecordsTableError(error)) {
@@ -39,38 +67,54 @@ function handleInterviewRecordsFetchError<T>(context: string, error: { code?: st
   throw error
 }
 
-async function fetchInterviewRecordRowsByType(recordType: "regular_interview" | "daily_support"): Promise<InterviewRecordRow[]> {
+async function fetchInterviewRecordRowsByType(
+  recordType: InterviewRecordType,
+  options: { personId?: string; limit?: number } = {}
+): Promise<InterviewRecordRow[]> {
   const supabase = createClient()
   const rows: InterviewRecordRow[] = []
-  let offset = 0
+  const accessiblePersonIds = await getAccessiblePersonIdsForCurrentUser(
+    supabase,
+    getFeatureForInterviewRecordType(recordType)
+  )
 
-  while (true) {
-    let query = supabase
-      .from("interview_records")
-      .select(INTERVIEW_RECORD_SELECT_COLUMNS_WITH_PERSON)
-      .eq("record_type", recordType)
+  if (accessiblePersonIds.length === 0) return []
 
-    if (recordType === "regular_interview") {
-      query = query.gte("interview_date", FUNBASE_REGULAR_MEETING_START_DATE)
+  const personIds = options.personId ? [options.personId] : accessiblePersonIds
+  if (options.personId && !accessiblePersonIds.includes(options.personId)) return []
+
+  for (const personIdChunk of chunkPersonIds(personIds)) {
+    let offset = 0
+
+    while (true) {
+      let query = supabase
+        .from("interview_records")
+        .select(INTERVIEW_RECORD_SELECT_COLUMNS_WITH_PERSON)
+        .eq("record_type", recordType)
+        .in("person_id", personIdChunk)
+
+      if (recordType === "regular_interview") {
+        query = query.gte("interview_date", FUNBASE_REGULAR_MEETING_START_DATE)
+      }
+
+      const { data, error } = await query
+        .order("interview_date", { ascending: false })
+        .order("created_at", { ascending: false })
+        .range(offset, offset + INTERVIEW_RECORD_PAGE_SIZE - 1)
+
+      if (error) {
+        return handleInterviewRecordsFetchError(`fetch ${recordType} records`, error)
+      }
+
+      const batch = (data || []) as InterviewRecordRow[]
+      rows.push(...batch)
+
+      if (batch.length < INTERVIEW_RECORD_PAGE_SIZE) break
+      offset += INTERVIEW_RECORD_PAGE_SIZE
     }
-
-    const { data, error } = await query
-      .order("interview_date", { ascending: false })
-      .order("created_at", { ascending: false })
-      .range(offset, offset + INTERVIEW_RECORD_PAGE_SIZE - 1)
-
-    if (error) {
-      return handleInterviewRecordsFetchError(`fetch ${recordType} records`, error)
-    }
-
-    const batch = (data || []) as InterviewRecordRow[]
-    rows.push(...batch)
-
-    if (batch.length < INTERVIEW_RECORD_PAGE_SIZE) break
-    offset += INTERVIEW_RECORD_PAGE_SIZE
   }
 
-  return rows
+  return sortInterviewRecordRows(rows).slice(0, options.limit)
 }
 
 /**
@@ -86,21 +130,8 @@ export async function getRegularInterviews(): Promise<RegularInterview[]> {
  * Get latest regular interviews for compact dashboard widgets.
  */
 export async function getLatestRegularInterviews(limit = 5): Promise<RegularInterview[]> {
-  const supabase = createClient()
-  const { data, error } = await supabase
-    .from("interview_records")
-    .select(INTERVIEW_RECORD_SELECT_COLUMNS_WITH_PERSON)
-    .eq("record_type", "regular_interview")
-    .gte("interview_date", FUNBASE_REGULAR_MEETING_START_DATE)
-    .order("interview_date", { ascending: false })
-    .order("created_at", { ascending: false })
-    .limit(limit)
-
-  if (error) {
-    return handleInterviewRecordsFetchError("fetch latest regular interviews", error)
-  }
-
-  return ((data || []) as InterviewRecordRow[]).map(mapInterviewRecordToRegularInterview)
+  const rows = await fetchInterviewRecordRowsByType("regular_interview", { limit })
+  return rows.map(mapInterviewRecordToRegularInterview)
 }
 
 /**
@@ -108,21 +139,8 @@ export async function getLatestRegularInterviews(limit = 5): Promise<RegularInte
  * @param personId - The FunBase people.id
  */
 export async function getRegularInterviewsByPersonId(personId: string): Promise<RegularInterview[]> {
-  const supabase = createClient()
-  const { data, error } = await supabase
-    .from("interview_records")
-    .select(INTERVIEW_RECORD_SELECT_COLUMNS_WITH_PERSON)
-    .eq("record_type", "regular_interview")
-    .gte("interview_date", FUNBASE_REGULAR_MEETING_START_DATE)
-    .eq("person_id", personId)
-    .order("interview_date", { ascending: false })
-    .order("created_at", { ascending: false })
-
-  if (error) {
-    return handleInterviewRecordsFetchError("fetch regular interviews by person", error)
-  }
-
-  return ((data || []) as InterviewRecordRow[]).map(mapInterviewRecordToRegularInterview)
+  const rows = await fetchInterviewRecordRowsByType("regular_interview", { personId })
+  return rows.map(mapInterviewRecordToRegularInterview)
 }
 
 /**
@@ -138,21 +156,9 @@ export async function getDailySupportRecords(): Promise<DailySupportRecord[]> {
  * Get latest daily support records for compact dashboard widgets.
  */
 export async function getLatestDailySupportRecords(limit = 5): Promise<DailySupportRecord[]> {
-  const supabase = createClient()
   const fetchLimit = Math.min(Math.max(limit * 5, limit), 100)
-  const { data, error } = await supabase
-    .from("interview_records")
-    .select(INTERVIEW_RECORD_SELECT_COLUMNS_WITH_PERSON)
-    .eq("record_type", "daily_support")
-    .order("interview_date", { ascending: false })
-    .order("created_at", { ascending: false })
-    .limit(fetchLimit)
-
-  if (error) {
-    return handleInterviewRecordsFetchError("fetch latest daily support records", error)
-  }
-
-  return mapInterviewRecordRowsToDailySupportRecords((data || []) as InterviewRecordRow[]).slice(0, limit)
+  const rows = await fetchInterviewRecordRowsByType("daily_support", { limit: fetchLimit })
+  return mapInterviewRecordRowsToDailySupportRecords(rows).slice(0, limit)
 }
 
 /**
@@ -160,20 +166,8 @@ export async function getLatestDailySupportRecords(limit = 5): Promise<DailySupp
  * @param personId - The FunBase people.id
  */
 export async function getDailySupportRecordsByPersonId(personId: string): Promise<DailySupportRecord[]> {
-  const supabase = createClient()
-  const { data, error } = await supabase
-    .from("interview_records")
-    .select(INTERVIEW_RECORD_SELECT_COLUMNS_WITH_PERSON)
-    .eq("record_type", "daily_support")
-    .eq("person_id", personId)
-    .order("interview_date", { ascending: false })
-    .order("created_at", { ascending: false })
-
-  if (error) {
-    return handleInterviewRecordsFetchError("fetch daily support records by person", error)
-  }
-
-  return mapInterviewRecordRowsToDailySupportRecords((data || []) as InterviewRecordRow[])
+  const rows = await fetchInterviewRecordRowsByType("daily_support", { personId })
+  return mapInterviewRecordRowsToDailySupportRecords(rows)
 }
 
 /**

--- a/lib/supabase/people-access.test.ts
+++ b/lib/supabase/people-access.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest"
-import { buildCompanyAccess, canAccessPersonByCompany } from "./people-access"
+import { buildCompanyAccess, canAccessPersonByCompany, getAccessiblePersonIdsForUser } from "./people-access"
 
 describe("people company access", () => {
   test("allows owner-like roles to see every company in their tenant", () => {
@@ -84,5 +84,47 @@ describe("people company access", () => {
 
     expect(canAccessPersonByCompany({ tenant_id: "tenant-1", company: "名谷病院" }, access)).toBe(false)
     expect(canAccessPersonByCompany({ tenant_id: "tenant-1", company: "天王寺特別養護老人ホーム" }, access)).toBe(false)
+  })
+
+  test("returns no accessible people when a feature is disabled", async () => {
+    const supabase = {
+      from(tableName: string) {
+        if (tableName === "user_tenants") {
+          return {
+            select: () => ({
+              eq: () => ({
+                eq: async () => ({
+                  data: [
+                    {
+                      id: "membership-1",
+                      tenant_id: "tenant-1",
+                      role: "member",
+                      status: "active",
+                      feature_permissions: { meetings: false },
+                    },
+                  ],
+                  error: null,
+                }),
+              }),
+            }),
+          }
+        }
+
+        if (tableName === "user_tenant_offices") {
+          return {
+            select: () => ({
+              in: async () => ({
+                data: [],
+                error: null,
+              }),
+            }),
+          }
+        }
+
+        throw new Error(`Unexpected table: ${tableName}`)
+      },
+    }
+
+    await expect(getAccessiblePersonIdsForUser(supabase, "user-1", "meetings")).resolves.toEqual([])
   })
 })

--- a/lib/supabase/people-access.ts
+++ b/lib/supabase/people-access.ts
@@ -305,6 +305,16 @@ function buildPeopleAccessOrFilter(access: CompanyAccess): string | null {
   return clauses.length > 0 ? clauses.join(",") : null
 }
 
+function hasVisibleCompanyAccess(access: CompanyAccess): boolean {
+  if (access.fullTenantIds.size > 0) return true
+
+  for (const companies of access.restrictedTenantCompanies.values()) {
+    if (companies.size > 0) return true
+  }
+
+  return false
+}
+
 export function applyPeopleAccessFilter<TQuery extends { or: (filters: string) => TQuery }>(
   query: TQuery,
   access: CompanyAccess
@@ -320,7 +330,7 @@ export async function getAccessiblePersonIdsForUser(
   feature: TenantFeaturePermission = "people"
 ): Promise<string[]> {
   const access = await getCompanyAccessForUser(supabase, userId, feature)
-  if (!access.hasActiveMembership) return []
+  if (!access.hasActiveMembership || !hasVisibleCompanyAccess(access)) return []
 
   const data = await fetchAllSupabaseRows(() => {
     const query = applyPeopleAccessFilter(

--- a/lib/supabase/visas-server.ts
+++ b/lib/supabase/visas-server.ts
@@ -1,5 +1,10 @@
 import { createClient } from './server'
 import type { Visa } from '@/lib/models'
+import {
+  applyPeopleAccessFilter,
+  canAccessPersonByCompany,
+  getCompanyAccessForUser,
+} from './people-access'
 
 /**
  * Server-side only function to get visas by person ID
@@ -7,18 +12,41 @@ import type { Visa } from '@/lib/models'
  */
 export async function getVisasByPersonId(personId: string): Promise<Visa[]> {
   const supabase = await createClient()
-  
+  const { data: { user } } = await supabase.auth.getUser()
+
+  if (!user) return []
+
+  const companyAccess = await getCompanyAccessForUser(supabase, user.id, "visas")
+  const personQuery = applyPeopleAccessFilter(
+    supabase
+      .from('people')
+      .select('id, tenant_id, company')
+      .eq('id', personId),
+    companyAccess
+  )
+
+  if (!personQuery) return []
+
+  const { data: person, error: personError } = await personQuery.single()
+
+  if (personError || !person || !canAccessPersonByCompany(person, companyAccess)) {
+    if (personError) {
+      console.error('Error verifying visa person access:', personError)
+    }
+    return []
+  }
+
   const { data, error } = await supabase
     .from('visas')
     .select()
     .eq('person_id', personId)
     .order('updated_at', { ascending: false })
-  
+
   if (error) {
     console.error('Error fetching visas by person ID:', error)
     throw error
   }
-  
+
   return data.map((visa: any) => ({
     id: visa.id,
     personId: visa.person_id,
@@ -42,4 +70,3 @@ export async function getVisasByPersonId(personId: string): Promise<Visa[]> {
     receptionApplicationNumber: visa.reception_application_number
   }))
 }
-

--- a/scripts/20260715_company_scoped_record_rls.sql
+++ b/scripts/20260715_company_scoped_record_rls.sql
@@ -1,0 +1,99 @@
+-- Company-scoped read policy for synced interview_records.
+--
+-- This script mirrors the FunBase application access model:
+-- - owner/admin/supporter can read all companies in their active tenant.
+-- - member/guest can read assigned active tenant_offices only.
+-- - member/guest with no active office assignment keeps full tenant access.
+-- - feature_permissions.{feature} = false denies that feature.
+--
+-- Move this file into the fun-base-infra supabase/migrations directory before
+-- applying through the normal Supabase migration flow.
+--
+-- This intentionally enables RLS only on interview_records. Other CRUD tables
+-- such as people, visas, meetings, and support_actions need separate write
+-- policies before RLS can be enabled safely there.
+
+create or replace function public.funbase_current_user_can_access_company(
+  p_tenant_id text,
+  p_company_name text,
+  p_feature text
+)
+returns boolean
+language sql
+stable
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.user_tenants ut
+    where ut.user_id = (select auth.uid())
+      and ut.status = 'active'
+      and ut.tenant_id::text = p_tenant_id
+      and (
+        ut.role in ('owner', 'admin', 'supporter')
+        or coalesce((ut.feature_permissions::jsonb ->> p_feature)::boolean, true)
+      )
+      and (
+        ut.role in ('owner', 'admin', 'supporter')
+        or not exists (
+          select 1
+          from public.user_tenant_offices uto
+          join public.tenant_offices office
+            on office.id = uto.tenant_office_id
+          where uto.user_tenant_id = ut.id
+            and office.is_active = true
+        )
+        or exists (
+          select 1
+          from public.user_tenant_offices uto
+          join public.tenant_offices office
+            on office.id = uto.tenant_office_id
+          where uto.user_tenant_id = ut.id
+            and office.is_active = true
+            and office.name = p_company_name
+        )
+      )
+  );
+$$;
+
+create or replace function public.funbase_current_user_can_access_person(
+  p_person_id text,
+  p_feature text
+)
+returns boolean
+language sql
+stable
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.people p
+    where p.id::text = p_person_id
+      and public.funbase_current_user_can_access_company(
+        p.tenant_id::text,
+        p.company,
+        p_feature
+      )
+  );
+$$;
+
+alter table public.interview_records enable row level security;
+
+drop policy if exists "company scoped interview records select" on public.interview_records;
+create policy "company scoped interview records select"
+on public.interview_records
+for select
+to authenticated
+using (
+  case record_type
+    when 'regular_interview' then (
+      public.funbase_current_user_can_access_person(person_id::text, 'meetings')
+      or public.funbase_current_user_can_access_company(tenant_id::text, company_name, 'meetings')
+    )
+    when 'daily_support' then (
+      public.funbase_current_user_can_access_person(person_id::text, 'support_actions')
+      or public.funbase_current_user_can_access_company(tenant_id::text, company_name, 'support_actions')
+    )
+    else false
+  end
+);


### PR DESCRIPTION
## Summary
- Scope synced `interview_records` reads by the current user's tenant/company access for meetings and support_actions.
- Apply the same guard to interview record detail and person-specific server reads.
- Add an executable RLS SQL script for `interview_records` that mirrors the tenant office and feature-permission model.
- Return an empty accessible-person set instead of throwing when a feature permission is disabled.

## Why
Company contacts assigned to a specific facility should not see interviews, support records, or timeline activities for people outside that facility. The current meetings/support/timeline screens read the Kintone-synced `interview_records` table, so the existing legacy `meetings` / `support_actions` helpers were not enough.

## Validation
- `./node_modules/.bin/vitest run lib/supabase/people-access.test.ts lib/interview-record-mapper.test.ts`
- `npx tsc --noEmit` still fails on existing connector / tenant-management / fixture type errors outside this change; no errors were reported for the touched files.