### PR TITLE
fix: clean up auth users for pending tenant invites

### DIFF
--- a/app/api/tenants/[tenantId]/members/[memberId]/route.test.ts
+++ b/app/api/tenants/[tenantId]/members/[memberId]/route.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  currentUser: { id: 'actor-user' },
+  targetMember: {
+    id: 'member-row',
+    user_id: 'pending-auth-user',
+    role: 'member',
+    email: 'pending@example.com',
+    status: 'pending',
+  },
+  actorMemberships: [{ role: 'admin' }],
+  otherMembershipCount: 0,
+  deleteMembershipError: null as null | { message: string },
+  otherMembershipsError: null as null | { message: string },
+  deleteAuthUserError: null as null | { message: string },
+  deleteUser: vi.fn(),
+  createAdminClient: vi.fn(),
+  createClient: vi.fn(),
+}))
+
+type QueryState = {
+  client: 'user' | 'admin'
+  table: string
+  action?: 'select' | 'delete'
+  selectColumns?: string
+  selectOptions?: Record<string, unknown>
+  filters: Array<{ method: string; args: unknown[] }>
+}
+
+function createQuery(state: QueryState): any {
+  const query: any = {
+    select(columns?: string, options?: Record<string, unknown>) {
+      state.action = 'select'
+      state.selectColumns = columns
+      state.selectOptions = options
+      return query
+    },
+    delete() {
+      state.action = 'delete'
+      return query
+    },
+    eq(...args: unknown[]) {
+      state.filters.push({ method: 'eq', args })
+      return query
+    },
+    neq(...args: unknown[]) {
+      state.filters.push({ method: 'neq', args })
+      return query
+    },
+    single() {
+      return Promise.resolve(resolveQuery(state, 'single'))
+    },
+    then(resolve: (value: unknown) => void, reject: (reason?: unknown) => void) {
+      return Promise.resolve(resolveQuery(state, 'then')).then(resolve, reject)
+    },
+  }
+  return query
+}
+
+function resolveQuery(state: QueryState, terminal: 'single' | 'then') {
+  if (state.client === 'user' && state.table === 'user_tenants') {
+    if (terminal === 'single' && state.selectColumns?.includes('id, user_id')) {
+      return { data: mocks.targetMember, error: null }
+    }
+    if (terminal === 'then' && state.action === 'select' && state.selectColumns === 'role') {
+      return { data: mocks.actorMemberships, error: null }
+    }
+    if (terminal === 'then' && state.action === 'delete') {
+      return { error: mocks.deleteMembershipError }
+    }
+  }
+
+  if (state.client === 'admin' && state.table === 'user_tenants') {
+    if (terminal === 'then' && state.action === 'select' && state.selectOptions?.head === true) {
+      return { count: mocks.otherMembershipCount, error: mocks.otherMembershipsError }
+    }
+  }
+
+  throw new Error(`Unhandled query: ${JSON.stringify(state)}`)
+}
+
+function createSupabaseClient(client: 'user' | 'admin') {
+  return {
+    auth: client === 'user'
+      ? { getUser: vi.fn().mockResolvedValue({ data: { user: mocks.currentUser }, error: null }) }
+      : { admin: { deleteUser: mocks.deleteUser } },
+    from: vi.fn((table: string) => createQuery({ client, table, filters: [] })),
+  }
+}
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: mocks.createClient,
+}))
+
+vi.mock('@/lib/supabase/client', () => ({
+  createAdminClient: mocks.createAdminClient,
+}))
+
+describe('DELETE /api/tenants/[tenantId]/members/[memberId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.currentUser = { id: 'actor-user' }
+    mocks.targetMember = {
+      id: 'member-row',
+      user_id: 'pending-auth-user',
+      role: 'member',
+      email: 'pending@example.com',
+      status: 'pending',
+    }
+    mocks.actorMemberships = [{ role: 'admin' }]
+    mocks.otherMembershipCount = 0
+    mocks.deleteMembershipError = null
+    mocks.otherMembershipsError = null
+    mocks.deleteAuthUserError = null
+    mocks.deleteUser.mockResolvedValue({ error: null })
+    mocks.createClient.mockImplementation(() => createSupabaseClient('user'))
+    mocks.createAdminClient.mockImplementation(() => createSupabaseClient('admin'))
+  })
+
+  it('deletes the Supabase Auth user when deleting an orphan pending invitation', async () => {
+    const { DELETE } = await import('./route')
+
+    const response = await DELETE(new Request('http://localhost') as any, {
+      params: { tenantId: 'tenant-1', memberId: 'member-row' },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ success: true })
+    expect(mocks.createAdminClient).toHaveBeenCalledTimes(2)
+    expect(mocks.deleteUser).toHaveBeenCalledWith('pending-auth-user')
+  })
+
+  it('still removes the pending membership when Auth cleanup fails', async () => {
+    mocks.deleteUser.mockResolvedValue({ error: { message: 'Auth user not found' } })
+    const { DELETE } = await import('./route')
+
+    const response = await DELETE(new Request('http://localhost') as any, {
+      params: { tenantId: 'tenant-1', memberId: 'member-row' },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ success: true })
+    expect(mocks.deleteUser).toHaveBeenCalledWith('pending-auth-user')
+  })
+
+  it('keeps the Supabase Auth user when the invitee has another app membership', async () => {
+    mocks.otherMembershipCount = 1
+    const { DELETE } = await import('./route')
+
+    const response = await DELETE(new Request('http://localhost') as any, {
+      params: { tenantId: 'tenant-1', memberId: 'member-row' },
+    })
+
+    expect(response.status).toBe(200)
+    expect(mocks.deleteUser).not.toHaveBeenCalled()
+  })
+
+  it('does not delete Auth users for active member removal', async () => {
+    mocks.targetMember = { ...mocks.targetMember, status: 'active' }
+    const { DELETE } = await import('./route')
+
+    const response = await DELETE(new Request('http://localhost') as any, {
+      params: { tenantId: 'tenant-1', memberId: 'member-row' },
+    })
+
+    expect(response.status).toBe(200)
+    expect(mocks.createAdminClient).not.toHaveBeenCalled()
+    expect(mocks.deleteUser).not.toHaveBeenCalled()
+  })
+})

--- a/app/api/tenants/[tenantId]/members/[memberId]/route.ts
+++ b/app/api/tenants/[tenantId]/members/[memberId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/lib/supabase/server"
+import { createAdminClient } from "@/lib/supabase/client"
 import {
   canManageTenant,
   getTenantMemberRemovalError,
@@ -300,7 +301,7 @@ export async function DELETE(
 
     const { data: targetMember, error: targetMemberError } = await supabase
       .from("user_tenants")
-      .select("id, user_id, role, email")
+      .select("id, user_id, role, email, status")
       .eq("id", params.memberId)
       .eq("tenant_id", params.tenantId)
       .single()
@@ -350,6 +351,31 @@ export async function DELETE(
       return NextResponse.json({ error: permissionError }, { status })
     }
 
+    let shouldDeleteAuthAfterMembershipRemoval = false
+    const shouldCheckPendingAuthCleanup =
+      targetMember.status === "pending" &&
+      Boolean(targetMember.user_id) &&
+      targetMember.user_id !== user.id
+
+    if (shouldCheckPendingAuthCleanup) {
+      const adminSupabase = createAdminClient()
+      const { count: otherMembershipCount, error: otherMembershipsError } = await adminSupabase
+        .from("user_tenants")
+        .select("id", { count: "exact", head: true })
+        .eq("user_id", targetMember.user_id)
+        .neq("id", params.memberId)
+
+      if (otherMembershipsError) {
+        console.error("Error checking pending invitee memberships:", otherMembershipsError)
+        return NextResponse.json(
+          { error: "Failed to verify pending invitee cleanup" },
+          { status: 500 }
+        )
+      }
+
+      shouldDeleteAuthAfterMembershipRemoval = (otherMembershipCount ?? 0) === 0
+    }
+
     const { error: deleteError } = await supabase
       .from("user_tenants")
       .delete()
@@ -362,6 +388,15 @@ export async function DELETE(
         { error: "Failed to remove member" },
         { status: 500 }
       )
+    }
+
+    if (shouldDeleteAuthAfterMembershipRemoval) {
+      const adminSupabase = createAdminClient()
+      const { error: deleteAuthUserError } = await adminSupabase.auth.admin.deleteUser(targetMember.user_id)
+
+      if (deleteAuthUserError) {
+        console.error("Error deleting pending invitee auth user:", deleteAuthUserError)
+      }
     }
 
     return NextResponse.json({ success: true })


### PR DESCRIPTION
## Summary
- Pending tenant invitation deletion now also cleans up the corresponding Supabase Auth user when the invitee has no other memberships.
- Active member removals keep Auth users intact.
- Auth cleanup failures no longer block removing the pending invitation row, so stale invites remain deletable.
- Added route-level regression tests for orphan pending invites, existing memberships, active members, and Auth cleanup failures.

## Verification
- `./node_modules/.bin/vitest run 'app/api/tenants/[tenantId]/members/[memberId]/route.test.ts'`
- `./node_modules/.bin/tsc --noEmit -p /tmp/fun-base-tenant-delete-tsconfig.json`
- `./node_modules/.bin/next build` (passes; existing warnings about `/api/connectors/[id]/sync` config and dynamic route usage are unchanged)
- `codex review --base origin/main` (no actionable regressions)

## Assumption
- Screenshot/context indicates the target screen is FunBase tenant member management in `fun-base`.
