### PR TITLE
fix: pass SMTP settings to interview sync

### DIFF
--- a/.github/workflows/cron-sync.yml
+++ b/.github/workflows/cron-sync.yml
@@ -140,8 +140,17 @@ jobs:
 
       - name: Sync Interview Records
         env:
+          NODE_ENV: production
+          NEXT_PUBLIC_APP_URL: ${{ vars.NEXT_PUBLIC_APP_URL || secrets.NEXT_PUBLIC_APP_URL }}
+          APP_BASE_URL: ${{ vars.APP_BASE_URL || secrets.APP_BASE_URL }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_SECURE: ${{ secrets.SMTP_SECURE }}
+          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           BATCH_SIZE: ${{ github.event.inputs.batch_size }}
           RECORD_ID_FROM: ${{ github.event.inputs.record_id_from }}

--- a/tests/cron-sync-workflow.test.ts
+++ b/tests/cron-sync-workflow.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+const workflow = readFileSync('.github/workflows/cron-sync.yml', 'utf8')
+
+function getSyncInterviewRecordsEnvBlock(): string {
+  const match = workflow.match(/- name: Sync Interview Records\n\s+env:\n(?<envBlock>(?:\s{10}[A-Z0-9_]+:.*\n)+)/)
+  if (!match?.groups?.envBlock) {
+    throw new Error('Sync Interview Records env block was not found')
+  }
+
+  return match.groups.envBlock
+}
+
+describe('cron-sync workflow', () => {
+  test('passes SMTP settings to the interview record sync job so email notifications are delivered', () => {
+    const envBlock = getSyncInterviewRecordsEnvBlock()
+
+    expect(envBlock).toContain('NODE_ENV: production')
+    expect(envBlock).toContain('NEXT_PUBLIC_APP_URL: ${{ vars.NEXT_PUBLIC_APP_URL || secrets.NEXT_PUBLIC_APP_URL }}')
+    expect(envBlock).toContain('APP_BASE_URL: ${{ vars.APP_BASE_URL || secrets.APP_BASE_URL }}')
+    expect(envBlock).toContain('SMTP_HOST: ${{ secrets.SMTP_HOST }}')
+    expect(envBlock).toContain('SMTP_USER: ${{ secrets.SMTP_USER }}')
+    expect(envBlock).toContain('SMTP_PASS: ${{ secrets.SMTP_PASS }}')
+    expect(envBlock).toContain('SMTP_PORT: ${{ secrets.SMTP_PORT }}')
+    expect(envBlock).toContain('SMTP_SECURE: ${{ secrets.SMTP_SECURE }}')
+    expect(envBlock).toContain('EMAIL_FROM: ${{ secrets.EMAIL_FROM }}')
+  })
+})


### PR DESCRIPTION
## Summary
- Pass SMTP-related GitHub Secrets to the interview_records sync workflow
- Pass app URL env (`NEXT_PUBLIC_APP_URL` / `APP_BASE_URL`) so notification email links do not fall back to localhost
- Set NODE_ENV=production so missing SMTP config fails the job instead of silently skipping email
- Add a workflow regression test for the interview sync env block

## Verification
- Confirmed current run 29528173413 skipped 34 emails because SMTP env was not configured
- RED: `./node_modules/.bin/vitest run tests/cron-sync-workflow.test.ts` failed before workflow change
- GREEN: `./node_modules/.bin/vitest run tests/cron-sync-workflow.test.ts lib/notifications/interview-record-notifications.test.ts` passed (6 tests)
- Codex review: no introduced correctness issues after app URL env fix

## Notes
- This assumes Production environment has SMTP_HOST / SMTP_USER / SMTP_PASS configured.
- App URL should be configured as repository/environment variable or secret: NEXT_PUBLIC_APP_URL or APP_BASE_URL.
