### PR TITLE
fix: prevent people table text overlap

### DIFF
--- a/app/people/page.tsx
+++ b/app/people/page.tsx
@@ -130,28 +130,42 @@ export default function PeoplePage() {
     })
   }
 
+  const renderTruncatedText = (value: unknown) => {
+    const text = value?.toString() ?? ""
+
+    return text ? (
+      <span className="block truncate" title={text}>
+        {text}
+      </span>
+    ) : (
+      <span className="text-muted-foreground">-</span>
+    )
+  }
+
   const columns: Column<PersonWithVisa>[] = [
     {
       key: "name",
       label: "名前",
       sortable: true,
+      headerClassName: "w-[260px]",
+      cellClassName: "w-[260px] max-w-[260px] overflow-hidden",
       render: (value, row) => (
-        <div className="flex items-center gap-3">
+        <div className="flex min-w-0 items-center gap-3">
           <PersonAvatar 
             name={value || ""} 
             imagePath={row.imagePath}
             size="md"
           />
-          <div>
-            <div className="flex items-center gap-2">
-              <span className="font-medium">{value}</span>
+          <div className="min-w-0">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="block truncate font-medium" title={value?.toString()}>{value}</span>
               {isManualPersonId(row.id) && (
-                <Badge variant="outline" className="border-amber-300 bg-amber-50 text-amber-700">
+                <Badge variant="outline" className="shrink-0 border-amber-300 bg-amber-50 text-amber-700">
                   手動
                 </Badge>
               )}
             </div>
-            {row.kana && <div className="text-xs text-muted-foreground">{row.kana}</div>}
+            {row.kana && <div className="truncate text-xs text-muted-foreground" title={row.kana}>{row.kana}</div>}
           </div>
         </div>
       ),
@@ -161,31 +175,44 @@ export default function PeoplePage() {
       label: "国籍",
       sortable: true,
       filterable: true,
+      headerClassName: "w-[120px]",
+      cellClassName: "w-[120px] max-w-[120px] overflow-hidden",
+      render: renderTruncatedText,
     },
     {
       key: "tenantName",
       label: "会社",
       sortable: true,
       filterable: true,
+      headerClassName: "w-[220px]",
+      cellClassName: "w-[220px] max-w-[220px] overflow-hidden",
+      render: renderTruncatedText,
     },
     {
       key: "company",
       label: "所属先",
       sortable: true,
       filterable: true,
+      headerClassName: "w-[320px]",
+      cellClassName: "w-[320px] max-w-[320px] overflow-hidden",
+      render: renderTruncatedText,
     },
     {
       key: "employeeNumber",
       label: "従業員番号",
       sortable: true,
+      headerClassName: "w-[130px]",
+      cellClassName: "w-[130px] max-w-[130px] overflow-hidden",
       render: (value) =>
-        value ? <span className="text-sm font-mono">{value}</span> : <span className="text-muted-foreground">-</span>,
+        value ? <span className="block truncate text-sm font-mono" title={value.toString()}>{value}</span> : <span className="text-muted-foreground">-</span>,
     },
     {
       key: "workingStatus",
       label: "就労ステータス",
       sortable: true,
       filterable: true,
+      headerClassName: "w-[130px]",
+      cellClassName: "w-[130px] max-w-[130px] overflow-hidden",
       render: (value) =>
         value ? <StatusBadge status={value} type="working" /> : <span className="text-muted-foreground">-</span>,
     },
@@ -306,7 +333,7 @@ export default function PeoplePage() {
         searchPlaceholder="人材名、法人名、事業所名で検索..."
         onRowClick={handleRowClick}
         loading={loading}
-        tableClassName="min-w-[960px] table-fixed"
+        tableClassName="min-w-[1180px] table-fixed"
         initialSearchTerm={searchParams.get('search') || ''}
         initialActiveFilters={getFiltersFromUrl()}
         onFilterChange={updateUrl}


### PR DESCRIPTION
## Summary
- 人材一覧テーブルの各列に幅を設定し、長い法人名・所属先名・氏名を省略表示に変更
- テーブル最小幅を広げ、列同士の文字重なりを防止
- 省略された値は `title` で確認できるようにしました

## Verification
- `pnpm install --frozen-lockfile`（依存関係は導入済みだが、既知の `[ERR_PNPM_IGNORED_BUILDS]` で終了コード1）
- `./node_modules/.bin/tsc --noEmit --pretty false`（既存の connector / tenant-management などの型エラーで失敗。今回変更ファイル起因のエラーは検出されず）
- `node` + TypeScript `transpileModule` による `app/people/page.tsx` 構文チェック: pass
- `git diff --check`: pass
- `codex review --base origin/main`: 指摘なし

## Assumption
- 画像と文脈から `fun-base` の人材一覧画面と判断しました。
