### PR TITLE
fix: hide internal tenant members

### DIFF
--- a/components/tenant/tenant-members-page.tsx
+++ b/components/tenant/tenant-members-page.tsx
@@ -15,6 +15,7 @@ import { MemberOfficesDialog } from "./member-offices-dialog"
 import { ConfirmDialog } from "./confirm-dialog"
 import { EmptyState } from "./empty-state"
 import { 
+  getCurrentUserTenants,
   getTenantMembers, 
   getTenantOffices,
   resendTenantInvitation,
@@ -39,6 +40,7 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
   const { user } = useAuth()
   const { toast } = useToast()
   const [members, setMembers] = useState<UserTenant[]>([])
+  const [currentUserTenants, setCurrentUserTenants] = useState<UserTenant[]>([])
   const [offices, setOffices] = useState<TenantOffice[]>([])
   const [searchQuery, setSearchQuery] = useState("")
   const [selectedMembers, setSelectedMembers] = useState<string[]>([])
@@ -70,12 +72,14 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
   const fetchData = useCallback(async () => {
     try {
       setLoading(true)
-      const [membersData, officesData] = await Promise.all([
+      const [membersData, officesData, currentUserTenantsData] = await Promise.all([
         getTenantMembers(tenantId),
         getTenantOffices(tenantId),
+        getCurrentUserTenants(),
       ])
       setMembers(membersData)
       setOffices(officesData)
+      setCurrentUserTenants(currentUserTenantsData)
     } catch (error) {
       console.error('Error fetching data:', error)
     } finally {
@@ -88,7 +92,9 @@ export function TenantMembersPage({ tenantId }: TenantMembersPageProps) {
   }, [fetchData])
 
   // Get current user's role in this tenant
-  const currentUserMember = members.find(m => m.user_id === user?.id)
+  const currentUserMember =
+    currentUserTenants.find((membership) => membership.tenant_id === tenantId)
+    || members.find(m => m.user_id === user?.id)
   const currentUserRole =
     currentUserMember?.role && currentUserMember.role !== 'supporter'
       ? currentUserMember.role

--- a/lib/supabase/tenants.ts
+++ b/lib/supabase/tenants.ts
@@ -1,5 +1,8 @@
 import { createClient, createAdminClient } from './client'
-import type { TenantFeaturePermissions } from '@/lib/tenant-access'
+import {
+  isVisibleCompanyTenantMember,
+  type TenantFeaturePermissions,
+} from '@/lib/tenant-access'
 
 export interface Tenant {
   id: string
@@ -157,7 +160,15 @@ export async function getTenantMembers(tenantId: string): Promise<UserTenant[]> 
     return []
   }
 
-  const memberIds = members.map((member: UserTenant) => member.id)
+  const visibleMembers = members.filter((member: UserTenant) =>
+    isVisibleCompanyTenantMember(member)
+  )
+
+  if (visibleMembers.length === 0) {
+    return []
+  }
+
+  const memberIds = visibleMembers.map((member: UserTenant) => member.id)
 
   const { data: assignments, error: assignmentsError } = await supabase
     .from('user_tenant_offices')
@@ -200,7 +211,7 @@ export async function getTenantMembers(tenantId: string): Promise<UserTenant[]> 
     officeIdsByMemberId.set(assignment.user_tenant_id, currentOfficeIds)
   }
 
-  return members.map((member: UserTenant) => ({
+  return visibleMembers.map((member: UserTenant) => ({
     ...member,
     offices: (officeIdsByMemberId.get(member.id) || [])
       .map((officeId) => officesById.get(officeId))

--- a/lib/tenant-access.test.ts
+++ b/lib/tenant-access.test.ts
@@ -6,6 +6,7 @@ import {
   isCompanyContactEmail,
   isCompanyContactRole,
   isInternalStaffEmail,
+  isVisibleCompanyTenantMember,
   normalizeTenantFeaturePermissions,
 } from "./tenant-access"
 
@@ -46,6 +47,14 @@ describe("tenant access", () => {
     expect(isCompanyContactRole("guest")).toBe(true)
     expect(isCompanyContactRole("admin")).toBe(false)
     expect(isCompanyContactRole("supporter")).toBe(false)
+  })
+
+  test("company tenant member visibility hides internal and email-less rows", () => {
+    expect(isVisibleCompanyTenantMember({ email: "contact@example.com" })).toBe(true)
+    expect(isVisibleCompanyTenantMember({ email: " ", user: { email: "contact@example.com" } })).toBe(true)
+    expect(isVisibleCompanyTenantMember({ email: "staff@funtoco.jp" })).toBe(false)
+    expect(isVisibleCompanyTenantMember({ user: { email: "staff@funtoco.jp" } })).toBe(false)
+    expect(isVisibleCompanyTenantMember({ email: null })).toBe(false)
   })
 
   test("feature permissions default to allowed for backward compatibility", () => {

--- a/lib/tenant-access.ts
+++ b/lib/tenant-access.ts
@@ -129,6 +129,21 @@ export function isCompanyContactEmail(email?: string | null): boolean {
   return normalizedEmail !== null && !isInternalStaffEmail(normalizedEmail)
 }
 
+export function isVisibleCompanyTenantMember(input: {
+  email?: string | null
+  user?: { email?: string | null } | null
+}): boolean {
+  const email =
+    normalizeEmailForClassification(input.email)
+    ?? normalizeEmailForClassification(input.user?.email)
+
+  if (!email) {
+    return false
+  }
+
+  return !isInternalStaffEmail(email)
+}
+
 export function isCompanyContactRole(role: TenantAccessRole | null): boolean {
   return role === "member" || role === "guest"
 }


### PR DESCRIPTION
## Summary
- Hide `@funtoco.jp` and email-less rows from the FunBase tenant member list shown to company-side users
- Preserve the signed-in user's own tenant membership separately so management controls do not disappear when the viewer is an internal Funtoco account
- Add regression coverage for internal/email-less member visibility classification

## Verification
- `./node_modules/.bin/vitest run lib/tenant-access.test.ts` ✅
- `./node_modules/.bin/next build` ✅ (completed with existing warnings about route config / Edge runtime / browserslist)
- `./node_modules/.bin/tsc --noEmit --pretty false` ⚠️ blocked by existing connector/tenant-management type errors unrelated to this change
- `codex review --base origin/main` ✅ no actionable regressions

## Notes
- `pnpm install --frozen-lockfile` installed dependencies but exited with `[ERR_PNPM_IGNORED_BUILDS]`; local binaries were still usable for verification.
