### PR TITLE
面談記録通知の内容を整理

### DIFF
--- a/lib/notifications/interview-record-notification-service.ts
+++ b/lib/notifications/interview-record-notification-service.ts
@@ -131,7 +131,7 @@ export async function notifyInterviewRecordCreated({
       const email = buildInterviewRecordEmail({
         title: createdAnnouncement.title,
         body: createdAnnouncement.body,
-        announcementUrl,
+        actionUrl: announcementUrl,
         settingsUrl,
       })
 
@@ -282,7 +282,11 @@ export async function notifyInterviewRecordsCreatedBatch({
       if (claimedEvents.length === 0) continue
 
       const announcement = buildInterviewRecordBatchAnnouncement({
-        count: claimedEvents.length,
+        records: claimedEvents.map(({ record }) => ({
+          personName: record.person_name,
+          companyName: record.company_name,
+          interviewDate: record.interview_date,
+        })),
         appBaseUrl,
       })
 
@@ -315,12 +319,11 @@ export async function notifyInterviewRecordsCreatedBatch({
         if (recipientInsertError) throw recipientInsertError
 
         if (group.emailRecipients.length > 0) {
-          const announcementUrl = `${appBaseUrl}/announcements?id=${encodeURIComponent(createdAnnouncement.id)}`
           const settingsUrl = `${appBaseUrl}/settings/notifications`
           const email = buildInterviewRecordEmail({
             title: createdAnnouncement.title,
-            body: createdAnnouncement.body,
-            announcementUrl,
+            body: announcement.emailBody,
+            actionUrl: announcement.actionUrl,
             settingsUrl,
           })
 

--- a/lib/notifications/interview-record-notifications.test.ts
+++ b/lib/notifications/interview-record-notifications.test.ts
@@ -84,29 +84,60 @@ describe('interview record notifications', () => {
     expect(announcement.body).toContain('https://funbase.example.com/interview-records/record-1')
   })
 
-  test('builds a single batch announcement for multiple interview records', () => {
+  test('builds a concise notification with the person for a single interview record', () => {
     const announcement = buildInterviewRecordBatchAnnouncement({
-      count: 12,
+      records: [{
+        personName: '山田 太郎',
+        companyName: '株式会社サンプル',
+        interviewDate: '2026-07-15',
+      }],
       appBaseUrl: 'https://funbase.example.com/',
     })
 
-    expect(announcement.title).toBe('新しい面談記録が12件追加されました')
-    expect(announcement.body).toContain('新しい面談記録が12件FunBaseに追加されました。')
-    expect(announcement.body).toContain('面談一覧: https://funbase.example.com/meetings')
+    expect(announcement.title).toBe('面談記録の追加（1件）')
+    expect(announcement.emailBody).toBe([
+      '対象者：山田 太郎',
+      '面談日：2026年7月15日',
+      '法人：株式会社サンプル',
+    ].join('\n'))
+    expect(announcement.body).toContain('面談一覧：https://funbase.example.com/meetings')
+    expect(announcement.emailBody).not.toContain('新しい面談記録')
+    expect(announcement.emailBody).not.toContain('https://')
     expect(announcement.body).not.toContain('interview-records/')
+  })
+
+  test('lists every person for a multi-record notification', () => {
+    const announcement = buildInterviewRecordBatchAnnouncement({
+      records: Array.from({ length: 7 }, (_, index) => ({
+        personName: `対象者 ${index + 1}`,
+        companyName: '株式会社サンプル',
+        interviewDate: `2026-07-${String(index + 1).padStart(2, '0')}`,
+      })),
+      appBaseUrl: 'https://funbase.example.com',
+    })
+
+    expect(announcement.title).toBe('面談記録の追加（7件）')
+    expect(announcement.emailBody).toContain('・対象者 1（2026年7月1日・株式会社サンプル）')
+    expect(announcement.emailBody).toContain('・対象者 5（2026年7月5日・株式会社サンプル）')
+    expect(announcement.emailBody).toContain('・対象者 6（2026年7月6日・株式会社サンプル）')
+    expect(announcement.emailBody).toContain('・対象者 7（2026年7月7日・株式会社サンプル）')
+    expect(announcement.emailBody).not.toContain('ほか')
   })
 
   test('builds email body with notification settings link', () => {
     const email = buildInterviewRecordEmail({
-      title: '新しい面談記録が追加されました',
-      body: '本文',
-      announcementUrl: 'https://funbase.example.com/announcements?id=announcement-1',
+      title: '面談記録の追加（1件）',
+      body: '対象者：山田 太郎\n面談日：2026年7月15日',
+      actionUrl: 'https://funbase.example.com/meetings',
       settingsUrl: 'https://funbase.example.com/settings/notifications',
     })
 
-    expect(email.subject).toBe('【FunBase】新しい面談記録が追加されました')
-    expect(email.text).toContain('https://funbase.example.com/announcements?id=announcement-1')
-    expect(email.text).toContain('通知設定: https://funbase.example.com/settings/notifications')
+    expect(email.subject).toBe('【FunBase】面談記録の追加（1件）')
+    expect(email.text).toContain('対象者：山田 太郎')
+    expect(email.text).toContain('面談記録を確認する：https://funbase.example.com/meetings')
+    expect(email.text).toContain('通知設定：https://funbase.example.com/settings/notifications')
+    expect(email.html).toContain('対象者：山田 太郎')
+    expect(email.html).toContain('background: #2563eb')
     expect(email.html).toContain('通知設定')
   })
 })

--- a/lib/notifications/interview-record-notifications.ts
+++ b/lib/notifications/interview-record-notifications.ts
@@ -32,14 +32,19 @@ export type InterviewRecordAnnouncementInput = {
 }
 
 export type InterviewRecordBatchAnnouncementInput = {
-  count: number
+  records: Array<{
+    personName?: string | null
+    companyName?: string | null
+    interviewDate?: string | null
+  }>
   appBaseUrl: string
 }
 
 export type InterviewRecordEmailInput = {
   title: string
   body: string
-  announcementUrl: string
+  actionUrl: string
+  actionLabel?: string
   settingsUrl: string
 }
 
@@ -131,30 +136,43 @@ export function buildInterviewRecordAnnouncement({
 }
 
 export function buildInterviewRecordBatchAnnouncement({
-  count,
+  records,
   appBaseUrl,
-}: InterviewRecordBatchAnnouncementInput): { title: string; body: string } {
+}: InterviewRecordBatchAnnouncementInput): {
+  title: string
+  body: string
+  emailBody: string
+  actionUrl: string
+} {
+  if (records.length === 0) {
+    throw new Error('At least one interview record is required')
+  }
+
+  const count = records.length
   const listUrl = `${trimTrailingSlash(appBaseUrl)}/meetings`
-  const lines = [
-    `新しい面談記録が${count}件FunBaseに追加されました。`,
-    '',
-    `面談一覧: ${listUrl}`,
-  ]
+  const summaryLines = count === 1
+    ? buildSingleRecordSummary(records[0])
+    : buildMultipleRecordSummary(records)
+  const emailBody = summaryLines.join('\n')
 
   return {
-    title: `新しい面談記録が${count}件追加されました`,
-    body: lines.join('\n'),
+    title: `面談記録の追加（${count}件）`,
+    body: `${emailBody}\n\n面談一覧：${listUrl}`,
+    emailBody,
+    actionUrl: listUrl,
   }
 }
 
 export function buildInterviewRecordEmail({
   title,
   body,
-  announcementUrl,
+  actionUrl,
+  actionLabel = '面談記録を確認する',
   settingsUrl,
 }: InterviewRecordEmailInput): { subject: string; text: string; html: string } {
   const safeTitle = escapeHtml(title)
-  const bodyText = `${body}\n\nFunBaseで確認: ${announcementUrl}\n通知設定: ${settingsUrl}`
+  const safeActionLabel = escapeHtml(actionLabel)
+  const bodyText = `${body}\n\n${actionLabel}：${actionUrl}\n通知設定：${settingsUrl}`
   const htmlBody = body
     .split('\n')
     .map((line) => escapeHtml(line))
@@ -168,7 +186,7 @@ export function buildInterviewRecordEmail({
         <h2 style="font-size: 18px; margin: 0 0 16px;">${safeTitle}</h2>
         <p>${htmlBody}</p>
         <p style="margin-top: 24px;">
-          <a href="${escapeAttribute(announcementUrl)}" style="color: #2563eb;">FunBaseで確認する</a>
+          <a href="${escapeAttribute(actionUrl)}" style="display: inline-block; padding: 10px 16px; border-radius: 6px; background: #2563eb; color: #ffffff; text-decoration: none;">${safeActionLabel}</a>
         </p>
         <p style="font-size: 12px; color: #6b7280; margin-top: 24px;">
           このメールはFunBaseの面談通知設定に基づいて送信されています。<br />
@@ -177,6 +195,40 @@ export function buildInterviewRecordEmail({
       </div>
     `.trim(),
   }
+}
+
+function buildSingleRecordSummary(record: InterviewRecordBatchAnnouncementInput['records'][number]): string[] {
+  return [
+    `対象者：${displayValue(record.personName, '対象者名未登録')}`,
+    record.interviewDate ? `面談日：${formatInterviewDate(record.interviewDate)}` : null,
+    record.companyName ? `法人：${record.companyName}` : null,
+  ].filter((line): line is string => line !== null)
+}
+
+function buildMultipleRecordSummary(records: InterviewRecordBatchAnnouncementInput['records']): string[] {
+  return [
+    '対象者：',
+    ...records.map((record) => {
+      const details = [
+        record.interviewDate ? formatInterviewDate(record.interviewDate) : null,
+        record.companyName || null,
+      ].filter((detail): detail is string => detail !== null)
+      const suffix = details.length > 0 ? `（${details.join('・')}）` : ''
+      return `・${displayValue(record.personName, '対象者名未登録')}${suffix}`
+    }),
+  ]
+}
+
+function displayValue(value: string | null | undefined, fallback: string): string {
+  const trimmed = value?.trim()
+  return trimmed || fallback
+}
+
+function formatInterviewDate(value: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match) return value
+
+  return `${Number(match[1])}年${Number(match[2])}月${Number(match[3])}日`
 }
 
 function trimTrailingSlash(value: string): string {

--- a/lib/sync/kintone-sync.ts
+++ b/lib/sync/kintone-sync.ts
@@ -1255,6 +1255,7 @@ export class KintoneDataSync {
                 interviewRecord: {
                   id: upsertedRecord.id,
                   person_id: personId,
+                  person_name: await this.getPersonNameForInterviewNotification(personId),
                   company_name: payload.company_name,
                   interview_date: payload.interview_date,
                   record_type: payload.record_type,


### PR DESCRIPTION
## 変更内容

- 面談記録通知の重複した案内文を整理
- 通知本文に対象者名・面談日・法人を表示
- 複数件の場合も対象者を省略せず全件表示
- 担当者の表示を除外
- 面談一覧へのリンクをボタン化

## 背景

従来のメールは件名と本文で同じ内容が繰り返され、どの対象者の面談記録なのかがメール上で分かりませんでした。

## 影響

メールを開いた時点で対象者と面談情報を確認でき、一覧へ直接移動できます。アプリ内通知にも同じ要約を表示します。

## 確認

- `vitest run lib/notifications/interview-record-notifications.test.ts`（7件成功）
- 変更ファイルにTypeScriptエラーがないことを確認
- `git diff --check` 成功