### PR TITLE
feat: add interview record notifications

### DIFF
--- a/app/settings/notifications/page.tsx
+++ b/app/settings/notifications/page.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { ArrowLeft, Bell } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { useAuth } from "@/contexts/auth-context"
+import { useToast } from "@/lib/hooks/use-toast"
+import { INTERVIEW_RECORD_EMAIL_NOTIFICATION_TYPE } from "@/lib/notifications/interview-record-notifications"
+import {
+  getNotificationPreferences,
+  updateNotificationPreference,
+} from "@/lib/supabase/notification-preferences"
+
+export default function NotificationSettingsPage() {
+  const router = useRouter()
+  const { user, loading: authLoading } = useAuth()
+  const { toast } = useToast()
+  const [interviewEmailEnabled, setInterviewEmailEnabled] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (authLoading) return
+    if (!user) {
+      router.replace("/login")
+      return
+    }
+
+    const load = async () => {
+      try {
+        const preferences = await getNotificationPreferences()
+        const interviewPreference = preferences.find(
+          (preference) => preference.notificationType === INTERVIEW_RECORD_EMAIL_NOTIFICATION_TYPE
+        )
+        setInterviewEmailEnabled(interviewPreference?.enabled ?? false)
+      } catch (error) {
+        console.error("Failed to load notification settings:", error)
+        toast({ title: "通知設定の読み込みに失敗しました", variant: "destructive" })
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    load()
+  }, [authLoading, router, toast, user])
+
+  const handleInterviewEmailChange = async (enabled: boolean) => {
+    const previous = interviewEmailEnabled
+    setInterviewEmailEnabled(enabled)
+    setSaving(true)
+
+    try {
+      await updateNotificationPreference(INTERVIEW_RECORD_EMAIL_NOTIFICATION_TYPE, enabled)
+      toast({ title: enabled ? "面談通知メールを有効にしました" : "面談通知メールを停止しました" })
+    } catch (error) {
+      console.error("Failed to update notification settings:", error)
+      setInterviewEmailEnabled(previous)
+      toast({ title: "通知設定の保存に失敗しました", variant: "destructive" })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-6">
+      <div className="mb-6 flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => router.back()}>
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-bold">
+            <Bell className="h-6 w-6" />
+            通知設定
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            FunBaseから届くメール通知を設定します
+          </p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>面談通知</CardTitle>
+          <CardDescription>
+            新しい面談記録がFunBaseに追加されたときのメール通知です。
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
+            <div className="space-y-1">
+              <Label htmlFor="interview-email-notification" className="font-medium">
+                面談記録の新着メールを受け取る
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                オフにしても、FunBase内のお知らせには表示されます。
+              </p>
+            </div>
+            <Switch
+              id="interview-email-notification"
+              checked={interviewEmailEnabled}
+              disabled={loading || saving}
+              onCheckedChange={handleInterviewEmailChange}
+            />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -589,6 +589,10 @@ export function Header() {
             <DropdownMenuContent align="end" className="w-48">
               <DropdownMenuLabel>管理者設定</DropdownMenuLabel>
               <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => navigate('/settings/notifications')}>
+                <Bell className="mr-2 h-4 w-4" />
+                通知設定
+              </DropdownMenuItem>
               <DropdownMenuItem onClick={() => navigate('/admin/tenants')}>
                 <Users className="mr-2 h-4 w-4" />
                 テナント管理

--- a/lib/notifications/email.ts
+++ b/lib/notifications/email.ts
@@ -1,0 +1,74 @@
+import nodemailer from 'nodemailer'
+
+type SendEmailInput = {
+  to: string | string[]
+  subject: string
+  text: string
+  html?: string
+}
+
+export const EMAIL_FROM =
+  process.env.EMAIL_FROM ??
+  (process.env.SMTP_USER ? `FunBase <${process.env.SMTP_USER}>` : 'FunBase <noreply@funtoco.jp>')
+
+function maskEmail(email: string): string {
+  const [localPart, domain] = email.split('@')
+  if (!domain) return '***'
+  const visibleLocal = localPart.slice(0, Math.min(2, localPart.length))
+  return `${visibleLocal}***@${domain}`
+}
+
+function getMaskedRecipients(to: string | string[]): string | string[] {
+  return Array.isArray(to) ? to.map(maskEmail) : maskEmail(to)
+}
+
+export async function sendEmail({ to, subject, text, html }: SendEmailInput): Promise<void> {
+  const smtpHost = process.env.SMTP_HOST
+  const smtpUser = process.env.SMTP_USER
+  const smtpPass = process.env.SMTP_PASS
+
+  if (!smtpHost || !smtpUser || !smtpPass) {
+    const message = '[email] skipped: SMTP_HOST, SMTP_USER or SMTP_PASS is not configured'
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error(message)
+    }
+    console.warn(message)
+    return
+  }
+
+  const port = Number(process.env.SMTP_PORT ?? 587)
+  const secure = process.env.SMTP_SECURE === 'true' || (process.env.SMTP_SECURE === undefined && port === 465)
+  const maskedTo = getMaskedRecipients(to)
+
+  console.info('[email] send attempt', {
+    provider: 'smtp',
+    to: maskedTo,
+    subject,
+    from: EMAIL_FROM,
+    host: smtpHost,
+    port,
+    secure,
+  })
+
+  const transporter = nodemailer.createTransport({
+    host: smtpHost,
+    port,
+    secure,
+    auth: { user: smtpUser, pass: smtpPass },
+  })
+
+  const info = await transporter.sendMail({
+    from: EMAIL_FROM,
+    to,
+    subject,
+    text,
+    html,
+  })
+
+  console.info('[email] send accepted', {
+    provider: 'smtp',
+    to: maskedTo,
+    subject,
+    messageId: typeof info.messageId === 'string' ? info.messageId : undefined,
+  })
+}

--- a/lib/notifications/interview-record-notification-service.ts
+++ b/lib/notifications/interview-record-notification-service.ts
@@ -1,0 +1,345 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import {
+  canAccessPersonByCompany,
+  getCompanyAccessForUser,
+} from '@/lib/supabase/people-access'
+import { sendEmail } from './email'
+import {
+  buildInterviewRecordAnnouncement,
+  buildInterviewRecordEmail,
+  getInterviewNotificationRecipients,
+  INTERVIEW_RECORD_EMAIL_NOTIFICATION_TYPE,
+  type InterviewNotificationPreferenceRow,
+  type InterviewNotificationRecipient,
+  type InterviewNotificationRecipientRow,
+} from './interview-record-notifications'
+
+type InterviewRecordNotificationInput = {
+  supabase: SupabaseClient<any, any, any>
+  tenantId: string
+  interviewRecord: {
+    id: string
+    person_id: string
+    person_name?: string | null
+    company_name?: string | null
+    interview_date?: string | null
+    record_type?: string | null
+    support_staff_name?: string | null
+  }
+}
+
+type AnnouncementRow = {
+  id: string
+  title: string
+  body: string
+}
+
+type InterviewNotificationRecipients = {
+  announcementRecipients: InterviewNotificationRecipient[]
+  emailRecipients: InterviewNotificationRecipient[]
+}
+
+export async function notifyInterviewRecordCreated({
+  supabase,
+  tenantId,
+  interviewRecord,
+}: InterviewRecordNotificationInput): Promise<void> {
+  const appBaseUrl = getAppBaseUrl()
+
+  const announcement = buildInterviewRecordAnnouncement({
+    id: interviewRecord.id,
+    personName: interviewRecord.person_name,
+    companyName: interviewRecord.company_name,
+    interviewDate: interviewRecord.interview_date,
+    recordType: interviewRecord.record_type,
+    supportStaffName: interviewRecord.support_staff_name,
+    appBaseUrl,
+  })
+
+  const eventId = await acquireInterviewNotificationEvent(supabase, tenantId, interviewRecord.id)
+  if (!eventId) {
+    console.log('[notification] interview-record:duplicate', {
+      tenantId,
+      interviewRecordId: interviewRecord.id,
+    })
+    return
+  }
+
+  let createdAnnouncement: AnnouncementRow | null = null
+  let announcementRecipients: InterviewNotificationRecipient[] = []
+  let emailRecipients: InterviewNotificationRecipient[] = []
+
+  try {
+    const recipients = await getRecipients(supabase, tenantId, {
+      personId: interviewRecord.person_id,
+      recordType: interviewRecord.record_type,
+    })
+    announcementRecipients = recipients.announcementRecipients
+    emailRecipients = recipients.emailRecipients
+
+    if (announcementRecipients.length === 0) {
+      await markInterviewNotificationEventSent(supabase, eventId)
+      console.log('[notification] interview-record:no-recipients', {
+        tenantId,
+        interviewRecordId: interviewRecord.id,
+      })
+      return
+    }
+
+    const { data: announcementRow, error: announcementError } = await supabase
+      .from('announcements')
+      .insert({
+        title: announcement.title,
+        body: announcement.body,
+        published: true,
+        tenant_id: tenantId,
+        created_by: null,
+      })
+      .select('id, title, body')
+      .single()
+
+    if (announcementError) {
+      throw announcementError
+    }
+
+    createdAnnouncement = announcementRow as AnnouncementRow
+    const { error: recipientInsertError } = await supabase
+      .from('announcement_recipients')
+      .insert(
+        announcementRecipients.map((recipient) => ({
+          announcement_id: createdAnnouncement!.id,
+          user_id: recipient.userId,
+        }))
+      )
+
+    if (recipientInsertError) {
+      throw recipientInsertError
+    }
+    if (emailRecipients.length > 0 && createdAnnouncement) {
+      const announcementUrl = `${appBaseUrl}/announcements?id=${encodeURIComponent(createdAnnouncement.id)}`
+      const settingsUrl = `${appBaseUrl}/settings/notifications`
+      const email = buildInterviewRecordEmail({
+        title: createdAnnouncement.title,
+        body: createdAnnouncement.body,
+        announcementUrl,
+        settingsUrl,
+      })
+
+      const emailResults = await Promise.allSettled(
+        emailRecipients.map((recipient) =>
+          sendEmail({
+            to: recipient.email,
+            subject: email.subject,
+            text: email.text,
+            html: email.html,
+          })
+        )
+      )
+
+      const failedEmailCount = emailResults.filter((result) => result.status === 'rejected').length
+      if (failedEmailCount > 0) {
+        console.warn('[notification] interview-record:email-partial-failure', {
+          tenantId,
+          interviewRecordId: interviewRecord.id,
+          failedEmailCount,
+        })
+      }
+    }
+  } catch (error) {
+    if (createdAnnouncement) {
+      await supabase.from('announcements').delete().eq('id', createdAnnouncement.id)
+    }
+    await markInterviewNotificationEventFailed(supabase, eventId, error)
+    throw error
+  }
+
+  await markInterviewNotificationEventSent(supabase, eventId)
+
+  console.log('[notification] interview-record:sent', {
+    tenantId,
+    interviewRecordId: interviewRecord.id,
+    announcementId: createdAnnouncement.id,
+    announcementRecipientCount: announcementRecipients.length,
+    emailRecipientCount: emailRecipients.length,
+  })
+}
+
+async function getRecipients(
+  supabase: SupabaseClient<any, any, any>,
+  tenantId: string,
+  record: { personId: string; recordType?: string | null }
+): Promise<InterviewNotificationRecipients> {
+  const emptyRecipients = { announcementRecipients: [], emailRecipients: [] }
+  const { data: members, error: membersError } = await supabase
+    .from('user_tenants')
+    .select('user_id, email, status, role')
+    .eq('tenant_id', tenantId)
+
+  if (membersError) throw membersError
+
+  const memberRows = (members || []) as InterviewNotificationRecipientRow[]
+  const userIds = memberRows
+    .map((member) => member.user_id)
+    .filter((userId): userId is string => Boolean(userId))
+
+  if (userIds.length === 0) return emptyRecipients
+
+  const accessibleUserIds = await getAccessibleUserIdsForInterviewRecord(supabase, userIds, record)
+  if (accessibleUserIds.size === 0) return emptyRecipients
+
+  const announcementRecipients = getInterviewNotificationRecipients(
+    memberRows,
+    [],
+    accessibleUserIds
+  )
+
+  const { data: preferences, error: preferencesError } = await supabase
+    .from('notification_preferences')
+    .select('user_id, notification_type, enabled')
+    .in('user_id', userIds)
+    .eq('notification_type', INTERVIEW_RECORD_EMAIL_NOTIFICATION_TYPE)
+
+  if (preferencesError) throw preferencesError
+
+  const emailRecipients = getInterviewNotificationRecipients(
+    memberRows,
+    (preferences || []) as InterviewNotificationPreferenceRow[],
+    accessibleUserIds,
+    { requireOptIn: true, enforceActiveCorporateMember: false }
+  )
+
+  return { announcementRecipients, emailRecipients }
+}
+
+async function getAccessibleUserIdsForInterviewRecord(
+  supabase: SupabaseClient<any, any, any>,
+  userIds: string[],
+  record: { personId: string; recordType?: string | null }
+): Promise<Set<string>> {
+  const feature = record.recordType === 'daily_support' ? 'support_actions' : 'meetings'
+  const { data: person, error: personError } = await supabase
+    .from('people')
+    .select('id, tenant_id, company')
+    .eq('id', record.personId)
+    .maybeSingle()
+
+  if (personError) throw personError
+  if (!person) return new Set()
+
+  const results = await Promise.all(
+    userIds.map(async (userId) => {
+      try {
+        const access = await getCompanyAccessForUser(supabase, userId, feature)
+        return canAccessPersonByCompany(person, access) ? userId : null
+      } catch (error) {
+        console.warn('[notification] interview-record:access-check-error', {
+          userId,
+          personId: record.personId,
+          error: error instanceof Error ? error.message : error,
+        })
+        return null
+      }
+    })
+  )
+
+  return new Set(results.filter((userId): userId is string => Boolean(userId)))
+}
+
+async function acquireInterviewNotificationEvent(
+  supabase: SupabaseClient<any, any, any>,
+  tenantId: string,
+  interviewRecordId: string
+): Promise<string | null> {
+  const eventPayload = {
+    tenant_id: tenantId,
+    notification_type: INTERVIEW_RECORD_EMAIL_NOTIFICATION_TYPE,
+    source_type: 'interview_record',
+    source_id: interviewRecordId,
+    status: 'pending',
+    error_message: null,
+    sent_at: null,
+  }
+
+  const { data, error } = await supabase
+    .from('notification_events')
+    .insert(eventPayload)
+    .select('id')
+    .single()
+
+  if (!error) return (data as { id: string }).id
+
+  if (!('code' in error) || error.code !== '23505') {
+    throw error
+  }
+
+  const { data: existing, error: existingError } = await supabase
+    .from('notification_events')
+    .select('id, status')
+    .eq('tenant_id', tenantId)
+    .eq('notification_type', INTERVIEW_RECORD_EMAIL_NOTIFICATION_TYPE)
+    .eq('source_type', 'interview_record')
+    .eq('source_id', interviewRecordId)
+    .maybeSingle()
+
+  if (existingError) throw existingError
+  if (!existing || existing.status !== 'failed') return null
+
+  const { data: retried, error: retryError } = await supabase
+    .from('notification_events')
+    .update({ status: 'pending', error_message: null, sent_at: null })
+    .eq('id', existing.id)
+    .eq('status', 'failed')
+    .select('id')
+    .maybeSingle()
+
+  if (retryError) throw retryError
+  return retried ? (retried as { id: string }).id : null
+}
+
+async function markInterviewNotificationEventSent(
+  supabase: SupabaseClient<any, any, any>,
+  eventId: string
+): Promise<void> {
+  const { error } = await supabase
+    .from('notification_events')
+    .update({ status: 'sent', sent_at: new Date().toISOString(), error_message: null })
+    .eq('id', eventId)
+
+  if (error) throw error
+}
+
+async function markInterviewNotificationEventFailed(
+  supabase: SupabaseClient<any, any, any>,
+  eventId: string,
+  error: unknown
+): Promise<void> {
+  const { error: updateError } = await supabase
+    .from('notification_events')
+    .update({
+      status: 'failed',
+      error_message: error instanceof Error ? error.message : String(error),
+    })
+    .eq('id', eventId)
+
+  if (updateError) {
+    console.warn('[notification] interview-record:event-failed-update-error', {
+      eventId,
+      error: updateError.message,
+    })
+  }
+}
+
+function getAppBaseUrl(): string {
+  const explicitUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.APP_BASE_URL
+  if (explicitUrl) return trimTrailingSlash(explicitUrl)
+
+  const vercelUrl = process.env.VERCEL_URL
+  if (vercelUrl) return trimTrailingSlash(`https://${vercelUrl}`)
+
+  return 'http://localhost:3000'
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '')
+}

--- a/lib/notifications/interview-record-notifications.test.ts
+++ b/lib/notifications/interview-record-notifications.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  buildInterviewRecordAnnouncement,
+  buildInterviewRecordEmail,
+  getInterviewNotificationRecipients,
+  shouldNotifyInterviewRecordCreation,
+  type InterviewNotificationPreferenceRow,
+  type InterviewNotificationRecipientRow,
+} from './interview-record-notifications'
+
+describe('interview record notifications', () => {
+  test('notifies only when a regular interview record is newly created', () => {
+    expect(shouldNotifyInterviewRecordCreation({ existingRecordId: null })).toBe(true)
+    expect(shouldNotifyInterviewRecordCreation({ existingRecordId: 'existing-id' })).toBe(false)
+    expect(
+      shouldNotifyInterviewRecordCreation({
+        existingRecordId: null,
+        recordType: 'daily_support',
+        activityEntries: [{ dai: '生活支援', funbaseVisibility: 'visible' }],
+      })
+    ).toBe(false)
+  })
+
+  test('selects active corporate tenant members and respects opt-out preferences', () => {
+    const members: InterviewNotificationRecipientRow[] = [
+      { user_id: 'user-1', email: 'owner@example.com', status: 'active', role: 'owner' },
+      { user_id: 'user-2', email: 'member@example.com', status: 'active', role: 'member' },
+      { user_id: 'user-3', email: 'supporter@funtoco.jp', status: 'active', role: 'supporter' },
+      { user_id: 'user-4', email: 'pending@example.com', status: 'pending', role: 'member' },
+      { user_id: 'user-5', email: null, status: 'active', role: 'member' },
+      { user_id: 'user-6', email: 'restricted@example.com', status: 'active', role: 'member' },
+    ]
+    const preferences: InterviewNotificationPreferenceRow[] = [
+      { user_id: 'user-2', notification_type: 'interview_record_email', enabled: false },
+    ]
+
+    expect(getInterviewNotificationRecipients(members, preferences, new Set(['user-1', 'user-2']))).toEqual([
+      { userId: 'user-1', email: 'owner@example.com' },
+    ])
+  })
+
+  test('requires explicit opt-in for email recipients when configured', () => {
+    const members: InterviewNotificationRecipientRow[] = [
+      { user_id: 'user-1', email: 'owner@example.com', status: 'active', role: 'owner' },
+      { user_id: 'user-2', email: 'member@example.com', status: 'active', role: 'member' },
+      { user_id: 'user-3', email: 'supporter@example.com', status: 'active', role: 'supporter' },
+      { user_id: 'user-4', email: 'suspended@example.com', status: 'suspended', role: 'member' },
+    ]
+    const preferences: InterviewNotificationPreferenceRow[] = [
+      { user_id: 'user-2', notification_type: 'interview_record_email', enabled: true },
+      { user_id: 'user-3', notification_type: 'interview_record_email', enabled: true },
+      { user_id: 'user-4', notification_type: 'interview_record_email', enabled: true },
+    ]
+
+    expect(
+      getInterviewNotificationRecipients(members, preferences, new Set(['user-1', 'user-2', 'user-3', 'user-4']), {
+        requireOptIn: true,
+        enforceActiveCorporateMember: false,
+      })
+    ).toEqual([
+      { userId: 'user-2', email: 'member@example.com' },
+      { userId: 'user-3', email: 'supporter@example.com' },
+      { userId: 'user-4', email: 'suspended@example.com' },
+    ])
+  })
+
+  test('builds announcement content with an interview detail link', () => {
+    const announcement = buildInterviewRecordAnnouncement({
+      id: 'record-1',
+      personName: '山田 太郎',
+      companyName: '株式会社サンプル',
+      interviewDate: '2026-07-15',
+      recordType: 'regular_interview',
+      supportStaffName: '佐藤',
+      appBaseUrl: 'https://funbase.example.com',
+    })
+
+    expect(announcement.title).toBe('新しい面談記録が追加されました')
+    expect(announcement.body).toContain('面談日: 2026-07-15')
+    expect(announcement.body).not.toContain('山田 太郎')
+    expect(announcement.body).not.toContain('株式会社サンプル')
+    expect(announcement.body).toContain('https://funbase.example.com/interview-records/record-1')
+  })
+
+  test('builds email body with notification settings link', () => {
+    const email = buildInterviewRecordEmail({
+      title: '新しい面談記録が追加されました',
+      body: '本文',
+      announcementUrl: 'https://funbase.example.com/announcements?id=announcement-1',
+      settingsUrl: 'https://funbase.example.com/settings/notifications',
+    })
+
+    expect(email.subject).toBe('【FunBase】新しい面談記録が追加されました')
+    expect(email.text).toContain('https://funbase.example.com/announcements?id=announcement-1')
+    expect(email.text).toContain('通知設定: https://funbase.example.com/settings/notifications')
+    expect(email.html).toContain('通知設定')
+  })
+})

--- a/lib/notifications/interview-record-notifications.ts
+++ b/lib/notifications/interview-record-notifications.ts
@@ -1,0 +1,175 @@
+export const INTERVIEW_RECORD_EMAIL_NOTIFICATION_TYPE = 'interview_record_email'
+
+type UserTenantRole = 'owner' | 'admin' | 'member' | 'guest' | 'supporter' | string
+type UserTenantStatus = 'active' | 'pending' | 'suspended' | string
+
+export type InterviewNotificationRecipientRow = {
+  user_id: string | null
+  email: string | null
+  status: UserTenantStatus
+  role: UserTenantRole
+}
+
+export type InterviewNotificationPreferenceRow = {
+  user_id: string | null
+  notification_type: string
+  enabled: boolean
+}
+
+export type InterviewNotificationRecipient = {
+  userId: string
+  email: string
+}
+
+export type InterviewRecordAnnouncementInput = {
+  id: string
+  personName?: string | null
+  companyName?: string | null
+  interviewDate?: string | null
+  recordType?: string | null
+  supportStaffName?: string | null
+  appBaseUrl: string
+}
+
+export type InterviewRecordEmailInput = {
+  title: string
+  body: string
+  announcementUrl: string
+  settingsUrl: string
+}
+
+export function shouldNotifyInterviewRecordCreation({
+  existingRecordId,
+  recordType,
+}: {
+  existingRecordId?: string | null
+  recordType?: string | null
+  activityEntries?: unknown[] | null
+  previousActivityEntries?: unknown[] | null
+}): boolean {
+  if (recordType === 'daily_support') return false
+
+  return !existingRecordId
+}
+
+export function getInterviewNotificationRecipients(
+  members: InterviewNotificationRecipientRow[],
+  preferences: InterviewNotificationPreferenceRow[] = [],
+  accessibleUserIds?: Set<string>,
+  options: { requireOptIn?: boolean; enforceActiveCorporateMember?: boolean } = {}
+): InterviewNotificationRecipient[] {
+  const enforceActiveCorporateMember = options.enforceActiveCorporateMember ?? true
+  const enabledPreferenceUserIds = new Set(
+    preferences
+      .filter(
+        (preference) =>
+          preference.notification_type === INTERVIEW_RECORD_EMAIL_NOTIFICATION_TYPE &&
+          preference.enabled === true &&
+          preference.user_id
+      )
+      .map((preference) => preference.user_id as string)
+  )
+  const disabledPreferenceUserIds = new Set(
+    preferences
+      .filter(
+        (preference) =>
+          preference.notification_type === INTERVIEW_RECORD_EMAIL_NOTIFICATION_TYPE &&
+          preference.enabled === false &&
+          preference.user_id
+      )
+      .map((preference) => preference.user_id as string)
+  )
+
+  const seenEmails = new Set<string>()
+
+  return members.reduce<InterviewNotificationRecipient[]>((recipients, member) => {
+    if (!member.user_id || !member.email) return recipients
+    if (accessibleUserIds && !accessibleUserIds.has(member.user_id)) return recipients
+    if (enforceActiveCorporateMember && member.status !== 'active') return recipients
+    if (enforceActiveCorporateMember && member.role === 'supporter') return recipients
+    if (options.requireOptIn && !enabledPreferenceUserIds.has(member.user_id)) return recipients
+    if (!options.requireOptIn && disabledPreferenceUserIds.has(member.user_id)) return recipients
+
+    const normalizedEmail = member.email.trim().toLowerCase()
+    if (!normalizedEmail || seenEmails.has(normalizedEmail)) return recipients
+
+    seenEmails.add(normalizedEmail)
+    recipients.push({ userId: member.user_id, email: normalizedEmail })
+    return recipients
+  }, [])
+}
+
+export function buildInterviewRecordAnnouncement({
+  id,
+  personName,
+  companyName,
+  interviewDate,
+  recordType,
+  supportStaffName,
+  appBaseUrl,
+}: InterviewRecordAnnouncementInput): { title: string; body: string } {
+  const detailUrl = `${trimTrailingSlash(appBaseUrl)}/interview-records/${encodeURIComponent(id)}`
+  const recordTypeLabel = recordType === 'daily_support' ? '日々の面談' : '定期面談'
+  const lines = [
+    '新しい面談記録がFunBaseに追加されました。',
+    '',
+    `種別: ${recordTypeLabel}`,
+    interviewDate ? `面談日: ${interviewDate}` : null,
+    '',
+    `詳細: ${detailUrl}`,
+  ].filter((line): line is string => line !== null)
+
+  return {
+    title: '新しい面談記録が追加されました',
+    body: lines.join('\n'),
+  }
+}
+
+export function buildInterviewRecordEmail({
+  title,
+  body,
+  announcementUrl,
+  settingsUrl,
+}: InterviewRecordEmailInput): { subject: string; text: string; html: string } {
+  const safeTitle = escapeHtml(title)
+  const bodyText = `${body}\n\nFunBaseで確認: ${announcementUrl}\n通知設定: ${settingsUrl}`
+  const htmlBody = body
+    .split('\n')
+    .map((line) => escapeHtml(line))
+    .join('<br />')
+
+  return {
+    subject: `【FunBase】${title}`,
+    text: bodyText,
+    html: `
+      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; line-height: 1.7; color: #111827;">
+        <h2 style="font-size: 18px; margin: 0 0 16px;">${safeTitle}</h2>
+        <p>${htmlBody}</p>
+        <p style="margin-top: 24px;">
+          <a href="${escapeAttribute(announcementUrl)}" style="color: #2563eb;">FunBaseで確認する</a>
+        </p>
+        <p style="font-size: 12px; color: #6b7280; margin-top: 24px;">
+          このメールはFunBaseの面談通知設定に基づいて送信されています。<br />
+          <a href="${escapeAttribute(settingsUrl)}" style="color: #6b7280;">通知設定</a>
+        </p>
+      </div>
+    `.trim(),
+  }
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '')
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function escapeAttribute(value: string): string {
+  return escapeHtml(value)
+}

--- a/lib/supabase/announcements.ts
+++ b/lib/supabase/announcements.ts
@@ -12,22 +12,84 @@ interface AnnouncementRow {
   updated_at: string
 }
 
+type SupabaseLikeError = {
+  code?: string
+  message?: string
+  details?: string
+  hint?: string
+}
+
+function isMissingAnnouncementScopeSchemaError(error: SupabaseLikeError | null | undefined): boolean {
+  const text = [error?.code, error?.message, error?.details, error?.hint]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+
+  return (
+    text.includes('tenant_id') ||
+    text.includes('announcement_recipients') ||
+    text.includes('relationship') ||
+    text.includes('schema cache')
+  )
+}
+
 /** 公開済みお知らせ一覧を取得 */
 export async function getPublishedAnnouncements(): Promise<Announcement[]> {
   const supabase = createClient()
+  const { data: userData } = await supabase.auth.getUser()
 
-  const { data, error } = await supabase
+  let { data: globalData, error: globalError } = await supabase
     .from('announcements')
     .select('*')
     .eq('published', true)
+    .is('tenant_id', null)
     .order('created_at', { ascending: false })
 
-  if (error) {
-    console.error('Error fetching announcements:', error)
-    throw error
+  if (globalError && isMissingAnnouncementScopeSchemaError(globalError)) {
+    console.warn('Announcement recipient schema is not deployed yet; falling back to global announcements only')
+    const fallback = await supabase
+      .from('announcements')
+      .select('*')
+      .eq('published', true)
+      .order('created_at', { ascending: false })
+    globalData = fallback.data
+    globalError = fallback.error
   }
 
-  return data.map(mapToAnnouncement)
+  if (globalError) {
+    console.error('Error fetching global announcements:', globalError)
+    throw globalError
+  }
+
+  let targetedData: AnnouncementRow[] = []
+  if (userData.user) {
+    const { data, error } = await supabase
+      .from('announcements')
+      .select('*, announcement_recipients!inner(user_id)')
+      .eq('published', true)
+      .eq('announcement_recipients.user_id', userData.user.id)
+      .order('created_at', { ascending: false })
+
+    if (error) {
+      if (isMissingAnnouncementScopeSchemaError(error)) {
+        console.warn('Announcement recipients are not deployed yet; skipping targeted announcements')
+      } else {
+        console.error('Error fetching targeted announcements:', error)
+        throw error
+      }
+    } else {
+      targetedData = (data || []) as unknown as AnnouncementRow[]
+    }
+  }
+
+  const byId = new Map<string, Announcement>()
+  ;[...(globalData || []), ...targetedData]
+    .map((row) => mapToAnnouncement(row as AnnouncementRow))
+    .forEach((announcement) => byId.set(announcement.id, announcement))
+
+  return Array.from(byId.values()).sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  )
 }
 
 /**

--- a/lib/supabase/notification-preferences.ts
+++ b/lib/supabase/notification-preferences.ts
@@ -1,0 +1,69 @@
+import { createClient } from './client'
+import { INTERVIEW_RECORD_EMAIL_NOTIFICATION_TYPE } from '@/lib/notifications/interview-record-notifications'
+
+export type NotificationPreference = {
+  notificationType: string
+  enabled: boolean
+}
+
+type NotificationPreferenceRow = {
+  notification_type: string
+  enabled: boolean
+}
+
+const DEFAULT_PREFERENCES: NotificationPreference[] = [
+  {
+    notificationType: INTERVIEW_RECORD_EMAIL_NOTIFICATION_TYPE,
+    enabled: false,
+  },
+]
+
+export async function getNotificationPreferences(): Promise<NotificationPreference[]> {
+  const supabase = createClient()
+  const { data: userData } = await supabase.auth.getUser()
+  if (!userData.user) return DEFAULT_PREFERENCES
+
+  const { data, error } = await supabase
+    .from('notification_preferences')
+    .select('notification_type, enabled')
+    .eq('user_id', userData.user.id)
+
+  if (error) {
+    console.error('Error fetching notification preferences:', error)
+    return DEFAULT_PREFERENCES
+  }
+
+  const rows = (data || []) as NotificationPreferenceRow[]
+  const rowByType = new Map(rows.map((row) => [row.notification_type, row]))
+
+  return DEFAULT_PREFERENCES.map((preference) => ({
+    ...preference,
+    enabled: rowByType.get(preference.notificationType)?.enabled ?? preference.enabled,
+  }))
+}
+
+export async function updateNotificationPreference(
+  notificationType: string,
+  enabled: boolean
+): Promise<void> {
+  const supabase = createClient()
+  const { data: userData } = await supabase.auth.getUser()
+  if (!userData.user) throw new Error('ログインが必要です')
+
+  const { error } = await supabase
+    .from('notification_preferences')
+    .upsert(
+      {
+        user_id: userData.user.id,
+        notification_type: notificationType,
+        enabled,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id,notification_type' }
+    )
+
+  if (error) {
+    console.error('Error updating notification preference:', error)
+    throw error
+  }
+}

--- a/lib/sync/kintone-sync.ts
+++ b/lib/sync/kintone-sync.ts
@@ -13,6 +13,11 @@ import { SyncLogger, createSyncLogger } from './sync-logger'
 import { getUpdateKeysByConnector, buildConflictColumns, buildUpdateCondition, getKintoneRecordValue } from './update-key-utils'
 import { uploadFileToStorage } from '@/lib/storage/file-uploader'
 import { getDataMappings, mapFieldValues, type DataMapping } from '@/lib/mappings/value-mapper'
+import { notifyInterviewRecordCreated } from '@/lib/notifications/interview-record-notification-service'
+import {
+  INTERVIEW_RECORD_EMAIL_NOTIFICATION_TYPE,
+  shouldNotifyInterviewRecordCreation,
+} from '@/lib/notifications/interview-record-notifications'
 import {
   buildInterviewRecordsQuery,
   getInterviewRecordSourceHumanResourceId,
@@ -1020,6 +1025,25 @@ export class KintoneDataSync {
     }
   }
 
+  private async getPersonNameForInterviewNotification(personId: string): Promise<string | null> {
+    const { data, error } = await this.supabase
+      .from('people')
+      .select('name')
+      .eq('tenant_id', this.tenantId)
+      .eq('id', personId)
+      .maybeSingle()
+
+    if (error) {
+      console.warn('[sync] interview-records:notification-person-name-lookup-error', {
+        personId,
+        error: error.message,
+      })
+      return null
+    }
+
+    return typeof data?.name === 'string' ? data.name : null
+  }
+
   private async syncInterviewRecords(
     appMappings: AppMapping[],
     options: KintoneSyncOptions = {}
@@ -1151,7 +1175,24 @@ export class KintoneDataSync {
             sourceAppId: appMapping.source_app_id,
           })
 
-          const { error: upsertError } = await this.supabase
+          const { data: existingRecord, error: existingRecordError } = await this.supabase
+            .from('interview_records')
+            .select('id, activity_entries')
+            .eq('tenant_id', this.tenantId)
+            .eq('source_system', payload.source_system)
+            .eq('source_app_id', payload.source_app_id)
+            .eq('source_record_id', payload.source_record_id)
+            .maybeSingle()
+
+          if (existingRecordError) {
+            console.error('[sync] interview-records:existing-lookup-error', {
+              sourceRecordId,
+              error: existingRecordError.message,
+            })
+            throw existingRecordError
+          }
+
+          const { data: upsertedRecord, error: upsertError } = await this.supabase
             .from('interview_records')
             .upsert(
               {
@@ -1161,6 +1202,8 @@ export class KintoneDataSync {
               },
               { onConflict: 'tenant_id,source_system,source_app_id,source_record_id' }
             )
+            .select('id')
+            .single()
 
           if (upsertError) {
             console.error('[sync] interview-records:db-error', {
@@ -1168,6 +1211,57 @@ export class KintoneDataSync {
               error: upsertError.message,
             })
             throw upsertError
+          }
+
+          let shouldAttemptInterviewNotification = shouldNotifyInterviewRecordCreation({
+            existingRecordId: existingRecord?.id ?? null,
+            recordType: payload.record_type,
+            activityEntries: payload.activity_entries,
+            previousActivityEntries: existingRecord?.activity_entries as unknown[] | null | undefined,
+          })
+
+          if (!shouldAttemptInterviewNotification && existingRecord?.id) {
+            const { data: failedNotificationEvent, error: failedNotificationError } = await this.supabase
+              .from('notification_events')
+              .select('id')
+              .eq('tenant_id', this.tenantId)
+              .eq('notification_type', INTERVIEW_RECORD_EMAIL_NOTIFICATION_TYPE)
+              .eq('source_type', 'interview_record')
+              .eq('source_id', existingRecord.id)
+              .eq('status', 'failed')
+              .maybeSingle()
+
+            if (failedNotificationError) {
+              console.error('[sync] interview-records:notification-retry-lookup-error', {
+                sourceRecordId,
+                error: failedNotificationError.message,
+              })
+            }
+
+            shouldAttemptInterviewNotification = Boolean(failedNotificationEvent)
+          }
+
+          if (shouldAttemptInterviewNotification) {
+            try {
+              await notifyInterviewRecordCreated({
+                supabase: this.supabase,
+                tenantId: this.tenantId,
+                interviewRecord: {
+                  id: upsertedRecord.id,
+                  person_id: personId,
+                  person_name: await this.getPersonNameForInterviewNotification(personId),
+                  company_name: payload.company_name,
+                  interview_date: payload.interview_date,
+                  record_type: payload.record_type,
+                  support_staff_name: payload.support_staff_name,
+                },
+              })
+            } catch (notificationError) {
+              console.error('[sync] interview-records:notification-error', {
+                sourceRecordId,
+                error: notificationError instanceof Error ? notificationError.message : notificationError,
+              })
+            }
           }
 
           syncedCount++

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "lucide-react": "^0.454.0",
     "next": "14.2.35",
     "next-themes": "latest",
+    "nodemailer": "9.0.3",
     "react": "^18",
     "react-day-picker": "9.8.0",
     "react-dom": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       next-themes:
         specifier: latest
         version: 0.4.6(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
+      nodemailer:
+        specifier: 9.0.3
+        version: 9.0.3
       react:
         specifier: ^18
         version: 18.0.0
@@ -2446,6 +2449,10 @@ packages:
         optional: true
       sass:
         optional: true
+
+  nodemailer@9.0.3:
+    resolution: {integrity: sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==}
+    engines: {node: '>=6.0.0'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -4965,6 +4972,8 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  nodemailer@9.0.3: {}
 
   object-assign@4.1.1: {}
 

--- a/types/nodemailer.d.ts
+++ b/types/nodemailer.d.ts
@@ -1,0 +1,29 @@
+declare module 'nodemailer' {
+  export type SendMailOptions = {
+    from?: string
+    to?: string | string[]
+    subject?: string
+    text?: string
+    html?: string
+  }
+
+  export type SentMessageInfo = {
+    messageId?: string
+  }
+
+  export type Transporter = {
+    sendMail(options: SendMailOptions): Promise<SentMessageInfo>
+  }
+
+  export function createTransport(options: {
+    host: string
+    port: number
+    secure: boolean
+    auth: { user: string; pass: string }
+  }): Transporter
+
+  const nodemailer: {
+    createTransport: typeof createTransport
+  }
+  export default nodemailer
+}


### PR DESCRIPTION
## Summary
- Add interview record announcement/email notifications during Kintone sync import
- Add notification settings page for interview email opt-in/out
- Scope announcement recipients by existing interview record access and notification preferences
- Link app PR to required infra migration PR: https://github.com/funtoco/fun-base-infra/pull/62

## Test Plan
- ./node_modules/.bin/vitest run lib/notifications/interview-record-notifications.test.ts lib/sync/interview-record-transformer.test.ts
- git diff --check
- ./node_modules/.bin/tsc --noEmit --pretty false (fails on pre-existing connector type errors outside this PR; touched files not reported by grep)

## Notes
- Requires fun-base-infra PR #62 to be deployed first for notification tables/RLS.