### PR TITLE
fix: link interview records by work id

### DIFF
--- a/lib/sync/interview-record-transformer.test.ts
+++ b/lib/sync/interview-record-transformer.test.ts
@@ -201,7 +201,7 @@ test('transformInterviewRecord maps daily support regardless of source status', 
   ])
 })
 
-test('transformInterviewRecord falls back to HRID when WOID is missing', () => {
+test('transformInterviewRecord keeps source_person_id based on WOID, not HRID', () => {
   const row = transformInterviewRecord(
     {
       $id: { value: '9562' },
@@ -219,7 +219,7 @@ test('transformInterviewRecord falls back to HRID when WOID is missing', () => {
     }
   )
 
-  assert.equal(row.source_person_id, '3505')
+  assert.equal(row.source_person_id, null)
 })
 
 test('parseActivityEntries normalizes Kintone subtable rows for daily support', () => {

--- a/lib/sync/interview-record-transformer.ts
+++ b/lib/sync/interview-record-transformer.ts
@@ -167,12 +167,8 @@ export function getInterviewRecordSourceWorkId(record: KintoneRecord): string | 
   return toStringOrNull(fieldValue(record, 'WOID'))
 }
 
-export function getInterviewRecordSourceHumanResourceId(record: KintoneRecord): string | null {
-  return toStringOrNull(fieldValue(record, 'HRID'))
-}
-
 export function getInterviewRecordSourcePersonId(record: KintoneRecord): string | null {
-  return getInterviewRecordSourceWorkId(record) ?? getInterviewRecordSourceHumanResourceId(record)
+  return getInterviewRecordSourceWorkId(record)
 }
 
 export function getInterviewRecordSourceRecordId(record: KintoneRecord): string | null {

--- a/lib/sync/kintone-sync.ts
+++ b/lib/sync/kintone-sync.ts
@@ -15,7 +15,6 @@ import { uploadFileToStorage } from '@/lib/storage/file-uploader'
 import { getDataMappings, mapFieldValues, type DataMapping } from '@/lib/mappings/value-mapper'
 import {
   buildInterviewRecordsQuery,
-  getInterviewRecordSourceHumanResourceId,
   getInterviewRecordSourceRecordId,
   getInterviewRecordSourceWorkId,
   isImportableInterviewRecord,
@@ -1064,82 +1063,37 @@ export class KintoneDataSync {
           }
 
           const sourceWorkId = getInterviewRecordSourceWorkId(record)
-          const sourceHumanResourceId = getInterviewRecordSourceHumanResourceId(record)
-          if (!sourceWorkId && !sourceHumanResourceId) {
+          if (!sourceWorkId) {
             skippedUnlinked++
             console.warn('[sync] interview-records:skip', {
               sourceRecordId,
-              reason: 'missing-source-person-link-id',
+              reason: 'missing-source-work-id',
             })
             return
           }
 
-          let personId: string | null = null
-          if (sourceWorkId) {
-            const { data: workIdPeople, error: workIdPersonError } = await this.supabase
-              .from('people')
-              .select('id')
-              .eq('tenant_id', this.tenantId)
-              .eq('id', sourceWorkId)
-              .limit(1)
+          const { data: workIdPeople, error: workIdPersonError } = await this.supabase
+            .from('people')
+            .select('id')
+            .eq('tenant_id', this.tenantId)
+            .eq('id', sourceWorkId)
+            .limit(1)
 
-            if (workIdPersonError) {
-              console.error('[sync] interview-records:person-lookup-error', {
-                sourceRecordId,
-                lookup: 'WOID',
-                error: workIdPersonError.message,
-              })
-              throw workIdPersonError
-            }
-
-            personId = workIdPeople?.[0]?.id ?? null
-          }
-
-          let fallbackPeople: Array<{ id: string }> | null = null
-          if (!personId && sourceHumanResourceId) {
-            const { data: people, error: personError } = await this.supabase
-              .from('people')
-              .select('id')
-              .eq('tenant_id', this.tenantId)
-              .eq('external_id', sourceHumanResourceId)
-              .limit(2)
-
-            if (personError) {
-              console.error('[sync] interview-records:person-lookup-error', {
-                sourceRecordId,
-                lookup: 'HRID',
-                error: personError.message,
-              })
-              throw personError
-            }
-
-            fallbackPeople = people
-          }
-
-          if (!personId && (!fallbackPeople || fallbackPeople.length === 0)) {
-            skippedUnlinked++
-            console.warn('[sync] interview-records:skip', {
+          if (workIdPersonError) {
+            console.error('[sync] interview-records:person-lookup-error', {
               sourceRecordId,
-              reason: 'person-not-found',
+              lookup: 'WOID',
+              error: workIdPersonError.message,
             })
-            return
+            throw workIdPersonError
           }
 
-          if (!personId && fallbackPeople && fallbackPeople.length > 1) {
-            skippedAmbiguousPerson++
-            console.warn('[sync] interview-records:skip', {
-              sourceRecordId,
-              reason: 'ambiguous-person',
-            })
-            return
-          }
-
-          personId = personId ?? fallbackPeople?.[0]?.id ?? null
+          const personId = workIdPeople?.[0]?.id ?? null
           if (!personId) {
             skippedUnlinked++
             console.warn('[sync] interview-records:skip', {
               sourceRecordId,
-              reason: 'person-not-found',
+              reason: 'work-id-person-not-found',
             })
             return
           }


### PR DESCRIPTION
## Summary
- 面談記録同期の紐づけをWOID（就労管理ID）必須に変更
- HRID（人材ID）でのフォールバック検索を削除
- `source_person_id` もWOIDのみを保存するように修正
- WOIDがない面談記録は同期対象外としてスキップ

## Tests
- ✅ `./node_modules/.bin/vitest run lib/sync/interview-record-transformer.test.ts --reporter=dot`
- ✅ `git diff --check`
- ✅ `codex review --base origin/main`
- ⚠️ `./node_modules/.bin/tsc --noEmit` は既存の型エラー（admin connector/tenant-management/data fixtures等）で失敗。今回変更箇所起因の新規エラーは確認されず。

## Notes
- repoは文脈から `fun-base` と判断しました。
