### PR TITLE
fix: keep email invite links reusable

### DIFF
--- a/app/api/invite/[token]/register/route.ts
+++ b/app/api/invite/[token]/register/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createAdminClient } from "@/lib/supabase/client"
+import { isExistingAccountSignUpError } from "@/lib/supabase/auth-errors"
+import { getInviteLinkInfo } from "@/lib/supabase/tenants"
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { token: string } }
+) {
+  try {
+    const inviteResult = await getInviteLinkInfo(params.token)
+
+    if (!inviteResult.success || !inviteResult.info) {
+      return NextResponse.json({ error: inviteResult.error }, { status: 404 })
+    }
+
+    if (!inviteResult.info.isActive) {
+      return NextResponse.json({ error: "この招待リンクは無効化されています" }, { status: 410 })
+    }
+
+    if (inviteResult.info.isExpired) {
+      return NextResponse.json({ error: "この招待リンクは期限切れです" }, { status: 410 })
+    }
+
+    const invitedEmail = inviteResult.info.invitedEmail?.trim().toLowerCase()
+    if (!invitedEmail) {
+      return NextResponse.json({ error: "招待メールアドレスを確認できません" }, { status: 400 })
+    }
+
+    const body = await request.json()
+    const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : ""
+    const password = typeof body.password === "string" ? body.password : ""
+
+    if (email !== invitedEmail) {
+      return NextResponse.json({ error: "招待されたメールアドレスで登録してください" }, { status: 400 })
+    }
+
+    if (password.length < 6) {
+      return NextResponse.json({ error: "パスワードは6文字以上で入力してください" }, { status: 400 })
+    }
+
+    const adminSupabase = createAdminClient()
+    const { error: createUserError } = await adminSupabase.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: {
+        invited_via: "tenant_invite_link",
+      },
+    })
+
+    if (createUserError) {
+      if (isExistingAccountSignUpError(createUserError.message)) {
+        return NextResponse.json({ error: "Account already exists" }, { status: 409 })
+      }
+
+      console.error("Error creating invited auth user:", createUserError)
+      return NextResponse.json({ error: "アカウント作成に失敗しました" }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("Error in invite register POST:", error)
+    return NextResponse.json({ error: "アカウント作成に失敗しました" }, { status: 500 })
+  }
+}

--- a/app/api/invite/[token]/route.ts
+++ b/app/api/invite/[token]/route.ts
@@ -25,6 +25,7 @@ export async function GET(
     tenantId: result.info.tenantId,
     tenantName: result.info.tenantName,
     defaultRole: result.info.defaultRole,
+    invitedEmail: result.info.invitedEmail,
   })
 }
 

--- a/app/api/tenants/[tenantId]/members/[memberId]/resend/route.ts
+++ b/app/api/tenants/[tenantId]/members/[memberId]/resend/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createAdminClient } from "@/lib/supabase/client"
+import { sendEmail } from "@/lib/notifications/email"
 import { getInviteRedirectUrl } from "@/lib/supabase/invite-redirect"
+import { buildTenantInvitationEmail, buildTenantInviteUrl } from "@/lib/tenant-invitation-email"
 import { createClient } from "@/lib/supabase/server"
-import { canManageTenant } from "@/lib/tenant-access"
+import { canManageTenant, TENANT_INVITABLE_ROLES } from "@/lib/tenant-access"
+
+const INVITABLE_ROLES = new Set(TENANT_INVITABLE_ROLES)
 
 export async function POST(
   request: NextRequest,
@@ -70,29 +74,52 @@ export async function POST(
       )
     }
 
-    let redirectTo: string
-    try {
-      redirectTo = getInviteRedirectUrl({ requestOrigin: request.nextUrl.origin })
-    } catch (error) {
-      console.error("Error resolving resend redirect URL:", error)
-      return NextResponse.json(
-        { error: error instanceof Error ? error.message : "Failed to resolve redirect URL" },
-        { status: 500 }
-      )
+    const adminSupabase = createAdminClient()
+    const { data: tenant, error: tenantError } = await adminSupabase
+      .from("tenants")
+      .select("name")
+      .eq("id", params.tenantId)
+      .single()
+
+    if (tenantError || !tenant) {
+      console.error("Error fetching tenant for resend:", tenantError)
+      return NextResponse.json({ error: "Failed to fetch tenant" }, { status: 500 })
     }
 
-    const adminSupabase = createAdminClient()
-    const { error } = await adminSupabase.auth.admin.inviteUserByEmail(targetMember.email, {
-      redirectTo,
+    const inviteLinkDefaultRole = INVITABLE_ROLES.has(targetMember.role as any)
+      ? targetMember.role
+      : "member"
+
+    const { data: link, error: inviteLinkError } = await adminSupabase
+      .from("tenant_invite_links")
+      .insert({
+        tenant_id: params.tenantId,
+        // Targeted email invites activate target_user_tenant_id, so default_role is
+        // only a schema-compatible fallback for the invite-link row.
+        default_role: inviteLinkDefaultRole,
+        is_active: true,
+        created_by: user.id,
+        target_user_tenant_id: targetMember.id,
+      })
+      .select("token")
+      .single()
+
+    if (inviteLinkError || !link) {
+      console.error("Error creating reusable resend invite link:", inviteLinkError)
+      return NextResponse.json({ error: "Failed to create invite link" }, { status: 500 })
+    }
+
+    const baseUrl = getInviteRedirectUrl({ requestOrigin: request.nextUrl.origin })
+    const inviteUrl = buildTenantInviteUrl(baseUrl, link.token)
+    const emailMessage = buildTenantInvitationEmail({
+      tenantName: tenant.name ?? "FunBase",
+      inviteUrl,
     })
 
-    if (error) {
-      console.error("Error resending invitation:", error)
-      return NextResponse.json(
-        { error: error.message || "Failed to resend invitation" },
-        { status: 500 }
-      )
-    }
+    await sendEmail({
+      to: targetMember.email,
+      ...emailMessage,
+    })
 
     return NextResponse.json({
       success: true,

--- a/app/api/tenants/[tenantId]/members/invite/route.ts
+++ b/app/api/tenants/[tenantId]/members/invite/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/lib/supabase/server"
 import { createAdminClient } from "@/lib/supabase/client"
+import { sendEmail } from "@/lib/notifications/email"
 import { getInviteRedirectUrl } from "@/lib/supabase/invite-redirect"
+import { buildTenantInvitationEmail, buildTenantInviteUrl } from "@/lib/tenant-invitation-email"
 import {
   canManageTenant,
   TENANT_INVITABLE_ROLES,
@@ -145,45 +147,25 @@ export async function POST(
         )
     }
 
-    let redirectTo: string
-    try {
-      redirectTo = getInviteRedirectUrl({ requestOrigin: request.nextUrl.origin })
-    } catch (error) {
-      console.error("Error resolving invitation redirect URL:", error)
-      return NextResponse.json(
-        { error: error instanceof Error ? error.message : "Failed to resolve redirect URL" },
-        { status: 500 }
-      )
-    }
-
-    // Use admin client to send invitation
     const adminSupabase = createAdminClient()
-    
+    let createdUserTenantId: string | null = null
+
     try {
-      // Use Supabase auth admin to send invitation email
-      const { data, error } = await adminSupabase.auth.admin.inviteUserByEmail(normalizedEmail, {
-        data: {
-          tenant_id: params.tenantId,
-          role: role,
-          invited_by: user.id,
-          office_ids: officeIds,
-        },
-        redirectTo
-      })
-      
-      if (error) {
-        console.error('Error sending invitation:', error)
-        return NextResponse.json(
-          { error: error.message || "Failed to send invitation" },
-          { status: 500 }
-        )
+      const { data: tenant, error: tenantError } = await adminSupabase
+        .from("tenants")
+        .select("name")
+        .eq("id", params.tenantId)
+        .single()
+
+      if (tenantError || !tenant) {
+        console.error("Error fetching tenant for invitation email:", tenantError)
+        return NextResponse.json({ error: "Failed to fetch tenant" }, { status: 500 })
       }
-      
-      // Store the invitation metadata in user_tenants with pending status
+
+      // Store the invitation metadata before sending the reusable app invite link.
       const { data: userTenant, error: userTenantError } = await adminSupabase
         .from('user_tenants')
         .insert({
-          user_id: data.user.id,
           tenant_id: params.tenantId,
           email: normalizedEmail,
           role: role,
@@ -193,10 +175,9 @@ export async function POST(
         })
         .select("id")
         .single()
-      
+
       if (userTenantError) {
         console.error('Error creating user tenant record:', userTenantError)
-        // Check if it's a duplicate key error
         if (userTenantError.code === '23505') {
           return NextResponse.json(
             { error: "This user is already a member or has a pending invitation" },
@@ -209,6 +190,8 @@ export async function POST(
         )
       }
 
+      createdUserTenantId = userTenant.id
+
       if (officeIds.length > 0) {
         const { error: officeAssignmentError } = await adminSupabase
           .from("user_tenant_offices")
@@ -220,19 +203,76 @@ export async function POST(
 
         if (officeAssignmentError) {
           console.error("Error creating user tenant office assignments:", officeAssignmentError)
-          return NextResponse.json(
-            { error: "Failed to assign affiliations" },
-            { status: 500 }
-          )
+          throw new Error("Failed to assign affiliations")
         }
       }
-      
-      return NextResponse.json({ 
-        success: true, 
-        message: "Invitation sent successfully" 
+
+      const { data: link, error: inviteLinkError } = await adminSupabase
+        .from("tenant_invite_links")
+        .insert({
+          tenant_id: params.tenantId,
+          default_role: role,
+          is_active: true,
+          created_by: user.id,
+          target_user_tenant_id: userTenant.id,
+        })
+        .select("token")
+        .single()
+
+      if (inviteLinkError || !link) {
+        console.error("Error creating reusable invite link:", inviteLinkError)
+        throw new Error("Failed to create invite link")
+      }
+
+      const baseUrl = getInviteRedirectUrl({ requestOrigin: request.nextUrl.origin })
+      const inviteUrl = buildTenantInviteUrl(baseUrl, link.token)
+      const emailMessage = buildTenantInvitationEmail({
+        tenantName: tenant.name ?? "FunBase",
+        inviteUrl,
+      })
+
+      await sendEmail({
+        to: normalizedEmail,
+        ...emailMessage,
+      })
+
+      return NextResponse.json({
+        success: true,
+        message: "Invitation sent successfully"
       })
     } catch (error) {
       console.error('Error in invitation process:', error)
+
+      if (createdUserTenantId) {
+        const { error: cleanupLinkError } = await adminSupabase
+          .from("tenant_invite_links")
+          .delete()
+          .eq("target_user_tenant_id", createdUserTenantId)
+
+        if (cleanupLinkError) {
+          console.error("Error cleaning up failed invite link:", cleanupLinkError)
+        }
+
+        const { error: cleanupOfficesError } = await adminSupabase
+          .from("user_tenant_offices")
+          .delete()
+          .eq("user_tenant_id", createdUserTenantId)
+
+        if (cleanupOfficesError) {
+          console.error("Error cleaning up failed invite office assignments:", cleanupOfficesError)
+        }
+
+        const { error: cleanupMemberError } = await adminSupabase
+          .from("user_tenants")
+          .delete()
+          .eq("id", createdUserTenantId)
+          .eq("status", "pending")
+
+        if (cleanupMemberError) {
+          console.error("Error cleaning up failed pending invitation:", cleanupMemberError)
+        }
+      }
+
       return NextResponse.json(
         { error: "Failed to send invitation" },
         { status: 500 }

--- a/app/auth/set-password/page.tsx
+++ b/app/auth/set-password/page.tsx
@@ -32,7 +32,9 @@ export default function SetPasswordPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const supabase = createClient()
-  const successRedirectPath = getSafeAuthNextPath(searchParams.get("next"), "/admin/tenants")
+  const [successRedirectPath] = useState(() =>
+    getSafeAuthNextPath(searchParams.get("next"), "/admin/tenants")
+  )
   const shouldActivateMembership = shouldActivateMembershipAfterPasswordSet(successRedirectPath)
 
   useEffect(() => {

--- a/app/auth/set-password/page.tsx
+++ b/app/auth/set-password/page.tsx
@@ -3,7 +3,10 @@
 import { useState, useEffect } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { createClient } from "@/lib/supabase/client"
-import { getSafeAuthNextPath } from "@/lib/auth-next-path"
+import {
+  getSafeAuthNextPath,
+  shouldActivateMembershipAfterPasswordSet,
+} from "@/lib/auth-next-path"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -30,6 +33,7 @@ export default function SetPasswordPage() {
   const searchParams = useSearchParams()
   const supabase = createClient()
   const successRedirectPath = getSafeAuthNextPath(searchParams.get("next"), "/admin/tenants")
+  const shouldActivateMembership = shouldActivateMembershipAfterPasswordSet(successRedirectPath)
 
   useEffect(() => {
     const initializeSession = async () => {
@@ -300,21 +304,24 @@ export default function SetPasswordPage() {
         return
       }
 
-      // Update tenant member status
-      try {
-        const response = await fetch('/api/auth/activate-membership', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        })
+      // Update tenant member status for legacy Supabase invite links. Token-scoped
+      // FunBase invite links are accepted after redirecting back to /invite/[token].
+      if (shouldActivateMembership) {
+        try {
+          const response = await fetch('/api/auth/activate-membership', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          })
 
-        if (!response.ok) {
-          console.error('Failed to activate membership, but password was set successfully')
+          if (!response.ok) {
+            console.error('Failed to activate membership, but password was set successfully')
+          }
+        } catch (membershipError) {
+          console.error('Error activating membership:', membershipError)
+          // Don't block the user flow if membership activation fails
         }
-      } catch (membershipError) {
-        console.error('Error activating membership:', membershipError)
-        // Don't block the user flow if membership activation fails
       }
 
       setSuccess(true)

--- a/app/auth/set-password/page.tsx
+++ b/app/auth/set-password/page.tsx
@@ -357,8 +357,8 @@ export default function SetPasswordPage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <Button 
-              onClick={() => router.push(successRedirectPath)} 
+            <Button
+              onClick={() => router.push(successRedirectPath)}
               className="w-full"
             >
               ホームへ

--- a/app/auth/set-password/page.tsx
+++ b/app/auth/set-password/page.tsx
@@ -1,8 +1,9 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import { createClient } from "@/lib/supabase/client"
+import { getSafeAuthNextPath } from "@/lib/auth-next-path"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -26,7 +27,9 @@ export default function SetPasswordPage() {
   const [authType, setAuthType] = useState<"signup" | "invite" | "recovery" | null>(null)
   
   const router = useRouter()
+  const searchParams = useSearchParams()
   const supabase = createClient()
+  const successRedirectPath = getSafeAuthNextPath(searchParams.get("next"), "/admin/tenants")
 
   useEffect(() => {
     const initializeSession = async () => {
@@ -318,7 +321,7 @@ export default function SetPasswordPage() {
       
       // Redirect after 3 seconds
       setTimeout(() => {
-        router.replace('/admin/tenants')
+        router.replace(successRedirectPath)
       }, 3000)
 
     } catch (error) {
@@ -346,7 +349,7 @@ export default function SetPasswordPage() {
           </CardHeader>
           <CardContent>
             <Button 
-              onClick={() => router.push('/admin/tenants')} 
+              onClick={() => router.push(successRedirectPath)} 
               className="w-full"
             >
               ホームへ

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -81,6 +81,18 @@ export default function InviteAcceptancePage() {
         const { data: { user } } = await supabase.auth.getUser()
 
         if (user) {
+          const invitedEmail = typeof data.invitedEmail === "string"
+            ? data.invitedEmail.trim().toLowerCase()
+            : ""
+          const currentEmail = user.email?.trim().toLowerCase() || ""
+
+          if (invitedEmail && currentEmail !== invitedEmail) {
+            await supabase.auth.signOut()
+            setAuthError("招待されたメールアドレスで参加してください。別アカウントからログアウトしました。")
+            setStatus("notLoggedIn")
+            return
+          }
+
           setStatus("accepting")
           await acceptInvite()
         } else {
@@ -146,6 +158,47 @@ export default function InviteAcceptancePage() {
       })
 
       if (!signInError) {
+        await acceptInvite()
+        return
+      }
+
+      if (invitedEmail) {
+        const registerResponse = await fetch(`/api/invite/${token}/register`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: registrationEmail, password }),
+        })
+        const registerResult = await registerResponse.json().catch(() => ({}))
+
+        if (registerResponse.status === 409) {
+          const { error: resetError } = await supabase.auth.resetPasswordForEmail(registrationEmail, {
+            redirectTo: passwordResetRedirectTo,
+          })
+
+          if (resetError) {
+            setAuthError("既にアカウントがあります。ログイン、またはパスワード再設定をお試しください。")
+            return
+          }
+
+          setStatus("signupSent")
+          return
+        }
+
+        if (!registerResponse.ok || !registerResult.success) {
+          setAuthError(registerResult.error || "アカウント作成に失敗しました。")
+          return
+        }
+
+        const { error: createdSignInError } = await supabase.auth.signInWithPassword({
+          email: registrationEmail,
+          password,
+        })
+
+        if (createdSignInError) {
+          setAuthError("アカウント作成後のログインに失敗しました。ログイン画面からお試しください。")
+          return
+        }
+
         await acceptInvite()
         return
       }

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, type FormEvent } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { createClient } from "@/lib/supabase/client"
+import { isExistingAccountSignUpError } from "@/lib/supabase/auth-errors"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -143,6 +144,20 @@ export default function InviteAcceptancePage() {
       })
 
       if (error) {
+        if (isExistingAccountSignUpError(error.message)) {
+          const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
+            redirectTo: emailRedirectTo,
+          })
+
+          if (resetError) {
+            setAuthError("既にアカウントがあります。ログイン、またはパスワード再設定をお試しください。")
+            return
+          }
+
+          setStatus("signupSent")
+          return
+        }
+
         setAuthError("アカウント作成に失敗しました。メールアドレスを確認してください。")
         return
       }

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -121,9 +121,10 @@ export default function InviteAcceptancePage() {
     }
 
     const origin = window.location.origin
-    // After email confirmation, redirect back to this invite page
-    const emailRedirectTo = `${origin}/auth/callback?next=/invite/${token}`
-    const passwordResetRedirectTo = `${origin}/auth/set-password?next=${encodeURIComponent(`/invite/${token}`)}`
+    const invitePath = `/invite/${token}`
+    const emailRedirectTo = `${origin}/auth/callback?next=${invitePath}`
+    const setPasswordNext = `/auth/set-password?type=recovery&next=${encodeURIComponent(invitePath)}`
+    const passwordResetRedirectTo = `${origin}/auth/callback?type=recovery&next=${encodeURIComponent(setPasswordNext)}`
 
     try {
       const { data, error } = await supabase.auth.signUp({

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -28,6 +28,7 @@ type PageStatus =
 interface InviteInfo {
   tenantName: string
   defaultRole: string
+  invitedEmail?: string | null
 }
 
 const roleLabel: Record<string, string> = {
@@ -53,6 +54,8 @@ export default function InviteAcceptancePage() {
   const [passwordConfirmation, setPasswordConfirmation] = useState("")
   const [authLoading, setAuthLoading] = useState(false)
   const [authError, setAuthError] = useState("")
+  const invitedEmail = inviteInfo?.invitedEmail?.trim() || ""
+  const registrationEmail = invitedEmail || email.trim()
 
   // Step 1: fetch invite info and check login state
   useEffect(() => {
@@ -68,7 +71,11 @@ export default function InviteAcceptancePage() {
           return
         }
 
-        setInviteInfo({ tenantName: data.tenantName, defaultRole: data.defaultRole })
+        setInviteInfo({
+          tenantName: data.tenantName,
+          defaultRole: data.defaultRole,
+          invitedEmail: data.invitedEmail ?? null,
+        })
 
         // Check if user is logged in
         const { data: { user } } = await supabase.auth.getUser()
@@ -113,6 +120,12 @@ export default function InviteAcceptancePage() {
     setAuthLoading(true)
     setAuthError("")
 
+    if (!registrationEmail) {
+      setAuthError("メールアドレスを確認してください")
+      setAuthLoading(false)
+      return
+    }
+
     const passwordError = validateInviteRegistrationPasswords(password, passwordConfirmation)
     if (passwordError) {
       setAuthError(passwordError)
@@ -127,7 +140,10 @@ export default function InviteAcceptancePage() {
     const passwordResetRedirectTo = `${origin}/auth/callback?type=recovery&next=${encodeURIComponent(setPasswordNext)}`
 
     try {
-      const { error: signInError } = await supabase.auth.signInWithPassword({ email, password })
+      const { error: signInError } = await supabase.auth.signInWithPassword({
+        email: registrationEmail,
+        password,
+      })
 
       if (!signInError) {
         await acceptInvite()
@@ -135,14 +151,14 @@ export default function InviteAcceptancePage() {
       }
 
       const { data, error } = await supabase.auth.signUp({
-        email,
+        email: registrationEmail,
         password,
         options: { emailRedirectTo },
       })
 
       if (error) {
         if (isExistingAccountSignUpError(error.message)) {
-          const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
+          const { error: resetError } = await supabase.auth.resetPasswordForEmail(registrationEmail, {
             redirectTo: passwordResetRedirectTo,
           })
 
@@ -165,7 +181,7 @@ export default function InviteAcceptancePage() {
       }
 
       if (isLikelyExistingAccountSignUpResponse(data.user)) {
-        const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
+        const { error: resetError } = await supabase.auth.resetPasswordForEmail(registrationEmail, {
           redirectTo: passwordResetRedirectTo,
         })
 
@@ -267,7 +283,7 @@ export default function InviteAcceptancePage() {
             <CheckCircle className="h-12 w-12 text-blue-500 mx-auto mb-2" />
             <CardTitle>確認メールを送信しました</CardTitle>
             <CardDescription>
-              {email} に確認メールを送りました。<br />
+              {registrationEmail} に確認メールを送りました。<br />
               メール内のリンクをクリックすると、自動的に {inviteInfo?.tenantName} に参加します。
             </CardDescription>
           </CardHeader>
@@ -304,17 +320,26 @@ export default function InviteAcceptancePage() {
               </Alert>
             )}
 
-            <div className="space-y-2">
-              <Label htmlFor="email">メールアドレス</Label>
-              <Input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                disabled={authLoading}
-              />
-            </div>
+            {invitedEmail ? (
+              <div className="space-y-2">
+                <Label>メールアドレス</Label>
+                <div className="rounded-md border bg-muted/40 px-3 py-2 text-sm text-foreground">
+                  {invitedEmail}
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <Label htmlFor="email">メールアドレス</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  disabled={authLoading}
+                />
+              </div>
+            )}
 
             <div className="space-y-2">
               <Label htmlFor="password">パスワード</Label>

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -127,6 +127,13 @@ export default function InviteAcceptancePage() {
     const passwordResetRedirectTo = `${origin}/auth/callback?type=recovery&next=${encodeURIComponent(setPasswordNext)}`
 
     try {
+      const { error: signInError } = await supabase.auth.signInWithPassword({ email, password })
+
+      if (!signInError) {
+        await acceptInvite()
+        return
+      }
+
       const { data, error } = await supabase.auth.signUp({
         email,
         password,

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -123,6 +123,7 @@ export default function InviteAcceptancePage() {
     const origin = window.location.origin
     // After email confirmation, redirect back to this invite page
     const emailRedirectTo = `${origin}/auth/callback?next=/invite/${token}`
+    const passwordResetRedirectTo = `${origin}/auth/set-password?next=${encodeURIComponent(`/invite/${token}`)}`
 
     try {
       const { data, error } = await supabase.auth.signUp({
@@ -134,7 +135,7 @@ export default function InviteAcceptancePage() {
       if (error) {
         if (isExistingAccountSignUpError(error.message)) {
           const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
-            redirectTo: emailRedirectTo,
+            redirectTo: passwordResetRedirectTo,
           })
 
           if (resetError) {
@@ -157,7 +158,7 @@ export default function InviteAcceptancePage() {
 
       if (isLikelyExistingAccountSignUpResponse(data.user)) {
         const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
-          redirectTo: emailRedirectTo,
+          redirectTo: passwordResetRedirectTo,
         })
 
         if (resetError) {

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -4,7 +4,10 @@ import { useState, useEffect, type FormEvent } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { createClient } from "@/lib/supabase/client"
 import { isExistingAccountSignUpError } from "@/lib/supabase/auth-errors"
-import { validateInviteRegistrationPasswords } from "@/lib/invite-registration-form"
+import {
+  isLikelyExistingAccountSignUpResponse,
+  validateInviteRegistrationPasswords,
+} from "@/lib/invite-registration-form"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -150,6 +153,17 @@ export default function InviteAcceptancePage() {
       if (data.session) {
         await acceptInvite()
         return
+      }
+
+      if (isLikelyExistingAccountSignUpResponse(data.user)) {
+        const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
+          redirectTo: emailRedirectTo,
+        })
+
+        if (resetError) {
+          setAuthError("既にアカウントがあります。ログイン、またはパスワード再設定をお試しください。")
+          return
+        }
       }
 
       setStatus("signupSent")

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, type FormEvent } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { createClient } from "@/lib/supabase/client"
 import { isExistingAccountSignUpError } from "@/lib/supabase/auth-errors"
+import { validateInviteRegistrationPasswords } from "@/lib/invite-registration-form"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -44,9 +45,9 @@ export default function InviteAcceptancePage() {
   const [acceptError, setAcceptError] = useState("")
 
   // Auth form state
-  const [authMode, setAuthMode] = useState<"login" | "register">("login")
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
+  const [passwordConfirmation, setPasswordConfirmation] = useState("")
   const [authLoading, setAuthLoading] = useState(false)
   const [authError, setAuthError] = useState("")
 
@@ -104,33 +105,17 @@ export default function InviteAcceptancePage() {
     }
   }
 
-  const handleLogin = async (e: FormEvent) => {
-    e.preventDefault()
-    setAuthLoading(true)
-    setAuthError("")
-
-    try {
-      const { error } = await supabase.auth.signInWithPassword({ email, password })
-
-      if (error) {
-        setAuthError("ログインに失敗しました。メールアドレスとパスワードを確認してください。")
-        return
-      }
-
-      // Logged in successfully → accept invite
-      await acceptInvite()
-    } catch (error) {
-      console.error("Error during login:", error)
-      setAuthError("ログイン中にエラーが発生しました。")
-    } finally {
-      setAuthLoading(false)
-    }
-  }
-
   const handleRegister = async (e: FormEvent) => {
     e.preventDefault()
     setAuthLoading(true)
     setAuthError("")
+
+    const passwordError = validateInviteRegistrationPasswords(password, passwordConfirmation)
+    if (passwordError) {
+      setAuthError(passwordError)
+      setAuthLoading(false)
+      return
+    }
 
     const origin = window.location.origin
     // After email confirmation, redirect back to this invite page
@@ -289,29 +274,7 @@ export default function InviteAcceptancePage() {
           )}
         </CardHeader>
         <CardContent>
-          {/* Mode tabs */}
-          <div className="flex rounded-lg border mb-4 overflow-hidden">
-            <button
-              type="button"
-              className={`flex-1 py-2 text-sm font-medium transition-colors ${
-                authMode === "login" ? "bg-primary text-primary-foreground" : "bg-background hover:bg-muted"
-              }`}
-              onClick={() => { setAuthMode("login"); setAuthError("") }}
-            >
-              ログイン
-            </button>
-            <button
-              type="button"
-              className={`flex-1 py-2 text-sm font-medium transition-colors ${
-                authMode === "register" ? "bg-primary text-primary-foreground" : "bg-background hover:bg-muted"
-              }`}
-              onClick={() => { setAuthMode("register"); setAuthError("") }}
-            >
-              新規登録
-            </button>
-          </div>
-
-          <form onSubmit={authMode === "login" ? handleLogin : handleRegister} className="space-y-4">
+          <form onSubmit={handleRegister} className="space-y-4">
             {authError && (
               <Alert variant="destructive">
                 <AlertDescription>{authError}</AlertDescription>
@@ -339,17 +302,26 @@ export default function InviteAcceptancePage() {
                 onChange={(e) => setPassword(e.target.value)}
                 required
                 disabled={authLoading}
-                minLength={authMode === "register" ? 6 : undefined}
+                minLength={6}
               />
-              {authMode === "register" && (
-                <p className="text-xs text-muted-foreground">6文字以上で入力してください</p>
-              )}
+              <p className="text-xs text-muted-foreground">6文字以上で入力してください</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="passwordConfirmation">パスワード（確認）</Label>
+              <Input
+                id="passwordConfirmation"
+                type="password"
+                value={passwordConfirmation}
+                onChange={(e) => setPasswordConfirmation(e.target.value)}
+                required
+                disabled={authLoading}
+                minLength={6}
+              />
             </div>
 
             <Button type="submit" className="w-full" disabled={authLoading}>
-              {authLoading
-                ? authMode === "login" ? "ログイン中..." : "登録中..."
-                : authMode === "login" ? "ログインして参加" : "アカウントを作成して参加"}
+              {authLoading ? "登録中..." : "アカウントを作成して参加"}
             </Button>
           </form>
         </CardContent>

--- a/lib/auth-next-path.test.ts
+++ b/lib/auth-next-path.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+
+import { getSafeAuthNextPath } from "./auth-next-path"
+
+describe("getSafeAuthNextPath", () => {
+  it("allows an app-relative invite path", () => {
+    expect(getSafeAuthNextPath("/invite/token", "/admin/tenants")).toBe("/invite/token")
+  })
+
+  it("rejects absolute external URLs", () => {
+    expect(getSafeAuthNextPath("https://example.com/invite/token", "/admin/tenants")).toBe("/admin/tenants")
+  })
+
+  it("rejects protocol-relative URLs", () => {
+    expect(getSafeAuthNextPath("//example.com/invite/token", "/admin/tenants")).toBe("/admin/tenants")
+  })
+
+  it("uses the fallback when the next path is missing", () => {
+    expect(getSafeAuthNextPath(null, "/admin/tenants")).toBe("/admin/tenants")
+  })
+})

--- a/lib/auth-next-path.test.ts
+++ b/lib/auth-next-path.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it } from "vitest"
 
-import { getSafeAuthNextPath } from "./auth-next-path"
+import {
+  getSafeAuthNextPath,
+  shouldActivateMembershipAfterPasswordSet,
+} from "./auth-next-path"
+
+describe("shouldActivateMembershipAfterPasswordSet", () => {
+  it("skips generic membership activation when returning to a token-scoped invite", () => {
+    expect(shouldActivateMembershipAfterPasswordSet("/invite/token")).toBe(false)
+  })
+
+  it("keeps generic membership activation for normal password setup", () => {
+    expect(shouldActivateMembershipAfterPasswordSet("/admin/tenants")).toBe(true)
+  })
+})
 
 describe("getSafeAuthNextPath", () => {
   it("allows an app-relative invite path", () => {

--- a/lib/auth-next-path.ts
+++ b/lib/auth-next-path.ts
@@ -1,3 +1,7 @@
+export function shouldActivateMembershipAfterPasswordSet(nextPath: string): boolean {
+  return !nextPath.startsWith("/invite/")
+}
+
 export function getSafeAuthNextPath(
   nextPath: string | null | undefined,
   fallbackPath: string

--- a/lib/auth-next-path.ts
+++ b/lib/auth-next-path.ts
@@ -1,0 +1,14 @@
+export function getSafeAuthNextPath(
+  nextPath: string | null | undefined,
+  fallbackPath: string
+): string {
+  if (!nextPath?.trim()) {
+    return fallbackPath
+  }
+
+  if (!nextPath.startsWith("/") || nextPath.startsWith("//")) {
+    return fallbackPath
+  }
+
+  return nextPath
+}

--- a/lib/invite-registration-form.test.ts
+++ b/lib/invite-registration-form.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+
+import { validateInviteRegistrationPasswords } from "./invite-registration-form"
+
+describe("validateInviteRegistrationPasswords", () => {
+  it("requires the password to be at least 6 characters", () => {
+    expect(validateInviteRegistrationPasswords("abcde", "abcde")).toBe("パスワードは6文字以上で入力してください")
+  })
+
+  it("requires the confirmation password to match", () => {
+    expect(validateInviteRegistrationPasswords("abcdef", "abcdeg")).toBe("パスワードが一致しません")
+  })
+
+  it("accepts matching passwords with at least 6 characters", () => {
+    expect(validateInviteRegistrationPasswords("abcdef", "abcdef")).toBeNull()
+  })
+})

--- a/lib/invite-registration-form.test.ts
+++ b/lib/invite-registration-form.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, it } from "vitest"
 
-import { validateInviteRegistrationPasswords } from "./invite-registration-form"
+import {
+  isLikelyExistingAccountSignUpResponse,
+  validateInviteRegistrationPasswords,
+} from "./invite-registration-form"
+
+describe("isLikelyExistingAccountSignUpResponse", () => {
+  it("detects Supabase's fake existing-user signup response", () => {
+    expect(isLikelyExistingAccountSignUpResponse({ identities: [] })).toBe(true)
+  })
+
+  it("does not treat a new signup identity as an existing account", () => {
+    expect(isLikelyExistingAccountSignUpResponse({ identities: [{ id: "identity" }] })).toBe(false)
+  })
+
+  it("does not treat a missing user as an existing account", () => {
+    expect(isLikelyExistingAccountSignUpResponse(null)).toBe(false)
+  })
+})
 
 describe("validateInviteRegistrationPasswords", () => {
   it("requires the password to be at least 6 characters", () => {

--- a/lib/invite-registration-form.ts
+++ b/lib/invite-registration-form.ts
@@ -3,7 +3,8 @@ type SignUpUserLike = {
 }
 
 export function isLikelyExistingAccountSignUpResponse(user: SignUpUserLike | null | undefined): boolean {
-  return Array.isArray(user?.identities) && user.identities.length === 0
+  const identities = user?.identities
+  return Array.isArray(identities) && identities.length === 0
 }
 
 export function validateInviteRegistrationPasswords(

--- a/lib/invite-registration-form.ts
+++ b/lib/invite-registration-form.ts
@@ -1,3 +1,11 @@
+type SignUpUserLike = {
+  identities?: unknown[] | null
+}
+
+export function isLikelyExistingAccountSignUpResponse(user: SignUpUserLike | null | undefined): boolean {
+  return Array.isArray(user?.identities) && user.identities.length === 0
+}
+
 export function validateInviteRegistrationPasswords(
   password: string,
   passwordConfirmation: string

--- a/lib/invite-registration-form.ts
+++ b/lib/invite-registration-form.ts
@@ -1,0 +1,14 @@
+export function validateInviteRegistrationPasswords(
+  password: string,
+  passwordConfirmation: string
+): string | null {
+  if (password.length < 6) {
+    return "パスワードは6文字以上で入力してください"
+  }
+
+  if (password !== passwordConfirmation) {
+    return "パスワードが一致しません"
+  }
+
+  return null
+}

--- a/lib/supabase/auth-errors.test.ts
+++ b/lib/supabase/auth-errors.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest"
+
+import { isExistingAccountSignUpError } from "./auth-errors"
+
+describe("isExistingAccountSignUpError", () => {
+  it("detects existing account sign-up errors", () => {
+    expect(isExistingAccountSignUpError("User already registered")).toBe(true)
+    expect(isExistingAccountSignUpError("A user with this email already exists")).toBe(true)
+  })
+
+  it("does not treat unrelated sign-up errors as existing accounts", () => {
+    expect(isExistingAccountSignUpError("Password should be at least 6 characters"))
+      .toBe(false)
+  })
+})

--- a/lib/supabase/auth-errors.ts
+++ b/lib/supabase/auth-errors.ts
@@ -1,0 +1,8 @@
+export function isExistingAccountSignUpError(errorMessage: string): boolean {
+  const normalizedMessage = errorMessage.trim().toLowerCase()
+  return (
+    normalizedMessage.includes("already registered") ||
+    normalizedMessage.includes("already exists") ||
+    normalizedMessage.includes("user already")
+  )
+}

--- a/lib/supabase/tenant-invitation-acceptance.test.ts
+++ b/lib/supabase/tenant-invitation-acceptance.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+
+import { getTenantMembershipIdentityFilter, pickTenantMembershipForInviteAcceptance } from "./tenants"
+
+describe("getTenantMembershipIdentityFilter", () => {
+  it("matches both authenticated user id and invited email so reusable invite links activate pending memberships", () => {
+    expect(getTenantMembershipIdentityFilter("user-123", " Invited@Example.COM ")).toBe(
+      "user_id.eq.user-123,email.eq.invited@example.com"
+    )
+  })
+
+  it("uses only the authenticated user id when email is missing", () => {
+    expect(getTenantMembershipIdentityFilter("user-123", "")).toBe("user_id.eq.user-123")
+  })
+})
+
+describe("pickTenantMembershipForInviteAcceptance", () => {
+  it("prefers the pending invite for the logged-in email over an active auxiliary membership", () => {
+    const picked = pickTenantMembershipForInviteAcceptance(
+      [
+        { id: "active-supporter", status: "active", role: "supporter", email: "invited@example.com" },
+        { id: "pending-member", status: "pending", role: "member", email: "Invited@Example.COM" },
+      ],
+      " invited@example.com "
+    )
+
+    expect(picked?.id).toBe("pending-member")
+  })
+
+  it("does not fall back to a supporter membership when accepting a normal invite", () => {
+    const picked = pickTenantMembershipForInviteAcceptance(
+      [{ id: "pending-supporter", status: "pending", role: "supporter", email: "invited@example.com" }],
+      "invited@example.com"
+    )
+
+    expect(picked).toBeUndefined()
+  })
+})

--- a/lib/supabase/tenant-invitation-acceptance.test.ts
+++ b/lib/supabase/tenant-invitation-acceptance.test.ts
@@ -27,6 +27,15 @@ describe("pickTenantMembershipForInviteAcceptance", () => {
     expect(picked?.id).toBe("pending-member")
   })
 
+  it("picks a suspended non-supporter membership so invite acceptance can reactivate it", () => {
+    const picked = pickTenantMembershipForInviteAcceptance(
+      [{ id: "suspended-member", status: "suspended", role: "member", email: "invited@example.com" }],
+      "invited@example.com"
+    )
+
+    expect(picked?.id).toBe("suspended-member")
+  })
+
   it("does not fall back to a supporter membership when accepting a normal invite", () => {
     const picked = pickTenantMembershipForInviteAcceptance(
       [{ id: "pending-supporter", status: "pending", role: "supporter", email: "invited@example.com" }],

--- a/lib/supabase/tenant-invitation-acceptance.test.ts
+++ b/lib/supabase/tenant-invitation-acceptance.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
 
-import { getTenantMembershipIdentityFilter, pickTenantMembershipForInviteAcceptance } from "./tenants"
+import {
+  getTenantMembershipIdentityFilter,
+  pickExistingMembershipForTargetedInvite,
+  pickTenantMembershipForInviteAcceptance,
+} from "./tenants"
 
 describe("getTenantMembershipIdentityFilter", () => {
   it("matches both authenticated user id and invited email so reusable invite links activate pending memberships", () => {
@@ -40,6 +44,38 @@ describe("pickTenantMembershipForInviteAcceptance", () => {
     const picked = pickTenantMembershipForInviteAcceptance(
       [{ id: "pending-supporter", status: "pending", role: "supporter", email: "invited@example.com" }],
       "invited@example.com"
+    )
+
+    expect(picked).toBeUndefined()
+  })
+})
+
+describe("pickExistingMembershipForTargetedInvite", () => {
+  it("prefers an active non-supporter membership over the targeted pending invite", () => {
+    const picked = pickExistingMembershipForTargetedInvite(
+      [
+        { id: "active-member", status: "active", role: "member" },
+        { id: "suspended-member", status: "suspended", role: "member" },
+      ],
+      "member"
+    )
+
+    expect(picked?.id).toBe("active-member")
+  })
+
+  it("picks a suspended membership with the targeted role to avoid duplicate user tenant roles", () => {
+    const picked = pickExistingMembershipForTargetedInvite(
+      [{ id: "suspended-member", status: "suspended", role: "member" }],
+      "member"
+    )
+
+    expect(picked?.id).toBe("suspended-member")
+  })
+
+  it("does not pick a suspended membership with a different role", () => {
+    const picked = pickExistingMembershipForTargetedInvite(
+      [{ id: "suspended-admin", status: "suspended", role: "admin" }],
+      "member"
     )
 
     expect(picked).toBeUndefined()

--- a/lib/supabase/tenants.ts
+++ b/lib/supabase/tenants.ts
@@ -595,6 +595,22 @@ export function pickTenantMembershipForInviteAcceptance(
   )
 }
 
+export function pickExistingMembershipForTargetedInvite(
+  memberships: InvitationMembershipCandidate[],
+  targetRole?: string | null
+): InvitationMembershipCandidate | undefined {
+  return (
+    memberships.find(
+      (membership) => membership.status === 'active' && membership.role !== 'supporter'
+    ) ?? memberships.find(
+      (membership) =>
+        membership.status === 'suspended' &&
+        membership.role !== 'supporter' &&
+        membership.role === targetRole
+    )
+  )
+}
+
 // Public: look up invite link info without authentication (uses admin client)
 export async function getInviteLinkInfo(token: string): Promise<{ success: boolean; info?: InviteLinkInfo; error?: string }> {
   try {
@@ -664,7 +680,7 @@ export async function acceptTenantInvitation(
     if (link.target_user_tenant_id) {
       const { data: targetMembership, error: targetMembershipError } = await adminSupabase
         .from('user_tenants')
-        .select('id, status, email, user_id')
+        .select('id, status, email, user_id, role')
         .eq('id', link.target_user_tenant_id)
         .eq('tenant_id', link.tenant_id)
         .maybeSingle()
@@ -689,20 +705,80 @@ export async function acceptTenantInvitation(
         return { success: false, error: 'すでにこのテナントのメンバーです' }
       }
 
-      const { data: activeMemberships, error: activeMembershipError } = await adminSupabase
+      if (targetMembership.status !== 'pending') {
+        return { success: false, error: 'この招待リンクは利用できません' }
+      }
+
+      const { data: existingMemberships, error: existingMembershipError } = await adminSupabase
         .from('user_tenants')
-        .select('id')
+        .select('id, status, role')
         .eq('tenant_id', link.tenant_id)
         .eq('user_id', userId)
-        .eq('status', 'active')
+        .in('status', ['active', 'suspended'])
         .neq('role', 'supporter')
 
-      if (activeMembershipError) {
-        console.error('Error checking active memberships for targeted invite:', activeMembershipError)
+      if (existingMembershipError) {
+        console.error('Error checking existing memberships for targeted invite:', existingMembershipError)
         return { success: false, error: '既存メンバー情報の確認に失敗しました' }
       }
 
-      if ((activeMemberships || []).length > 0) {
+      const existingMembership = pickExistingMembershipForTargetedInvite(
+        existingMemberships || [],
+        targetMembership.role
+      )
+
+      if (existingMembership) {
+        if (existingMembership.status === 'suspended') {
+          const { data: targetOfficeAssignments, error: targetOfficeAssignmentsError } = await adminSupabase
+            .from('user_tenant_offices')
+            .select('tenant_office_id')
+            .eq('tenant_id', link.tenant_id)
+            .eq('user_tenant_id', targetMembership.id)
+
+          if (targetOfficeAssignmentsError) {
+            console.error('Error fetching targeted invite office assignments:', targetOfficeAssignmentsError)
+            return { success: false, error: '所属先情報の確認に失敗しました' }
+          }
+
+          const { error: deleteExistingOfficesError } = await adminSupabase
+            .from('user_tenant_offices')
+            .delete()
+            .eq('tenant_id', link.tenant_id)
+            .eq('user_tenant_id', existingMembership.id)
+
+          if (deleteExistingOfficesError) {
+            console.error('Error clearing existing suspended membership offices:', deleteExistingOfficesError)
+            return { success: false, error: '所属先情報の更新に失敗しました' }
+          }
+
+          if ((targetOfficeAssignments || []).length > 0) {
+            const { error: moveTargetOfficesError } = await adminSupabase
+              .from('user_tenant_offices')
+              .update({ user_tenant_id: existingMembership.id })
+              .eq('tenant_id', link.tenant_id)
+              .eq('user_tenant_id', targetMembership.id)
+
+            if (moveTargetOfficesError) {
+              console.error('Error moving targeted invite office assignments:', moveTargetOfficesError)
+              return { success: false, error: '所属先情報の更新に失敗しました' }
+            }
+          }
+
+          const { error: reactivateError } = await adminSupabase
+            .from('user_tenants')
+            .update({
+              email: normalizedUserEmail,
+              status: 'active',
+              joined_at: new Date().toISOString(),
+            })
+            .eq('id', existingMembership.id)
+
+          if (reactivateError) {
+            console.error('Error reactivating existing targeted invite membership:', reactivateError)
+            return { success: false, error: 'テナント参加処理に失敗しました' }
+          }
+        }
+
         const { error: deletePendingError } = await adminSupabase
           .from('user_tenants')
           .delete()

--- a/lib/supabase/tenants.ts
+++ b/lib/supabase/tenants.ts
@@ -631,7 +631,7 @@ export async function getInviteLinkInfo(token: string): Promise<{ success: boole
     if (data.target_user_tenant_id) {
       const { data: targetMembership, error: targetMembershipError } = await adminSupabase
         .from('user_tenants')
-        .select('email')
+        .select('email, status')
         .eq('id', data.target_user_tenant_id)
         .eq('tenant_id', data.tenant_id)
         .maybeSingle()
@@ -641,7 +641,11 @@ export async function getInviteLinkInfo(token: string): Promise<{ success: boole
         return { success: false, error: '招待情報の確認に失敗しました' }
       }
 
-      invitedEmail = targetMembership?.email ?? null
+      if (!targetMembership || targetMembership.status !== 'pending') {
+        return { success: false, error: 'この招待リンクは無効化されています' }
+      }
+
+      invitedEmail = targetMembership.email ?? null
     }
 
     const isExpired = data.expires_at ? new Date(data.expires_at) < new Date() : false
@@ -695,6 +699,20 @@ export async function acceptTenantInvitation(
     }
 
     const normalizedUserEmail = userEmail.trim().toLowerCase()
+    const deactivateTargetedInviteLink = async () => {
+      const { error: deactivateError } = await adminSupabase
+        .from('tenant_invite_links')
+        .update({ is_active: false })
+        .eq('id', link.id)
+        .eq('target_user_tenant_id', link.target_user_tenant_id)
+
+      if (deactivateError) {
+        console.error('Error deactivating targeted invite link:', deactivateError)
+        return false
+      }
+
+      return true
+    }
 
     if (link.target_user_tenant_id) {
       const { data: targetMembership, error: targetMembershipError } = await adminSupabase
@@ -719,6 +737,7 @@ export async function acceptTenantInvitation(
 
       if (targetMembership.status === 'active') {
         if (targetMembership.user_id === userId) {
+          await deactivateTargetedInviteLink()
           return { success: true, tenantId: link.tenant_id }
         }
         return { success: false, error: 'すでにこのテナントのメンバーです' }
@@ -808,6 +827,7 @@ export async function acceptTenantInvitation(
           console.error('Error deleting duplicate pending targeted invite:', deletePendingError)
         }
 
+        await deactivateTargetedInviteLink()
         return { success: true, tenantId: link.tenant_id }
       }
 
@@ -826,6 +846,7 @@ export async function acceptTenantInvitation(
         return { success: false, error: 'テナント参加処理に失敗しました' }
       }
 
+      await deactivateTargetedInviteLink()
       return { success: true, tenantId: link.tenant_id }
     }
 

--- a/lib/supabase/tenants.ts
+++ b/lib/supabase/tenants.ts
@@ -562,6 +562,37 @@ export interface InviteLinkInfo {
   isExpired: boolean
 }
 
+type InvitationMembershipCandidate = {
+  id: string
+  status: string
+  role?: string | null
+  user_id?: string | null
+  email?: string | null
+}
+
+export function getTenantMembershipIdentityFilter(userId: string, userEmail: string): string {
+  const normalizedEmail = userEmail.trim().toLowerCase()
+  return normalizedEmail ? `user_id.eq.${userId},email.eq.${normalizedEmail}` : `user_id.eq.${userId}`
+}
+
+export function pickTenantMembershipForInviteAcceptance(
+  memberships: InvitationMembershipCandidate[],
+  userEmail: string
+): InvitationMembershipCandidate | undefined {
+  const normalizedEmail = userEmail.trim().toLowerCase()
+
+  return (
+    memberships.find(
+      (membership) =>
+        membership.status === 'pending' &&
+        membership.email?.trim().toLowerCase() === normalizedEmail &&
+        membership.role !== 'supporter'
+    ) ?? memberships.find(
+      (membership) => membership.status === 'active' && membership.role !== 'supporter'
+    )
+  )
+}
+
 // Public: look up invite link info without authentication (uses admin client)
 export async function getInviteLinkInfo(token: string): Promise<{ success: boolean; info?: InviteLinkInfo; error?: string }> {
   try {
@@ -610,7 +641,7 @@ export async function acceptTenantInvitation(
     // 1. Look up the invite link
     const { data: link, error: linkError } = await adminSupabase
       .from('tenant_invite_links')
-      .select('id, tenant_id, default_role, expires_at, is_active')
+      .select('id, tenant_id, default_role, expires_at, is_active, target_user_tenant_id')
       .eq('token', token)
       .single()
 
@@ -626,27 +657,108 @@ export async function acceptTenantInvitation(
       return { success: false, error: 'この招待リンクは期限切れです' }
     }
 
-    // 2. Check if user is already a member
-    const { data: existing, error: existingError } = await adminSupabase
+    const normalizedUserEmail = userEmail.trim().toLowerCase()
+
+    if (link.target_user_tenant_id) {
+      const { data: targetMembership, error: targetMembershipError } = await adminSupabase
+        .from('user_tenants')
+        .select('id, status, email, user_id')
+        .eq('id', link.target_user_tenant_id)
+        .eq('tenant_id', link.tenant_id)
+        .maybeSingle()
+
+      if (targetMembershipError) {
+        console.error('Error fetching target invite membership:', targetMembershipError)
+        return { success: false, error: '招待情報の確認に失敗しました' }
+      }
+
+      if (!targetMembership) {
+        return { success: false, error: '招待情報が見つかりません' }
+      }
+
+      if (targetMembership.email?.trim().toLowerCase() !== normalizedUserEmail) {
+        return { success: false, error: '招待されたメールアドレスでログインしてください' }
+      }
+
+      if (targetMembership.status === 'active') {
+        if (targetMembership.user_id === userId) {
+          return { success: true, tenantId: link.tenant_id }
+        }
+        return { success: false, error: 'すでにこのテナントのメンバーです' }
+      }
+
+      const { data: activeMemberships, error: activeMembershipError } = await adminSupabase
+        .from('user_tenants')
+        .select('id')
+        .eq('tenant_id', link.tenant_id)
+        .eq('user_id', userId)
+        .eq('status', 'active')
+        .neq('role', 'supporter')
+
+      if (activeMembershipError) {
+        console.error('Error checking active memberships for targeted invite:', activeMembershipError)
+        return { success: false, error: '既存メンバー情報の確認に失敗しました' }
+      }
+
+      if ((activeMemberships || []).length > 0) {
+        const { error: deletePendingError } = await adminSupabase
+          .from('user_tenants')
+          .delete()
+          .eq('id', targetMembership.id)
+          .eq('status', 'pending')
+
+        if (deletePendingError) {
+          console.error('Error deleting duplicate pending targeted invite:', deletePendingError)
+        }
+
+        return { success: true, tenantId: link.tenant_id }
+      }
+
+      const { error: updateError } = await adminSupabase
+        .from('user_tenants')
+        .update({
+          user_id: userId,
+          email: normalizedUserEmail,
+          status: 'active',
+          joined_at: new Date().toISOString(),
+        })
+        .eq('id', targetMembership.id)
+
+      if (updateError) {
+        console.error('Error activating target membership:', updateError)
+        return { success: false, error: 'テナント参加処理に失敗しました' }
+      }
+
+      return { success: true, tenantId: link.tenant_id }
+    }
+
+    // 2. Check if user is already a member or has a pending invite for this email
+    const { data: existingMemberships, error: existingError } = await adminSupabase
       .from('user_tenants')
-      .select('id, status')
+      .select('id, status, role, email')
       .eq('tenant_id', link.tenant_id)
-      .eq('user_id', userId)
-      .maybeSingle()
+      .or(getTenantMembershipIdentityFilter(userId, userEmail))
 
     if (existingError) {
       console.error('Error fetching existing membership:', existingError)
       return { success: false, error: '既存メンバー情報の確認に失敗しました' }
     }
 
+    const existing = pickTenantMembershipForInviteAcceptance(existingMemberships || [], userEmail)
+
     if (existing) {
       if (existing.status === 'active') {
         return { success: false, error: 'すでにこのテナントのメンバーです' }
       }
-      // Activate pending membership
+      // Activate pending membership and attach it to the authenticated user.
       const { error: updateError } = await adminSupabase
         .from('user_tenants')
-        .update({ status: 'active', joined_at: new Date().toISOString() })
+        .update({
+          user_id: userId,
+          email: userEmail.trim().toLowerCase(),
+          status: 'active',
+          joined_at: new Date().toISOString(),
+        })
         .eq('id', existing.id)
 
       if (updateError) {

--- a/lib/supabase/tenants.ts
+++ b/lib/supabase/tenants.ts
@@ -589,6 +589,8 @@ export function pickTenantMembershipForInviteAcceptance(
         membership.role !== 'supporter'
     ) ?? memberships.find(
       (membership) => membership.status === 'active' && membership.role !== 'supporter'
+    ) ?? memberships.find(
+      (membership) => membership.status === 'suspended' && membership.role !== 'supporter'
     )
   )
 }

--- a/lib/supabase/tenants.ts
+++ b/lib/supabase/tenants.ts
@@ -558,6 +558,7 @@ export interface InviteLinkInfo {
   tenantId: string
   tenantName: string
   defaultRole: 'admin' | 'member' | 'guest'
+  invitedEmail?: string | null
   isActive: boolean
   isExpired: boolean
 }
@@ -618,12 +619,29 @@ export async function getInviteLinkInfo(token: string): Promise<{ success: boole
 
     const { data, error } = await adminSupabase
       .from('tenant_invite_links')
-      .select('tenant_id, default_role, expires_at, is_active, tenants(name)')
+      .select('tenant_id, default_role, expires_at, is_active, target_user_tenant_id, tenants(name)')
       .eq('token', token)
       .single()
 
     if (error || !data) {
       return { success: false, error: '招待リンクが見つかりません' }
+    }
+
+    let invitedEmail: string | null = null
+    if (data.target_user_tenant_id) {
+      const { data: targetMembership, error: targetMembershipError } = await adminSupabase
+        .from('user_tenants')
+        .select('email')
+        .eq('id', data.target_user_tenant_id)
+        .eq('tenant_id', data.tenant_id)
+        .maybeSingle()
+
+      if (targetMembershipError) {
+        console.error('Error fetching target invite email:', targetMembershipError)
+        return { success: false, error: '招待情報の確認に失敗しました' }
+      }
+
+      invitedEmail = targetMembership?.email ?? null
     }
 
     const isExpired = data.expires_at ? new Date(data.expires_at) < new Date() : false
@@ -637,6 +655,7 @@ export async function getInviteLinkInfo(token: string): Promise<{ success: boole
         tenantId: data.tenant_id,
         tenantName: tenant?.name ?? '不明なテナント',
         defaultRole: data.default_role as 'admin' | 'member' | 'guest',
+        invitedEmail,
         isActive: data.is_active,
         isExpired,
       },

--- a/lib/tenant-invitation-email.test.ts
+++ b/lib/tenant-invitation-email.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+
+import { buildTenantInvitationEmail, buildTenantInviteUrl } from "./tenant-invitation-email"
+
+describe("tenant invitation email", () => {
+  it("builds a reusable app invite URL instead of a Supabase one-time auth link", () => {
+    expect(buildTenantInviteUrl("https://funbase.funtoco.jp", "token-123")).toBe(
+      "https://funbase.funtoco.jp/invite/token-123"
+    )
+  })
+
+  it("includes the reusable invite URL in text and html bodies", () => {
+    const email = buildTenantInvitationEmail({
+      tenantName: "株式会社テスト",
+      inviteUrl: "https://funbase.funtoco.jp/invite/token-123",
+    })
+
+    expect(email.subject).toBe("FunBaseへの招待: 株式会社テスト")
+    expect(email.text).toContain("https://funbase.funtoco.jp/invite/token-123")
+    expect(email.html).toContain("https://funbase.funtoco.jp/invite/token-123")
+  })
+})

--- a/lib/tenant-invitation-email.ts
+++ b/lib/tenant-invitation-email.ts
@@ -1,0 +1,41 @@
+type TenantInvitationEmailInput = {
+  tenantName: string
+  inviteUrl: string
+}
+
+export function buildTenantInviteUrl(baseUrl: string, token: string): string {
+  const normalizedBaseUrl = baseUrl.trim()
+  const url = new URL(`/invite/${encodeURIComponent(token)}`, normalizedBaseUrl)
+  return url.toString()
+}
+
+export function buildTenantInvitationEmail({ tenantName, inviteUrl }: TenantInvitationEmailInput) {
+  const subject = `FunBaseへの招待: ${tenantName}`
+  const text = [
+    `${tenantName} のFunBaseに招待されました。`,
+    "",
+    "以下のリンクから参加してください。",
+    inviteUrl,
+    "",
+    "この招待リンクは参加が完了するまで再度開けます。",
+  ].join("\n")
+
+  const html = `
+    <p>${escapeHtml(tenantName)} のFunBaseに招待されました。</p>
+    <p><a href="${escapeHtml(inviteUrl)}">FunBaseに参加する</a></p>
+    <p>リンクが開けない場合は、以下のURLをブラウザに貼り付けてください。</p>
+    <p>${escapeHtml(inviteUrl)}</p>
+    <p>この招待リンクは参加が完了するまで再度開けます。</p>
+  `
+
+  return { subject, text, html }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+}


### PR DESCRIPTION
## Summary
- メール招待を Supabase Auth の one-time invite ではなく、FunBase 管理の `/invite/{token}` リンク送信に変更
- メール招待リンクを `tenant_invite_links.target_user_tenant_id` で pending membership に紐付け、参加完了までは再オープン可能にしつつ、転送リンクを別ユーザーが受諾できないように制御
- 招待画面を新規登録中心に整理し、メール招待では招待済みメールアドレスを表示のみ（再入力不要）に変更
- 招待メールリンク経由の新規登録だけ、Supabase Auth の追加メール確認をスキップして即時ログイン→参加完了するフローに変更
- 既存アカウントの場合は通常どおりパスワード再設定導線へ誘導
- 別アカウントでログイン中に対象メールの招待リンクを開いた場合は、誤受諾せずログアウトして対象メールでの参加フォームを表示
- 参加完了後は targeted invite link を無効化し、古いメールリンクが再利用されないように制御
- recovery callback の `next=/invite/{token}` を保持し、既存アカウントのパスワード設定後も token-scoped invite acceptance に戻す
- SMTP / link 作成 / office assignment 失敗時の cleanup と、同一 tenant/email の pending 招待重複防止を追加
- Codex review 指摘の supporter fallback / resend `default_role` / office scope / targeted invite token RLS / old-link reactivation edge cases を修正

## Deployment order / dependency
- This app PR requires infra migrations to be applied first:
  - https://github.com/funtoco/fun-base-infra/pull/63（merged: pending invite 基盤）
  - https://github.com/funtoco/fun-base-infra/pull/64（targeted invite token RLS / active membership integrity）
- The migrations make `user_tenants.user_id` nullable for pending email invitations, add `tenant_invite_links.target_user_tenant_id`, hide targeted invite tokens from normal tenant-admin RLS access, restrict client-created targeted invite links, and enforce `user_id` for non-pending memberships.
- If the app is deployed/tested before the migrations are applied, email invite creation or confirmation-skip registration can fail.

## Verification
- `./node_modules/.bin/vitest run lib/supabase/tenant-invitation-acceptance.test.ts lib/auth-next-path.test.ts lib/invite-registration-form.test.ts lib/tenant-invitation-email.test.ts lib/supabase/auth-errors.test.ts` ✅（5 files / 24 tests）
- `git diff --check --cached` ✅
- `./node_modules/.bin/next build` ✅
- `codex review --base origin/main` ✅（最終追加指摘なし）
- `./node_modules/.bin/tsc --noEmit --pretty false` ⚠️ 既存の connector / UI 型エラーで失敗（今回 invite 差分外）

## Related
- Infra migration PRs: https://github.com/funtoco/fun-base-infra/pull/63, https://github.com/funtoco/fun-base-infra/pull/64
