### PR TITLE
fix: align FunBase password minimum length copy

### DIFF
--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -33,9 +33,9 @@ export async function POST(request: NextRequest) {
     }
 
     // パスワードの強度チェック
-    if (password.length < 6) {
+    if (password.length < 8) {
       return NextResponse.json(
-        { error: "Password must be at least 6 characters" },
+        { error: "Password must be at least 8 characters" },
         { status: 400 }
       )
     }

--- a/app/api/invite/[token]/register/route.ts
+++ b/app/api/invite/[token]/register/route.ts
@@ -3,6 +3,33 @@ import { createAdminClient } from "@/lib/supabase/client"
 import { isExistingAccountSignUpError } from "@/lib/supabase/auth-errors"
 import { getInviteLinkInfo } from "@/lib/supabase/tenants"
 
+async function authUserExistsByEmail(
+  adminSupabase: ReturnType<typeof createAdminClient>,
+  email: string
+): Promise<boolean> {
+  const targetEmail = email.trim().toLowerCase()
+  let page = 1
+  const perPage = 1000
+
+  while (true) {
+    const { data, error } = await adminSupabase.auth.admin.listUsers({ page, perPage })
+
+    if (error) {
+      throw error
+    }
+
+    if (data.users.some((user) => user.email?.trim().toLowerCase() === targetEmail)) {
+      return true
+    }
+
+    if (!data.nextPage) {
+      return false
+    }
+
+    page = data.nextPage
+  }
+}
+
 export async function POST(
   request: NextRequest,
   { params }: { params: { token: string } }
@@ -35,11 +62,17 @@ export async function POST(
       return NextResponse.json({ error: "招待されたメールアドレスで登録してください" }, { status: 400 })
     }
 
-    if (password.length < 6) {
-      return NextResponse.json({ error: "パスワードは6文字以上で入力してください" }, { status: 400 })
+    const adminSupabase = createAdminClient()
+    const userExists = await authUserExistsByEmail(adminSupabase, email)
+
+    if (userExists) {
+      return NextResponse.json({ error: "Account already exists" }, { status: 409 })
     }
 
-    const adminSupabase = createAdminClient()
+    if (password.length < 8) {
+      return NextResponse.json({ error: "パスワードは8文字以上で入力してください" }, { status: 400 })
+    }
+
     const { error: createUserError } = await adminSupabase.auth.admin.createUser({
       email,
       password,

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -138,7 +138,9 @@ export default function InviteAcceptancePage() {
       return
     }
 
-    const passwordError = validateInviteRegistrationPasswords(password, passwordConfirmation)
+    const passwordError = validateInviteRegistrationPasswords(password, passwordConfirmation, {
+      enforceMinimumLength: false,
+    })
     if (passwordError) {
       setAuthError(passwordError)
       setAuthLoading(false)
@@ -200,6 +202,12 @@ export default function InviteAcceptancePage() {
         }
 
         await acceptInvite()
+        return
+      }
+
+      const newPasswordError = validateInviteRegistrationPasswords(password, passwordConfirmation)
+      if (newPasswordError) {
+        setAuthError(newPasswordError)
         return
       }
 
@@ -403,9 +411,8 @@ export default function InviteAcceptancePage() {
                 onChange={(e) => setPassword(e.target.value)}
                 required
                 disabled={authLoading}
-                minLength={6}
               />
-              <p className="text-xs text-muted-foreground">6文字以上で入力してください</p>
+              <p className="text-xs text-muted-foreground">8文字以上で入力してください</p>
             </div>
 
             <div className="space-y-2">
@@ -417,7 +424,6 @@ export default function InviteAcceptancePage() {
                 onChange={(e) => setPasswordConfirmation(e.target.value)}
                 required
                 disabled={authLoading}
-                minLength={6}
               />
             </div>
 

--- a/components/tenant/create-user-dialog.tsx
+++ b/components/tenant/create-user-dialog.tsx
@@ -52,8 +52,8 @@ export function CreateUserDialog({
 
     if (!password) {
       newErrors.password = "パスワードを入力してください"
-    } else if (password.length < 6) {
-      newErrors.password = "パスワードは6文字以上で入力してください"
+    } else if (password.length < 8) {
+      newErrors.password = "パスワードは8文字以上で入力してください"
     }
 
     if (!confirmPassword) {
@@ -159,7 +159,7 @@ export function CreateUserDialog({
                   type={showPassword ? "text" : "password"}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  placeholder="6文字以上"
+                  placeholder="8文字以上"
                 />
                 <Button
                   type="button"

--- a/lib/invite-registration-form.test.ts
+++ b/lib/invite-registration-form.test.ts
@@ -20,15 +20,21 @@ describe("isLikelyExistingAccountSignUpResponse", () => {
 })
 
 describe("validateInviteRegistrationPasswords", () => {
-  it("requires the password to be at least 6 characters", () => {
-    expect(validateInviteRegistrationPasswords("abcde", "abcde")).toBe("パスワードは6文字以上で入力してください")
+  it("requires the password to be at least 8 characters", () => {
+    expect(validateInviteRegistrationPasswords("abcdefg", "abcdefg")).toBe("パスワードは8文字以上で入力してください")
   })
 
   it("requires the confirmation password to match", () => {
-    expect(validateInviteRegistrationPasswords("abcdef", "abcdeg")).toBe("パスワードが一致しません")
+    expect(validateInviteRegistrationPasswords("abcdefgh", "abcdefgi")).toBe("パスワードが一致しません")
   })
 
-  it("accepts matching passwords with at least 6 characters", () => {
-    expect(validateInviteRegistrationPasswords("abcdef", "abcdef")).toBeNull()
+  it("can skip the minimum length check for existing-account sign in", () => {
+    expect(
+      validateInviteRegistrationPasswords("abcdef", "abcdef", { enforceMinimumLength: false })
+    ).toBeNull()
+  })
+
+  it("accepts matching passwords with at least 8 characters", () => {
+    expect(validateInviteRegistrationPasswords("abcdefgh", "abcdefgh")).toBeNull()
   })
 })

--- a/lib/invite-registration-form.ts
+++ b/lib/invite-registration-form.ts
@@ -9,10 +9,13 @@ export function isLikelyExistingAccountSignUpResponse(user: SignUpUserLike | nul
 
 export function validateInviteRegistrationPasswords(
   password: string,
-  passwordConfirmation: string
+  passwordConfirmation: string,
+  options: { enforceMinimumLength?: boolean } = {}
 ): string | null {
-  if (password.length < 6) {
-    return "パスワードは6文字以上で入力してください"
+  const enforceMinimumLength = options.enforceMinimumLength ?? true
+
+  if (enforceMinimumLength && password.length < 8) {
+    return "パスワードは8文字以上で入力してください"
   }
 
   if (password !== passwordConfirmation) {

--- a/lib/supabase/auth-errors.test.ts
+++ b/lib/supabase/auth-errors.test.ts
@@ -9,7 +9,7 @@ describe("isExistingAccountSignUpError", () => {
   })
 
   it("does not treat unrelated sign-up errors as existing accounts", () => {
-    expect(isExistingAccountSignUpError("Password should be at least 6 characters"))
+    expect(isExistingAccountSignUpError("Password should be at least 8 characters"))
       .toBe(false)
   })
 })


### PR DESCRIPTION
## 概要
- 招待/ユーザー作成まわりに残っていた「6文字以上」表記とバリデーションを「8文字以上」に統一
- 招待リンク画面では、既存アカウントの6〜7文字パスワードでのログインは従来通り試せるようにし、新規作成時だけ8文字以上を必須化
- 既存アカウント判定はSupabase Authのページングを最後まで確認し、既存ユーザーにはパスワード再設定導線を返すよう調整

## 元 Slack
FunBaseのパスワード設定で、テナント管理「再送」URLだけ「6文字以上」と表示される件

## 分類
bugfix / high

## 変更点
- `/invite/[token]` の表示・新規登録バリデーションを8文字以上へ変更
- `/api/invite/[token]/register` と `/api/admin/users` のサーバー側チェックを8文字以上へ変更
- 管理画面のユーザー作成ダイアログの表示・チェックを8文字以上へ変更
- 関連Vitestを更新

## テスト
- `./node_modules/.bin/vitest run lib/invite-registration-form.test.ts lib/supabase/auth-errors.test.ts` ✅
- `./node_modules/.bin/next build` ✅（既存の dynamic server usage / connector config warning は出るが exit 0）
- `codex review --base origin/main` ✅ no actionable regressions

## リスク / ロールバック
- 低リスク。文言/バリデーション統一が中心。
- 既存アカウントの短いパスワードログインを壊さないよう、招待画面ではログイン試行後に新規作成用の8文字チェックを行う。
