### PR TITLE
ci: run interview record sync after 9am JST

### DIFF
--- a/.github/workflows/cron-sync.yml
+++ b/.github/workflows/cron-sync.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 2 * * *'
     - cron: '0 3 * * *'
-    - cron: '0 19 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       sync_type:
@@ -119,7 +119,7 @@ jobs:
           pnpm dlx tsx@4.20.3 scripts/sync-by-type.ts --type visas
 
   sync-interview-records:
-    if: github.event_name == 'schedule' && github.event.schedule == '0 19 * * *' || github.event_name == 'workflow_dispatch' && github.event.inputs.sync_type == 'interview_records'
+    if: github.event_name == 'schedule' && github.event.schedule == '0 0 * * *' || github.event_name == 'workflow_dispatch' && github.event.inputs.sync_type == 'interview_records'
     runs-on: ubuntu-latest
     timeout-minutes: 360
     environment: Production
@@ -184,7 +184,7 @@ jobs:
           }
 
           if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
-            # 04:00 JST daily: small newest-record window, one connector at a time.
+            # 09:00 JST daily: small newest-record window, one connector at a time.
             cmd+=(--all-batches --limit 1 --record-id-tail-size 2000)
           else
             cmd+=(--all-batches)


### PR DESCRIPTION
## 概要
面談記録同期の定期実行を 04:00 JST から 09:00 JST に変更します。

## 元 Slack
このSlackスレッド

## 分類
ci / high confidence

## 変更点
- GitHub Actions の interview_records schedule を `0 19 * * *`（04:00 JST）から `0 0 * * *`（09:00 JST）へ変更
- scheduled event の job 条件も同じ cron に更新
- コメントを `09:00 JST daily` に更新

## テスト
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/cron-sync.yml'); puts 'yaml ok'"` ✅
- `codex review --base origin/main` ✅（指摘なし）

## リスク / ロールバック
- `.github/workflows` のみの変更です。必要なら cron を `0 19 * * *` に戻せば即ロールバックできます。
- GitHub Actions の schedule は UTC 指定のため、`0 0 * * *` = JST 09:00 です。
