### PR TITLE
feat(portal) フェーズ2: 申請ポータル画面・案件作成・チェックリスト・アップロード/レビュー/コメント

### DIFF
--- a/__tests__/portal-create-case-validation.test.ts
+++ b/__tests__/portal-create-case-validation.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { validateNewCase } from '@/lib/portal/case-validation'
+
+const OFFICE = '11111111-1111-1111-1111-111111111111'
+
+const validInput = {
+  tenant_office_id: OFFICE,
+  entity_type: 'corporate',
+  application_category: 'initial',
+  field: 'care',
+}
+
+describe('validateNewCase', () => {
+  it('正常入力は ok:true と正規化した値を返す', () => {
+    const result = validateNewCase(validInput)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value).toEqual({
+        tenant_office_id: OFFICE,
+        entity_type: 'corporate',
+        application_category: 'initial',
+        field: 'care',
+        management_number: null,
+        title: null,
+      })
+    }
+  })
+
+  it('任意項目（管理番号・タイトル）を trim して保持する', () => {
+    const result = validateNewCase({
+      ...validInput,
+      management_number: '  A-100 ',
+      title: '  近江舞子 初回  ',
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.management_number).toBe('A-100')
+      expect(result.value.title).toBe('近江舞子 初回')
+    }
+  })
+
+  it('tenant_office_id が欠落するとエラー', () => {
+    expect(validateNewCase({ ...validInput, tenant_office_id: '' })).toEqual({
+      ok: false,
+      error: 'tenant_office_id is required',
+    })
+    expect(validateNewCase({ ...validInput, tenant_office_id: undefined })).toEqual({
+      ok: false,
+      error: 'tenant_office_id is required',
+    })
+  })
+
+  it('entity_type が欠落・enum外だとエラー', () => {
+    expect(validateNewCase({ ...validInput, entity_type: undefined })).toEqual({
+      ok: false,
+      error: 'entity_type is required',
+    })
+    expect(validateNewCase({ ...validInput, entity_type: 'ngo' })).toEqual({
+      ok: false,
+      error: 'invalid entity_type',
+    })
+  })
+
+  it('application_category が欠落・enum外だとエラー', () => {
+    expect(validateNewCase({ ...validInput, application_category: undefined })).toEqual({
+      ok: false,
+      error: 'application_category is required',
+    })
+    expect(validateNewCase({ ...validInput, application_category: 'switch' })).toEqual({
+      ok: false,
+      error: 'invalid application_category',
+    })
+  })
+
+  it('field が欠落・enum外だとエラー', () => {
+    expect(validateNewCase({ ...validInput, field: undefined })).toEqual({
+      ok: false,
+      error: 'field is required',
+    })
+    expect(validateNewCase({ ...validInput, field: 'construction' })).toEqual({
+      ok: false,
+      error: 'invalid field',
+    })
+  })
+
+  it('入力自体が無いとエラー', () => {
+    expect(validateNewCase(null)).toEqual({ ok: false, error: 'input is required' })
+    expect(validateNewCase(undefined)).toEqual({ ok: false, error: 'input is required' })
+  })
+
+  it('renewal / sole_proprietor / 他分野 も許容', () => {
+    const result = validateNewCase({
+      tenant_office_id: OFFICE,
+      entity_type: 'sole_proprietor',
+      application_category: 'renewal',
+      field: 'food_manufacturing',
+    })
+    expect(result.ok).toBe(true)
+  })
+})

--- a/__tests__/portal-materialize.test.ts
+++ b/__tests__/portal-materialize.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { groupRequirements, type MemberNameRef } from '@/lib/portal/requirements'
+import type { CaseDocumentRequirement } from '@/lib/portal/types'
+
+function req(
+  overrides: Partial<CaseDocumentRequirement> & Pick<CaseDocumentRequirement, 'id' | 'documentCode' | 'scope' | 'sortOrder'>
+): CaseDocumentRequirement {
+  return {
+    caseId: 'case-1',
+    name: overrides.documentCode,
+    personId: null,
+    isRequired: true,
+    copyType: 'copy',
+    issuer: null,
+    validityMonths: null,
+    status: 'not_submitted',
+    ...overrides,
+  }
+}
+
+describe('groupRequirements', () => {
+  it('office 行を sort_order 昇順で返し、person が無ければ persons は空', () => {
+    const rows = [
+      req({ id: '2', documentCode: 'tax_payment_cert', scope: 'office', sortOrder: 20 }),
+      req({ id: '1', documentCode: 'company_registry', scope: 'office', sortOrder: 10 }),
+    ]
+    const result = groupRequirements(rows)
+    expect(result.office.map((r) => r.documentCode)).toEqual([
+      'company_registry',
+      'tax_payment_cert',
+    ])
+    expect(result.persons).toEqual([])
+  })
+
+  it('person 行を person_id ごとにまとめ、各グループ内は sort_order 昇順', () => {
+    const rows = [
+      req({ id: 'o1', documentCode: 'company_registry', scope: 'office', sortOrder: 10 }),
+      req({ id: 'p1b', documentCode: 'passport_copy', scope: 'person', personId: 'person-A', sortOrder: 120 }),
+      req({ id: 'p1a', documentCode: 'residence_card', scope: 'person', personId: 'person-A', sortOrder: 110 }),
+      req({ id: 'p2a', documentCode: 'residence_card', scope: 'person', personId: 'person-B', sortOrder: 110 }),
+    ]
+    const members: MemberNameRef[] = [
+      { personId: 'person-A', personName: 'アウン' },
+      { personId: 'person-B', personName: 'ディーパ' },
+    ]
+    const result = groupRequirements(rows, members)
+
+    expect(result.office).toHaveLength(1)
+    expect(result.persons).toHaveLength(2)
+
+    const groupA = result.persons[0]
+    expect(groupA.personId).toBe('person-A')
+    expect(groupA.personName).toBe('アウン')
+    expect(groupA.items.map((r) => r.documentCode)).toEqual([
+      'residence_card',
+      'passport_copy',
+    ])
+
+    const groupB = result.persons[1]
+    expect(groupB.personName).toBe('ディーパ')
+    expect(groupB.items).toHaveLength(1)
+  })
+
+  it('members の並び順を尊重し、書類行がまだ無いメンバーも空グループで表示', () => {
+    const rows = [
+      req({ id: 'p1', documentCode: 'residence_card', scope: 'person', personId: 'person-A', sortOrder: 110 }),
+    ]
+    const members: MemberNameRef[] = [
+      { personId: 'person-A', personName: 'アウン' },
+      { personId: 'person-B', personName: 'ディーパ' },
+    ]
+    const result = groupRequirements(rows, members)
+    expect(result.persons.map((p) => p.personId)).toEqual(['person-A', 'person-B'])
+    expect(result.persons[1].items).toEqual([])
+  })
+
+  it('members に含まれない person_id の行は末尾に追加（名前は null）', () => {
+    const rows = [
+      req({ id: 'p1', documentCode: 'residence_card', scope: 'person', personId: 'person-A', sortOrder: 110 }),
+      req({ id: 'p2', documentCode: 'residence_card', scope: 'person', personId: 'person-Z', sortOrder: 110 }),
+    ]
+    const members: MemberNameRef[] = [{ personId: 'person-A', personName: 'アウン' }]
+    const result = groupRequirements(rows, members)
+    expect(result.persons.map((p) => p.personId)).toEqual(['person-A', 'person-Z'])
+    expect(result.persons[1].personName).toBeNull()
+  })
+})

--- a/__tests__/portal-materialize.test.ts
+++ b/__tests__/portal-materialize.test.ts
@@ -14,6 +14,9 @@ function req(
     issuer: null,
     validityMonths: null,
     status: 'not_submitted',
+    rejectionReason: null,
+    officeDocumentId: null,
+    personDocumentId: null,
     ...overrides,
   }
 }

--- a/app/api/applications/[caseId]/comments/route.ts
+++ b/app/api/applications/[caseId]/comments/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { addComment, listComments } from '@/lib/portal/comments'
+
+// GET /api/applications/[caseId]/comments — コメント一覧（古い順、RLSでoffice境界に絞る）
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { caseId: string } }
+) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const comments = await listComments(params.caseId)
+    return NextResponse.json({ comments })
+  } catch (error) {
+    console.error('Error listing comments:', error)
+    return NextResponse.json({ error: 'コメントの取得に失敗しました' }, { status: 500 })
+  }
+}
+
+// POST /api/applications/[caseId]/comments — コメント投稿
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { caseId: string } }
+) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await request.json().catch(() => null)
+    const text = typeof body?.body === 'string' ? body.body : ''
+    const requirementId =
+      typeof body?.requirementId === 'string' ? body.requirementId : null
+
+    const result = await addComment({
+      caseId: params.caseId,
+      body: text,
+      requirementId,
+    })
+
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status })
+    }
+
+    return NextResponse.json({ success: true, comment: result.data }, { status: 201 })
+  } catch (error) {
+    console.error('Error posting comment:', error)
+    return NextResponse.json({ error: 'コメントの投稿に失敗しました' }, { status: 500 })
+  }
+}

--- a/app/api/applications/[caseId]/members/route.ts
+++ b/app/api/applications/[caseId]/members/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { addMember, getCase, getRequirements } from '@/lib/portal/applications'
+
+// POST /api/applications/[caseId]/members — 人材追加 → materialize 再実行 → 更新後の要件を返す
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { caseId: string } }
+) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await request.json().catch(() => null)
+    const personId =
+      body && typeof body.person_id === 'string' ? body.person_id.trim() : ''
+    const visaId =
+      body && typeof body.visa_id === 'string' && body.visa_id.trim()
+        ? body.visa_id.trim()
+        : null
+
+    if (!personId) {
+      return NextResponse.json({ error: 'person_id is required' }, { status: 400 })
+    }
+
+    try {
+      await addMember(params.caseId, personId, visaId)
+    } catch (error) {
+      const code = (error as { code?: string })?.code
+      if (code === '42501') {
+        return NextResponse.json(
+          { error: 'この案件に人材を追加する権限がありません' },
+          { status: 403 }
+        )
+      }
+      const message = error instanceof Error ? error.message : ''
+      if (message.includes('not found or not accessible')) {
+        return NextResponse.json({ error: 'Not found' }, { status: 404 })
+      }
+      // 外部キー違反（people 未存在/越境）などは 400
+      if (code === '23503') {
+        return NextResponse.json(
+          { error: '指定した人材を追加できません' },
+          { status: 400 }
+        )
+      }
+      console.error('Error adding member:', error)
+      return NextResponse.json({ error: 'Failed to add member' }, { status: 500 })
+    }
+
+    const detail = await getCase(params.caseId)
+    const requirements = await getRequirements(params.caseId)
+    return NextResponse.json({ case: detail, requirements }, { status: 201 })
+  } catch (error) {
+    console.error('Error adding member:', error)
+    return NextResponse.json({ error: 'Failed to add member' }, { status: 500 })
+  }
+}

--- a/app/api/applications/[caseId]/remind/route.ts
+++ b/app/api/applications/[caseId]/remind/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { remindCase } from '@/lib/portal/documents'
+
+// POST /api/applications/[caseId]/remind — リマインドを記録（writerのみ）。
+// メール送信は未実装（nodemailer 未導入）。将来ここから通知を送る。
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: { caseId: string } }
+) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const result = await remindCase({ caseId: params.caseId })
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status })
+    }
+
+    return NextResponse.json({ success: true, ...result.data })
+  } catch (error) {
+    console.error('Error reminding case:', error)
+    return NextResponse.json({ error: 'リマインドに失敗しました' }, { status: 500 })
+  }
+}

--- a/app/api/applications/[caseId]/requirements/[requirementId]/documents/route.ts
+++ b/app/api/applications/[caseId]/requirements/[requirementId]/documents/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { uploadRequirementDocument } from '@/lib/portal/documents'
+
+// POST /api/applications/[caseId]/requirements/[requirementId]/documents
+// multipart/form-data の file を受け取り、要件に紐付けてアップロードする。
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { caseId: string; requirementId: string } }
+) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    let formData: FormData
+    try {
+      formData = await request.formData()
+    } catch {
+      return NextResponse.json(
+        { error: 'ファイルの受信に失敗しました' },
+        { status: 400 }
+      )
+    }
+
+    const file = formData.get('file')
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: 'ファイルが指定されていません' }, { status: 400 })
+    }
+
+    const result = await uploadRequirementDocument({
+      caseId: params.caseId,
+      requirementId: params.requirementId,
+      file,
+    })
+
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status })
+    }
+
+    return NextResponse.json({ success: true, ...result.data })
+  } catch (error) {
+    console.error('Error uploading requirement document:', error)
+    return NextResponse.json(
+      { error: 'アップロードに失敗しました' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/applications/[caseId]/requirements/[requirementId]/route.ts
+++ b/app/api/applications/[caseId]/requirements/[requirementId]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { reviewRequirement, type ReviewAction } from '@/lib/portal/documents'
+
+const VALID_ACTIONS: ReviewAction[] = ['approve', 'reject', 'reset']
+
+// PATCH /api/applications/[caseId]/requirements/[requirementId]
+// { action: 'approve' | 'reject' (reason必須) | 'reset' }。承認/差戻しは writer のみ。
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { caseId: string; requirementId: string } }
+) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await request.json().catch(() => null)
+    const action = body?.action as ReviewAction | undefined
+    if (!action || !VALID_ACTIONS.includes(action)) {
+      return NextResponse.json({ error: '不正な操作です' }, { status: 400 })
+    }
+
+    const result = await reviewRequirement({
+      caseId: params.caseId,
+      requirementId: params.requirementId,
+      action,
+      reason: typeof body?.reason === 'string' ? body.reason : null,
+    })
+
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status })
+    }
+
+    return NextResponse.json({ success: true, ...result.data })
+  } catch (error) {
+    console.error('Error reviewing requirement:', error)
+    return NextResponse.json({ error: 'レビューに失敗しました' }, { status: 500 })
+  }
+}

--- a/app/api/applications/[caseId]/route.ts
+++ b/app/api/applications/[caseId]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { getCase, getRequirements } from '@/lib/portal/applications'
+
+// GET /api/applications/[caseId] — 案件 + 要件（グループ化）+ メンバー
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { caseId: string } }
+) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const detail = await getCase(params.caseId)
+    if (!detail) {
+      // アクセス不可 or 存在しない（RLS が区別しないため 404 で統一）
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    }
+
+    const requirements = await getRequirements(params.caseId)
+    return NextResponse.json({ case: detail, requirements })
+  } catch (error) {
+    console.error('Error fetching application:', error)
+    return NextResponse.json({ error: 'Failed to fetch application' }, { status: 500 })
+  }
+}

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { validateNewCase } from '@/lib/portal/case-validation'
+import { createCase, listCases } from '@/lib/portal/applications'
+
+// GET /api/applications — アクセス可能な案件一覧（RLS が office 境界に絞る）
+export async function GET() {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const cases = await listCases()
+    return NextResponse.json({ cases })
+  } catch (error) {
+    console.error('Error listing applications:', error)
+    return NextResponse.json({ error: 'Failed to list applications' }, { status: 500 })
+  }
+}
+
+// POST /api/applications — 案件作成 → materialize
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await request.json().catch(() => null)
+    const validation = validateNewCase(body)
+    if (!validation.ok) {
+      return NextResponse.json({ error: validation.error }, { status: 400 })
+    }
+
+    try {
+      const caseId = await createCase(validation.value)
+      return NextResponse.json({ id: caseId }, { status: 201 })
+    } catch (error) {
+      // RLS 違反や未認可（office 越境等）は 403 として返す
+      const code = (error as { code?: string })?.code
+      if (code === '42501') {
+        return NextResponse.json(
+          { error: 'この事業所で案件を作成する権限がありません' },
+          { status: 403 }
+        )
+      }
+      const message = error instanceof Error ? error.message : ''
+      if (
+        message.includes('not authorized') ||
+        message.includes('office not found or not accessible')
+      ) {
+        return NextResponse.json(
+          { error: 'この事業所で案件を作成する権限がありません' },
+          { status: 403 }
+        )
+      }
+      console.error('Error creating application:', error)
+      return NextResponse.json({ error: 'Failed to create application' }, { status: 500 })
+    }
+  } catch (error) {
+    console.error('Error creating application:', error)
+    return NextResponse.json({ error: 'Failed to create application' }, { status: 500 })
+  }
+}

--- a/app/api/documents/[kind]/[docId]/url/route.ts
+++ b/app/api/documents/[kind]/[docId]/url/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createRequirementDocumentSignedUrl } from '@/lib/portal/documents'
+import type { DocumentKind } from '@/lib/portal/types'
+
+// GET /api/documents/[kind]/[docId]/url — 署名URL（60分）を返す。kind=office|person
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { kind: string; docId: string } }
+) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    if (params.kind !== 'office' && params.kind !== 'person') {
+      return NextResponse.json({ error: '不正な種別です' }, { status: 400 })
+    }
+
+    const result = await createRequirementDocumentSignedUrl({
+      kind: params.kind as DocumentKind,
+      documentId: params.docId,
+    })
+
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status })
+    }
+
+    return NextResponse.json({ url: result.data.url })
+  } catch (error) {
+    console.error('Error creating document signed URL:', error)
+    return NextResponse.json({ error: '表示URLの発行に失敗しました' }, { status: 500 })
+  }
+}

--- a/app/applications/[caseId]/page.tsx
+++ b/app/applications/[caseId]/page.tsx
@@ -1,0 +1,79 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ArrowLeft } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { CaseProgressHeader } from '@/components/portal/case-progress-header'
+import { ChecklistTable } from '@/components/portal/checklist-table'
+import { AddMembersDialog } from '@/components/portal/add-members-dialog'
+import {
+  getCaseWithRequirements,
+  getOfficePeopleForCase,
+} from '@/lib/portal/applications'
+import {
+  APPLICATION_CATEGORY_LABELS,
+  ENTITY_TYPE_LABELS,
+  FIELD_LABELS,
+} from '@/lib/portal/types'
+
+export const dynamic = 'force-dynamic'
+
+export default async function ApplicationDetailPage({
+  params,
+}: {
+  params: { caseId: string }
+}) {
+  const data = await getCaseWithRequirements(params.caseId)
+  if (!data) {
+    notFound()
+  }
+
+  const { case: detail, requirements } = data
+  const memberPersonIds = detail.members.map((m) => m.personId)
+  const availablePeople = await getOfficePeopleForCase(
+    detail.tenantOfficeId,
+    memberPersonIds
+  )
+
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <Button asChild variant="ghost" size="sm" className="mb-2 -ml-2 gap-1">
+          <Link href="/applications">
+            <ArrowLeft className="h-4 w-4" />
+            申請ポータルに戻る
+          </Link>
+        </Button>
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold text-foreground">
+              {detail.title || detail.officeName || '無題の案件'}
+            </h1>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              {detail.officeName && (
+                <Badge variant="outline">{detail.officeName}</Badge>
+              )}
+              <Badge variant="secondary">{FIELD_LABELS[detail.field]}</Badge>
+              <Badge variant="secondary">
+                {ENTITY_TYPE_LABELS[detail.entityType]}
+              </Badge>
+              <Badge variant="secondary">
+                {APPLICATION_CATEGORY_LABELS[detail.applicationCategory]}
+              </Badge>
+              {detail.managementNumber && (
+                <span className="text-sm text-muted-foreground">
+                  管理番号：{detail.managementNumber}
+                </span>
+              )}
+            </div>
+          </div>
+          <AddMembersDialog caseId={detail.id} people={availablePeople} />
+        </div>
+      </div>
+
+      <CaseProgressHeader status={detail.status} />
+
+      <ChecklistTable requirements={requirements} />
+    </div>
+  )
+}

--- a/app/applications/[caseId]/page.tsx
+++ b/app/applications/[caseId]/page.tsx
@@ -76,6 +76,21 @@ export default async function ApplicationDetailPage({
             <AddMembersDialog caseId={detail.id} people={availablePeople} />
           </div>
         </div>
+
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium text-muted-foreground">
+            対象人材：
+          </span>
+          {detail.members.length === 0 ? (
+            <span className="text-sm text-muted-foreground">未設定</span>
+          ) : (
+            detail.members.map((member) => (
+              <Badge key={member.id} variant="secondary">
+                {member.personName ?? '（氏名未取得）'}
+              </Badge>
+            ))
+          )}
+        </div>
       </div>
 
       <CaseProgressHeader status={detail.status} />

--- a/app/applications/[caseId]/page.tsx
+++ b/app/applications/[caseId]/page.tsx
@@ -6,10 +6,13 @@ import { Badge } from '@/components/ui/badge'
 import { CaseProgressHeader } from '@/components/portal/case-progress-header'
 import { ChecklistTable } from '@/components/portal/checklist-table'
 import { AddMembersDialog } from '@/components/portal/add-members-dialog'
+import { CommentThread } from '@/components/portal/comment-thread'
+import { RemindButton } from '@/components/portal/remind-button'
 import {
   getCaseWithRequirements,
   getOfficePeopleForCase,
 } from '@/lib/portal/applications'
+import { listComments } from '@/lib/portal/comments'
 import {
   APPLICATION_CATEGORY_LABELS,
   ENTITY_TYPE_LABELS,
@@ -28,12 +31,13 @@ export default async function ApplicationDetailPage({
     notFound()
   }
 
-  const { case: detail, requirements } = data
+  const { case: detail, requirements, isWriter } = data
   const memberPersonIds = detail.members.map((m) => m.personId)
   const availablePeople = await getOfficePeopleForCase(
     detail.tenantOfficeId,
     memberPersonIds
   )
+  const comments = await listComments(detail.id)
 
   return (
     <div className="space-y-6 p-6">
@@ -67,13 +71,22 @@ export default async function ApplicationDetailPage({
               )}
             </div>
           </div>
-          <AddMembersDialog caseId={detail.id} people={availablePeople} />
+          <div className="flex flex-wrap items-center gap-2">
+            {isWriter && <RemindButton caseId={detail.id} />}
+            <AddMembersDialog caseId={detail.id} people={availablePeople} />
+          </div>
         </div>
       </div>
 
       <CaseProgressHeader status={detail.status} />
 
-      <ChecklistTable requirements={requirements} />
+      <ChecklistTable
+        caseId={detail.id}
+        requirements={requirements}
+        canReview={isWriter}
+      />
+
+      <CommentThread caseId={detail.id} comments={comments} />
     </div>
   )
 }

--- a/app/applications/new/page.tsx
+++ b/app/applications/new/page.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { NewCaseForm } from '@/components/portal/new-case-form'
+import { getAccessibleOffices } from '@/lib/portal/applications'
+
+export const dynamic = 'force-dynamic'
+
+export default async function NewApplicationPage() {
+  const offices = await getAccessibleOffices()
+
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <Button asChild variant="ghost" size="sm" className="mb-2 -ml-2 gap-1">
+          <Link href="/applications">
+            <ArrowLeft className="h-4 w-4" />
+            申請ポータルに戻る
+          </Link>
+        </Button>
+        <h1 className="text-3xl font-bold text-foreground">新規案件</h1>
+        <p className="mt-2 text-muted-foreground">
+          事業所と申請の内容を選ぶと、必要書類のチェックリストが自動で作られます。人材は作成後に追加できます。
+        </p>
+      </div>
+
+      <NewCaseForm offices={offices} />
+    </div>
+  )
+}

--- a/app/applications/page.tsx
+++ b/app/applications/page.tsx
@@ -1,0 +1,110 @@
+import Link from 'next/link'
+import { ClipboardList, Plus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { EmptyState } from '@/components/ui/empty-state'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { listCases } from '@/lib/portal/applications'
+import {
+  APPLICATION_CATEGORY_LABELS,
+  CASE_STATUS_LABELS,
+  ENTITY_TYPE_LABELS,
+  FIELD_LABELS,
+} from '@/lib/portal/types'
+
+export const dynamic = 'force-dynamic'
+
+export default async function ApplicationsPage() {
+  const cases = await listCases()
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-foreground">申請ポータル</h1>
+          <p className="mt-2 text-muted-foreground">
+            ビザ申請の案件と、必要書類のチェックリストを管理します。
+          </p>
+        </div>
+        <Button asChild className="gap-2">
+          <Link href="/applications/new">
+            <Plus className="h-4 w-4" />
+            新規案件
+          </Link>
+        </Button>
+      </div>
+
+      {cases.length === 0 ? (
+        <div className="rounded-xl border border-border bg-card shadow-sm">
+          <EmptyState
+            icon={<ClipboardList className="h-10 w-10" />}
+            title="案件がまだありません"
+            description="「新規案件」から最初の申請案件を作成すると、必要書類のチェックリストが自動で作られます。"
+            action={
+              <Button asChild className="gap-2">
+                <Link href="/applications/new">
+                  <Plus className="h-4 w-4" />
+                  新規案件
+                </Link>
+              </Button>
+            }
+          />
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-border bg-card shadow-sm">
+          <Table className="min-w-[880px]">
+            <TableHeader>
+              <TableRow>
+                <TableHead>タイトル / 事業所</TableHead>
+                <TableHead className="w-[140px]">分野</TableHead>
+                <TableHead className="w-[120px]">種別</TableHead>
+                <TableHead className="w-[100px]">初回/更新</TableHead>
+                <TableHead className="w-[130px]">ステータス</TableHead>
+                <TableHead className="w-[120px]">管理番号</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {cases.map((c) => (
+                <TableRow key={c.id} className="cursor-pointer">
+                  <TableCell>
+                    <Link
+                      href={`/applications/${c.id}`}
+                      className="block font-medium text-foreground hover:underline"
+                    >
+                      {c.title || c.officeName || '無題の案件'}
+                    </Link>
+                    {c.officeName && (
+                      <span className="text-xs text-muted-foreground">
+                        {c.officeName}
+                      </span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-sm">{FIELD_LABELS[c.field]}</TableCell>
+                  <TableCell className="text-sm">
+                    {ENTITY_TYPE_LABELS[c.entityType]}
+                  </TableCell>
+                  <TableCell className="text-sm">
+                    {APPLICATION_CATEGORY_LABELS[c.applicationCategory]}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="secondary">{CASE_STATUS_LABELS[c.status]}</Badge>
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {c.managementNumber || '-'}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Calendar,
   CheckSquare,
   CircleHelp,
+  ClipboardList,
   Clock,
   ExternalLink,
   FileText,
@@ -48,6 +49,11 @@ const navigation: NavigationItem[] = [
     href: "/visas",
     icon: FileText,
     feature: "visas",
+  },
+  {
+    name: "申請ポータル",
+    href: "/applications",
+    icon: ClipboardList,
   },
   {
     name: "面談一覧",

--- a/components/portal/add-members-dialog.tsx
+++ b/components/portal/add-members-dialog.tsx
@@ -84,7 +84,7 @@ export function AddMembersDialog({
         <DialogHeader>
           <DialogTitle>人材を追加</DialogTitle>
           <DialogDescription>
-            この事業所の人材を選んで追加します。追加すると、その人の必要書類がチェックリストに増えます。
+            この事業所の人材を選んで、この案件の対象人材として記録します。
           </DialogDescription>
         </DialogHeader>
 

--- a/components/portal/add-members-dialog.tsx
+++ b/components/portal/add-members-dialog.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { UserPlus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+
+export interface SelectablePerson {
+  id: string
+  name: string | null
+  visaId: string | null
+}
+
+export function AddMembersDialog({
+  caseId,
+  people,
+}: {
+  caseId: string
+  people: SelectablePerson[]
+}) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [selected, setSelected] = useState<Record<string, boolean>>({})
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const selectedIds = Object.keys(selected).filter((id) => selected[id])
+  const canSubmit = selectedIds.length > 0 && !submitting
+
+  function toggle(id: string) {
+    setSelected((prev) => ({ ...prev, [id]: !prev[id] }))
+  }
+
+  async function handleAdd() {
+    if (!canSubmit) return
+    setSubmitting(true)
+    setError(null)
+
+    try {
+      for (const personId of selectedIds) {
+        const person = people.find((p) => p.id === personId)
+        const res = await fetch(`/api/applications/${caseId}/members`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            person_id: personId,
+            visa_id: person?.visaId ?? null,
+          }),
+        })
+        if (!res.ok) {
+          const result = await res.json().catch(() => ({}))
+          throw new Error(result.error || '人材の追加に失敗しました')
+        }
+      }
+      setOpen(false)
+      setSelected({})
+      router.refresh()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '人材の追加に失敗しました')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button className="gap-2">
+          <UserPlus className="h-4 w-4" />
+          人材を追加
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>人材を追加</DialogTitle>
+          <DialogDescription>
+            この事業所の人材を選んで追加します。追加すると、その人の必要書類がチェックリストに増えます。
+          </DialogDescription>
+        </DialogHeader>
+
+        {people.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            追加できる人材がいません。（すでに全員が追加済み、またはこの事業所に人材が登録されていません）
+          </p>
+        ) : (
+          <div className="max-h-72 space-y-1 overflow-y-auto">
+            {people.map((person) => (
+              <label
+                key={person.id}
+                className="flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2 hover:bg-muted"
+              >
+                <Checkbox
+                  checked={Boolean(selected[person.id])}
+                  onCheckedChange={() => toggle(person.id)}
+                />
+                <span className="text-sm">{person.name ?? '（氏名未取得）'}</span>
+              </label>
+            ))}
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)} type="button">
+            キャンセル
+          </Button>
+          <Button onClick={handleAdd} disabled={!canSubmit} type="button">
+            {submitting
+              ? '追加中...'
+              : `追加${selectedIds.length > 0 ? `（${selectedIds.length}名）` : ''}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/portal/case-progress-header.tsx
+++ b/components/portal/case-progress-header.tsx
@@ -1,0 +1,36 @@
+import { Stepper } from '@/components/ui/stepper'
+import {
+  CASE_FLOW_STEPS,
+  CASE_STATUS_LABELS,
+  type CaseStatus,
+} from '@/lib/portal/types'
+
+interface CaseProgressHeaderProps {
+  status: CaseStatus
+}
+
+// 申請の流れ（draft → collecting → reviewing → ready → synced → completed）を Stepper 風に表示。
+export function CaseProgressHeader({ status }: CaseProgressHeaderProps) {
+  const labels = CASE_FLOW_STEPS.map((s) => CASE_STATUS_LABELS[s])
+
+  // archived は途中経路に無いため、最終段扱い（全ステップ完了）で描画する
+  const flowIndex = CASE_FLOW_STEPS.indexOf(status)
+  const currentStep =
+    flowIndex >= 0 ? flowIndex + 1 : CASE_FLOW_STEPS.length + 1
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-sm font-medium text-muted-foreground">申請の流れ</h3>
+        <span className="text-xs text-muted-foreground">
+          現在のステータス：{CASE_STATUS_LABELS[status]}
+        </span>
+      </div>
+      <div className="overflow-x-auto">
+        <div className="min-w-[640px]">
+          <Stepper steps={labels} currentStep={currentStep} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/portal/checklist-table.tsx
+++ b/components/portal/checklist-table.tsx
@@ -1,4 +1,10 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Building2, CheckCircle2, Eye, Undo2, Upload, User, XCircle } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import {
   Table,
   TableBody,
@@ -7,74 +13,302 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { useToast } from '@/lib/hooks/use-toast'
+import { cn } from '@/lib/utils'
 import {
   COPY_TYPE_LABELS,
   REQUIREMENT_STATUS_LABELS,
   type CaseDocumentRequirement,
+  type DocumentKind,
   type GroupedRequirements,
   type RequirementStatus,
 } from '@/lib/portal/types'
-import { Building2, User } from 'lucide-react'
+import { RejectReasonDialog } from './reject-reason-dialog'
 
-function statusVariant(
-  status: RequirementStatus
-): 'default' | 'secondary' | 'destructive' | 'outline' {
-  switch (status) {
-    case 'approved':
-      return 'default'
-    case 'needs_fix':
-      return 'destructive'
-    case 'reviewing':
-      return 'outline'
-    case 'not_submitted':
-    default:
-      return 'secondary'
-  }
+// ステータスbadge色分け：未提出=グレー / 確認中=青 / 承認済み=緑 / 要修正=赤
+const STATUS_STYLES: Record<RequirementStatus, string> = {
+  not_submitted: 'bg-muted text-muted-foreground border border-border',
+  reviewing:
+    'bg-blue-100 text-blue-700 border border-blue-200 dark:bg-blue-950 dark:text-blue-300 dark:border-blue-900',
+  approved:
+    'bg-green-100 text-green-700 border border-green-200 dark:bg-green-950 dark:text-green-300 dark:border-green-900',
+  needs_fix:
+    'bg-red-100 text-red-700 border border-red-200 dark:bg-red-950 dark:text-red-300 dark:border-red-900',
 }
 
-function RequirementRows({ items }: { items: CaseDocumentRequirement[] }) {
+function StatusBadge({ status }: { status: RequirementStatus }) {
   return (
-    <>
-      {items.map((item) => (
-        <TableRow key={item.id}>
-          <TableCell className="font-medium">{item.name}</TableCell>
-          <TableCell>
-            {item.isRequired ? (
-              <Badge variant="outline" className="border-primary/30 text-primary">
-                必須
-              </Badge>
-            ) : (
-              <span className="text-sm text-muted-foreground">任意</span>
-            )}
-          </TableCell>
-          <TableCell>
-            {item.copyType ? (
-              <span className="text-sm">{COPY_TYPE_LABELS[item.copyType]}</span>
-            ) : (
-              <span className="text-muted-foreground">-</span>
-            )}
-          </TableCell>
-          <TableCell>
-            <Badge variant={statusVariant(item.status)}>
-              {REQUIREMENT_STATUS_LABELS[item.status]}
-            </Badge>
-          </TableCell>
-        </TableRow>
-      ))}
-    </>
+    <span
+      className={cn(
+        'inline-flex w-fit items-center rounded-md px-2 py-0.5 text-xs font-medium whitespace-nowrap',
+        STATUS_STYLES[status]
+      )}
+    >
+      {REQUIREMENT_STATUS_LABELS[status]}
+    </span>
+  )
+}
+
+function requirementDoc(
+  item: CaseDocumentRequirement
+): { kind: DocumentKind; docId: string } | null {
+  if (item.officeDocumentId) {
+    return { kind: 'office', docId: item.officeDocumentId }
+  }
+  if (item.personDocumentId) {
+    return { kind: 'person', docId: item.personDocumentId }
+  }
+  return null
+}
+
+interface RowActionsState {
+  busyId: string | null
+  reject: { requirementId: string; name: string } | null
+}
+
+function RequirementRow({
+  caseId,
+  item,
+  canReview,
+  actions,
+  setActions,
+}: {
+  caseId: string
+  item: CaseDocumentRequirement
+  canReview: boolean
+  actions: RowActionsState
+  setActions: React.Dispatch<React.SetStateAction<RowActionsState>>
+}) {
+  const router = useRouter()
+  const { toast } = useToast()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const busy = actions.busyId === item.id
+  const doc = requirementDoc(item)
+  const canUpload = item.status === 'not_submitted' || item.status === 'needs_fix'
+
+  function setBusy(on: boolean) {
+    setActions((prev) => ({ ...prev, busyId: on ? item.id : null }))
+  }
+
+  async function handleUpload(file: File) {
+    setBusy(true)
+    try {
+      const form = new FormData()
+      form.append('file', file)
+      const res = await fetch(
+        `/api/applications/${caseId}/requirements/${item.id}/documents`,
+        { method: 'POST', body: form }
+      )
+      const result = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        toast({
+          variant: 'destructive',
+          title: 'アップロードに失敗しました',
+          description: result.error || '時間をおいて再度お試しください。',
+        })
+        return
+      }
+      toast({ title: '提出しました', description: `「${item.name}」を提出しました（確認中）。` })
+      router.refresh()
+    } catch {
+      toast({
+        variant: 'destructive',
+        title: 'アップロードに失敗しました',
+        description: 'ネットワークエラーが発生しました。',
+      })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleView() {
+    if (!doc) return
+    setBusy(true)
+    try {
+      const res = await fetch(`/api/documents/${doc.kind}/${doc.docId}/url`)
+      const result = await res.json().catch(() => ({}))
+      if (!res.ok || !result.url) {
+        toast({
+          variant: 'destructive',
+          title: '表示できませんでした',
+          description: result.error || '時間をおいて再度お試しください。',
+        })
+        return
+      }
+      window.open(result.url, '_blank', 'noopener,noreferrer')
+    } catch {
+      toast({ variant: 'destructive', title: '表示できませんでした' })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleReview(action: 'approve' | 'reset') {
+    setBusy(true)
+    try {
+      const res = await fetch(
+        `/api/applications/${caseId}/requirements/${item.id}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action }),
+        }
+      )
+      const result = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        toast({
+          variant: 'destructive',
+          title: '操作に失敗しました',
+          description: result.error || '時間をおいて再度お試しください。',
+        })
+        return
+      }
+      toast({
+        title: action === 'approve' ? '承認しました' : '未提出に戻しました',
+        description: `「${item.name}」`,
+      })
+      router.refresh()
+    } catch {
+      toast({ variant: 'destructive', title: '操作に失敗しました' })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <TableRow>
+      <TableCell className="font-medium align-top">
+        {item.name}
+        {item.status === 'needs_fix' && item.rejectionReason && (
+          <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+            差戻し理由：{item.rejectionReason}
+          </p>
+        )}
+      </TableCell>
+      <TableCell className="align-top">
+        {item.isRequired ? (
+          <Badge variant="outline" className="border-primary/30 text-primary">
+            必須
+          </Badge>
+        ) : (
+          <span className="text-sm text-muted-foreground">任意</span>
+        )}
+      </TableCell>
+      <TableCell className="align-top">
+        {item.copyType ? (
+          <span className="text-sm">{COPY_TYPE_LABELS[item.copyType]}</span>
+        ) : (
+          <span className="text-muted-foreground">-</span>
+        )}
+      </TableCell>
+      <TableCell className="align-top">
+        <StatusBadge status={item.status} />
+      </TableCell>
+      <TableCell className="align-top">
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            className="hidden"
+            accept="image/png,image/jpeg,image/webp,image/heic,image/heif,application/pdf"
+            onChange={(e) => {
+              const file = e.target.files?.[0]
+              if (file) {
+                void handleUpload(file)
+              }
+              e.target.value = ''
+            }}
+          />
+          {canUpload && (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={busy}
+              onClick={() => fileInputRef.current?.click()}
+              className="gap-1"
+            >
+              <Upload className="h-3.5 w-3.5" />
+              {item.status === 'needs_fix' ? '再提出' : 'アップロード'}
+            </Button>
+          )}
+          {doc && (
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={busy}
+              onClick={handleView}
+              className="gap-1"
+            >
+              <Eye className="h-3.5 w-3.5" />
+              表示
+            </Button>
+          )}
+          {canReview && item.status === 'reviewing' && (
+            <>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={busy}
+                onClick={() => handleReview('approve')}
+                className="gap-1 border-green-300 text-green-700 hover:bg-green-50 dark:border-green-900 dark:text-green-300 dark:hover:bg-green-950"
+              >
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                承認
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={busy}
+                onClick={() =>
+                  setActions((prev) => ({
+                    ...prev,
+                    reject: { requirementId: item.id, name: item.name },
+                  }))
+                }
+                className="gap-1 border-red-300 text-red-700 hover:bg-red-50 dark:border-red-900 dark:text-red-300 dark:hover:bg-red-950"
+              >
+                <XCircle className="h-3.5 w-3.5" />
+                差戻し
+              </Button>
+            </>
+          )}
+          {canReview && item.status === 'approved' && (
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={busy}
+              onClick={() => handleReview('reset')}
+              className="gap-1 text-muted-foreground"
+            >
+              <Undo2 className="h-3.5 w-3.5" />
+              取消
+            </Button>
+          )}
+        </div>
+      </TableCell>
+    </TableRow>
   )
 }
 
 function ChecklistSection({
+  caseId,
   title,
   icon,
   items,
   emptyLabel,
+  canReview,
+  actions,
+  setActions,
 }: {
+  caseId: string
   title: string
   icon: React.ReactNode
   items: CaseDocumentRequirement[]
   emptyLabel: string
+  canReview: boolean
+  actions: RowActionsState
+  setActions: React.Dispatch<React.SetStateAction<RowActionsState>>
 }) {
   return (
     <div className="rounded-xl border border-border bg-card shadow-sm">
@@ -84,22 +318,30 @@ function ChecklistSection({
         <span className="text-xs text-muted-foreground">（{items.length}件）</span>
       </div>
       {items.length === 0 ? (
-        <p className="px-4 py-6 text-center text-sm text-muted-foreground">
-          {emptyLabel}
-        </p>
+        <p className="px-4 py-6 text-center text-sm text-muted-foreground">{emptyLabel}</p>
       ) : (
         <div className="overflow-x-auto">
-          <Table className="min-w-[560px]">
+          <Table className="min-w-[720px]">
             <TableHeader>
               <TableRow>
                 <TableHead>書類名</TableHead>
-                <TableHead className="w-[100px]">必須/任意</TableHead>
-                <TableHead className="w-[100px]">原本/写し</TableHead>
-                <TableHead className="w-[120px]">ステータス</TableHead>
+                <TableHead className="w-[90px]">必須/任意</TableHead>
+                <TableHead className="w-[90px]">原本/写し</TableHead>
+                <TableHead className="w-[100px]">ステータス</TableHead>
+                <TableHead className="w-[220px]">操作</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              <RequirementRows items={items} />
+              {items.map((item) => (
+                <RequirementRow
+                  key={item.id}
+                  caseId={caseId}
+                  item={item}
+                  canReview={canReview}
+                  actions={actions}
+                  setActions={setActions}
+                />
+              ))}
             </TableBody>
           </Table>
         </div>
@@ -108,14 +350,63 @@ function ChecklistSection({
   )
 }
 
-export function ChecklistTable({ requirements }: { requirements: GroupedRequirements }) {
+export function ChecklistTable({
+  caseId,
+  requirements,
+  canReview,
+}: {
+  caseId: string
+  requirements: GroupedRequirements
+  canReview: boolean
+}) {
+  const router = useRouter()
+  const { toast } = useToast()
+  const [actions, setActions] = useState<RowActionsState>({ busyId: null, reject: null })
+  const [rejectSubmitting, setRejectSubmitting] = useState(false)
+
+  async function submitReject(reason: string) {
+    if (!actions.reject) return
+    const requirementId = actions.reject.requirementId
+    setRejectSubmitting(true)
+    try {
+      const res = await fetch(
+        `/api/applications/${caseId}/requirements/${requirementId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'reject', reason }),
+        }
+      )
+      const result = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        toast({
+          variant: 'destructive',
+          title: '差戻しに失敗しました',
+          description: result.error || '時間をおいて再度お試しください。',
+        })
+        return
+      }
+      toast({ title: '差し戻しました', description: '会社の担当者に修正を依頼できます。' })
+      setActions((prev) => ({ ...prev, reject: null }))
+      router.refresh()
+    } catch {
+      toast({ variant: 'destructive', title: '差戻しに失敗しました' })
+    } finally {
+      setRejectSubmitting(false)
+    }
+  }
+
   return (
     <div className="space-y-6">
       <ChecklistSection
+        caseId={caseId}
         title="会社・事業所の書類"
         icon={<Building2 className="h-4 w-4 text-muted-foreground" />}
         items={requirements.office}
         emptyLabel="会社の必要書類はまだありません。"
+        canReview={canReview}
+        actions={actions}
+        setActions={setActions}
       />
 
       <div className="space-y-4">
@@ -128,14 +419,28 @@ export function ChecklistTable({ requirements }: { requirements: GroupedRequirem
           requirements.persons.map((group) => (
             <ChecklistSection
               key={group.personId}
+              caseId={caseId}
               title={group.personName ?? '（氏名未取得）'}
               icon={<User className="h-4 w-4 text-muted-foreground" />}
               items={group.items}
               emptyLabel="この人材の必要書類はまだ生成されていません。"
+              canReview={canReview}
+              actions={actions}
+              setActions={setActions}
             />
           ))
         )}
       </div>
+
+      <RejectReasonDialog
+        open={actions.reject !== null}
+        onOpenChange={(open) =>
+          setActions((prev) => ({ ...prev, reject: open ? prev.reject : null }))
+        }
+        documentName={actions.reject?.name}
+        submitting={rejectSubmitting}
+        onSubmit={submitReject}
+      />
     </div>
   )
 }

--- a/components/portal/checklist-table.tsx
+++ b/components/portal/checklist-table.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { Building2, CheckCircle2, Eye, Undo2, Upload, User, XCircle } from 'lucide-react'
+import { Building2, CheckCircle2, Eye, Undo2, Upload, XCircle } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -408,29 +408,6 @@ export function ChecklistTable({
         actions={actions}
         setActions={setActions}
       />
-
-      <div className="space-y-4">
-        <h4 className="text-sm font-semibold text-foreground">人材ごとの書類</h4>
-        {requirements.persons.length === 0 ? (
-          <p className="rounded-xl border border-dashed border-border px-4 py-6 text-center text-sm text-muted-foreground">
-            まだ人材が追加されていません。「人材を追加」から人材を選ぶと、その人の必要書類が表示されます。
-          </p>
-        ) : (
-          requirements.persons.map((group) => (
-            <ChecklistSection
-              key={group.personId}
-              caseId={caseId}
-              title={group.personName ?? '（氏名未取得）'}
-              icon={<User className="h-4 w-4 text-muted-foreground" />}
-              items={group.items}
-              emptyLabel="この人材の必要書類はまだ生成されていません。"
-              canReview={canReview}
-              actions={actions}
-              setActions={setActions}
-            />
-          ))
-        )}
-      </div>
 
       <RejectReasonDialog
         open={actions.reject !== null}

--- a/components/portal/checklist-table.tsx
+++ b/components/portal/checklist-table.tsx
@@ -1,0 +1,141 @@
+import { Badge } from '@/components/ui/badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  COPY_TYPE_LABELS,
+  REQUIREMENT_STATUS_LABELS,
+  type CaseDocumentRequirement,
+  type GroupedRequirements,
+  type RequirementStatus,
+} from '@/lib/portal/types'
+import { Building2, User } from 'lucide-react'
+
+function statusVariant(
+  status: RequirementStatus
+): 'default' | 'secondary' | 'destructive' | 'outline' {
+  switch (status) {
+    case 'approved':
+      return 'default'
+    case 'needs_fix':
+      return 'destructive'
+    case 'reviewing':
+      return 'outline'
+    case 'not_submitted':
+    default:
+      return 'secondary'
+  }
+}
+
+function RequirementRows({ items }: { items: CaseDocumentRequirement[] }) {
+  return (
+    <>
+      {items.map((item) => (
+        <TableRow key={item.id}>
+          <TableCell className="font-medium">{item.name}</TableCell>
+          <TableCell>
+            {item.isRequired ? (
+              <Badge variant="outline" className="border-primary/30 text-primary">
+                必須
+              </Badge>
+            ) : (
+              <span className="text-sm text-muted-foreground">任意</span>
+            )}
+          </TableCell>
+          <TableCell>
+            {item.copyType ? (
+              <span className="text-sm">{COPY_TYPE_LABELS[item.copyType]}</span>
+            ) : (
+              <span className="text-muted-foreground">-</span>
+            )}
+          </TableCell>
+          <TableCell>
+            <Badge variant={statusVariant(item.status)}>
+              {REQUIREMENT_STATUS_LABELS[item.status]}
+            </Badge>
+          </TableCell>
+        </TableRow>
+      ))}
+    </>
+  )
+}
+
+function ChecklistSection({
+  title,
+  icon,
+  items,
+  emptyLabel,
+}: {
+  title: string
+  icon: React.ReactNode
+  items: CaseDocumentRequirement[]
+  emptyLabel: string
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-card shadow-sm">
+      <div className="flex items-center gap-2 border-b border-border px-4 py-3">
+        {icon}
+        <h4 className="text-sm font-semibold text-foreground">{title}</h4>
+        <span className="text-xs text-muted-foreground">（{items.length}件）</span>
+      </div>
+      {items.length === 0 ? (
+        <p className="px-4 py-6 text-center text-sm text-muted-foreground">
+          {emptyLabel}
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <Table className="min-w-[560px]">
+            <TableHeader>
+              <TableRow>
+                <TableHead>書類名</TableHead>
+                <TableHead className="w-[100px]">必須/任意</TableHead>
+                <TableHead className="w-[100px]">原本/写し</TableHead>
+                <TableHead className="w-[120px]">ステータス</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <RequirementRows items={items} />
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function ChecklistTable({ requirements }: { requirements: GroupedRequirements }) {
+  return (
+    <div className="space-y-6">
+      <ChecklistSection
+        title="会社・事業所の書類"
+        icon={<Building2 className="h-4 w-4 text-muted-foreground" />}
+        items={requirements.office}
+        emptyLabel="会社の必要書類はまだありません。"
+      />
+
+      <div className="space-y-4">
+        <h4 className="text-sm font-semibold text-foreground">人材ごとの書類</h4>
+        {requirements.persons.length === 0 ? (
+          <p className="rounded-xl border border-dashed border-border px-4 py-6 text-center text-sm text-muted-foreground">
+            まだ人材が追加されていません。「人材を追加」から人材を選ぶと、その人の必要書類が表示されます。
+          </p>
+        ) : (
+          requirements.persons.map((group) => (
+            <ChecklistSection
+              key={group.personId}
+              title={group.personName ?? '（氏名未取得）'}
+              icon={<User className="h-4 w-4 text-muted-foreground" />}
+              items={group.items}
+              emptyLabel="この人材の必要書類はまだ生成されていません。"
+            />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/portal/comment-thread.tsx
+++ b/components/portal/comment-thread.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { MessageSquare, Send } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { useToast } from '@/lib/hooks/use-toast'
+import type { CaseComment } from '@/lib/portal/types'
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) {
+    return iso
+  }
+  return d.toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+/**
+ * 案件のコメント一覧＋投稿フォーム。会社とファントコのやり取りをメール代わりに残す。
+ */
+export function CommentThread({
+  caseId,
+  comments,
+}: {
+  caseId: string
+  comments: CaseComment[]
+}) {
+  const router = useRouter()
+  const { toast } = useToast()
+  const [body, setBody] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const canSubmit = body.trim().length > 0 && !submitting
+
+  async function handleSubmit() {
+    if (!canSubmit) return
+    setSubmitting(true)
+    try {
+      const res = await fetch(`/api/applications/${caseId}/comments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body }),
+      })
+      const result = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        toast({
+          variant: 'destructive',
+          title: 'コメントを投稿できませんでした',
+          description: result.error || '時間をおいて再度お試しください。',
+        })
+        return
+      }
+      setBody('')
+      router.refresh()
+    } catch {
+      toast({ variant: 'destructive', title: 'コメントを投稿できませんでした' })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-card shadow-sm">
+      <div className="flex items-center gap-2 border-b border-border px-4 py-3">
+        <MessageSquare className="h-4 w-4 text-muted-foreground" />
+        <h4 className="text-sm font-semibold text-foreground">コメント</h4>
+        <span className="text-xs text-muted-foreground">（{comments.length}件）</span>
+      </div>
+
+      <div className="space-y-4 px-4 py-4">
+        {comments.length === 0 ? (
+          <p className="text-center text-sm text-muted-foreground">
+            まだコメントはありません。書類のやり取りや連絡事項をここに残せます。
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {comments.map((comment) => (
+              <li
+                key={comment.id}
+                className="rounded-lg border border-border bg-background px-3 py-2"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-xs font-medium text-foreground">
+                    {comment.authorLabel ?? '担当者'}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {formatTimestamp(comment.createdAt)}
+                  </span>
+                </div>
+                <p className="mt-1 whitespace-pre-wrap text-sm text-foreground">
+                  {comment.body}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="space-y-2 border-t border-border pt-4">
+          <Textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder="連絡事項や書類についてのやり取りを入力..."
+            rows={3}
+          />
+          <div className="flex justify-end">
+            <Button onClick={handleSubmit} disabled={!canSubmit} className="gap-1">
+              <Send className="h-3.5 w-3.5" />
+              {submitting ? '投稿中...' : '投稿'}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/portal/new-case-form.tsx
+++ b/components/portal/new-case-form.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  APPLICATION_CATEGORY_LABELS,
+  ENTITY_TYPE_LABELS,
+  FIELD_LABELS,
+  type AccessibleOffice,
+  type ApplicationCategory,
+  type EntityType,
+  type Field,
+} from '@/lib/portal/types'
+
+const ENTITY_OPTIONS = Object.entries(ENTITY_TYPE_LABELS) as [EntityType, string][]
+const CATEGORY_OPTIONS = Object.entries(
+  APPLICATION_CATEGORY_LABELS
+) as [ApplicationCategory, string][]
+const FIELD_OPTIONS = Object.entries(FIELD_LABELS) as [Field, string][]
+
+export function NewCaseForm({ offices }: { offices: AccessibleOffice[] }) {
+  const router = useRouter()
+  const [officeId, setOfficeId] = useState('')
+  const [entityType, setEntityType] = useState<EntityType | ''>('')
+  const [category, setCategory] = useState<ApplicationCategory | ''>('')
+  const [field, setField] = useState<Field | ''>('')
+  const [managementNumber, setManagementNumber] = useState('')
+  const [title, setTitle] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const hasOffices = offices.length > 0
+  const canSubmit = Boolean(officeId && entityType && category && field) && !submitting
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!canSubmit) return
+    setSubmitting(true)
+    setError(null)
+
+    try {
+      const res = await fetch('/api/applications', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          tenant_office_id: officeId,
+          entity_type: entityType,
+          application_category: category,
+          field,
+          management_number: managementNumber || null,
+          title: title || null,
+        }),
+      })
+      const result = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setError(result.error || '案件の作成に失敗しました')
+        setSubmitting(false)
+        return
+      }
+      router.push(`/applications/${result.id}`)
+    } catch {
+      setError('案件の作成に失敗しました。時間をおいて再度お試しください。')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-xl space-y-6">
+      {!hasOffices && (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          案件を作成できる事業所がありません。担当者に事業所の割り当てをご確認ください。
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="office">事業所 *</Label>
+        <Select value={officeId} onValueChange={setOfficeId} disabled={!hasOffices}>
+          <SelectTrigger id="office" className="w-full">
+            <SelectValue placeholder="事業所を選んでください" />
+          </SelectTrigger>
+          <SelectContent>
+            {offices.map((office) => (
+              <SelectItem key={office.id} value={office.id}>
+                {office.name}
+                {office.tenantName ? `（${office.tenantName}）` : ''}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="entity-type">申請者の種別 *</Label>
+        <Select value={entityType} onValueChange={(v) => setEntityType(v as EntityType)}>
+          <SelectTrigger id="entity-type" className="w-full">
+            <SelectValue placeholder="法人 / 個人事業主" />
+          </SelectTrigger>
+          <SelectContent>
+            {ENTITY_OPTIONS.map(([value, label]) => (
+              <SelectItem key={value} value={value}>
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="category">申請の種類 *</Label>
+        <Select value={category} onValueChange={(v) => setCategory(v as ApplicationCategory)}>
+          <SelectTrigger id="category" className="w-full">
+            <SelectValue placeholder="初回 / 更新" />
+          </SelectTrigger>
+          <SelectContent>
+            {CATEGORY_OPTIONS.map(([value, label]) => (
+              <SelectItem key={value} value={value}>
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="field">分野 *</Label>
+        <Select value={field} onValueChange={(v) => setField(v as Field)}>
+          <SelectTrigger id="field" className="w-full">
+            <SelectValue placeholder="分野を選んでください" />
+          </SelectTrigger>
+          <SelectContent>
+            {FIELD_OPTIONS.map(([value, label]) => (
+              <SelectItem key={value} value={value}>
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="management-number">管理番号（任意）</Label>
+        <Input
+          id="management-number"
+          value={managementNumber}
+          onChange={(e) => setManagementNumber(e.target.value)}
+          placeholder="例：A-100"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="title">タイトル（任意）</Label>
+        <Input
+          id="title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="例：近江舞子しょうぶ苑 初回申請"
+        />
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <Button type="submit" disabled={!canSubmit}>
+          {submitting ? '作成中...' : '案件を作成'}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => router.push('/applications')}
+        >
+          キャンセル
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/components/portal/reject-reason-dialog.tsx
+++ b/components/portal/reject-reason-dialog.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+export interface RejectReasonDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  documentName?: string | null
+  submitting?: boolean
+  onSubmit: (reason: string) => void
+}
+
+/**
+ * 差戻し理由を入力するダイアログ。理由は必須。
+ */
+export function RejectReasonDialog({
+  open,
+  onOpenChange,
+  documentName,
+  submitting = false,
+  onSubmit,
+}: RejectReasonDialogProps) {
+  const [reason, setReason] = useState('')
+
+  // ダイアログを開くたびに入力をリセット
+  useEffect(() => {
+    if (open) {
+      setReason('')
+    }
+  }, [open])
+
+  const trimmed = reason.trim()
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>書類を差し戻す</DialogTitle>
+          <DialogDescription>
+            {documentName ? `「${documentName}」を差し戻します。` : '書類を差し戻します。'}
+            会社の担当者に伝わるよう、修正してほしい点を具体的に書いてください。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          <Label htmlFor="reject-reason">差戻しの理由 *</Label>
+          <Textarea
+            id="reject-reason"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="例：登記事項証明書が3ヶ月以内のものではありません。再取得をお願いします。"
+            rows={4}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            キャンセル
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => onSubmit(trimmed)}
+            disabled={!trimmed || submitting}
+          >
+            {submitting ? '差戻し中...' : '差し戻す'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/portal/remind-button.tsx
+++ b/components/portal/remind-button.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Bell } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/lib/hooks/use-toast'
+
+/**
+ * 案件のリマインドを記録するボタン（writer=OP向け）。押下で 'reminded' イベントを記録し、
+ * トーストで結果を表示する。メール送信は今後対応（nodemailer 未導入）。
+ */
+export function RemindButton({ caseId }: { caseId: string }) {
+  const router = useRouter()
+  const { toast } = useToast()
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleRemind() {
+    setSubmitting(true)
+    try {
+      const res = await fetch(`/api/applications/${caseId}/remind`, { method: 'POST' })
+      const result = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        toast({
+          variant: 'destructive',
+          title: 'リマインドに失敗しました',
+          description: result.error || '時間をおいて再度お試しください。',
+        })
+        return
+      }
+      toast({
+        title: 'リマインドを記録しました',
+        description: result.message || undefined,
+      })
+      router.refresh()
+    } catch {
+      toast({ variant: 'destructive', title: 'リマインドに失敗しました' })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Button variant="outline" onClick={handleRemind} disabled={submitting} className="gap-1">
+      <Bell className="h-4 w-4" />
+      {submitting ? '記録中...' : 'リマインド'}
+    </Button>
+  )
+}

--- a/docs/specs/2026-07-24-visa-application-portal-design.md
+++ b/docs/specs/2026-07-24-visa-application-portal-design.md
@@ -1,0 +1,324 @@
+# 受入企業向け 在留資格申請 提出ポータル ― 設計仕様書 (v2)
+
+- 対象プロダクト: **FunBase**（既存の外国人人材管理アプリを拡張）
+- 作成日: 2026-07-24 / 版: v2（アドバーサリアル検証24件＋スコープ確定を反映）
+- ステータス: ドラフト（レビュー待ち）
+- 凡例: `【事実】`=既存コード確認済み / `【設計】`=新規提案 / `【要確認】`=業務/実データ確認が必要。
+
+## 0. v2での主な変更（v1からの差分）
+- **入力フォームは作らない**。企業の提出は **Excel添付 ＋ 証明書ファイルのアップロード** のみ（お手軽さ重視。ビザ費用をいただく前提で企業に入力負担をかけない）。
+- 企業とのやり取りは **FunBase内のコメント**（案件ごと）で補完＝メールスレッドの置換。
+- **案件はOP（supporter）が作成**する（§4章を新設。旧仕様の致命的欠落を解消）。
+- **kintone連携（書き込み）はv1で実施**。提出Excelを読み取り、kintone登録に必要な項目を集めてkintoneへ反映（転記削減）。**OCR（証明書画像の中身読取）はv2**。
+- セキュリティ（office境界）を **people.tenant_office_id(UUID) 導入で一本化**し、検証で判明した越境穴を塞ぐ。
+- 既存メンバー締め出しを防ぐ **移行/バックフィル手順**を明記。
+
+## 1. 背景と課題
+特定技能ビザ申請で、受入企業からの提出書類を **メール添付** でやり取りしており、(1)進捗が追えない、(2)企業が何が必要/不足か分からない、(3)OPが受領ファイルを目視で kintone に手入力転記、という課題がある。本ポータルは①提出をメールから置換し、②提出Excelを読み取って kintone へ連携し転記を削減する。
+
+## 2. 棲み分け（確定）
+```
+企業 ──FunBaseポータル(Excel+書類提出・可視化・コメント)──▶ kintone(登録の正) ──ボタン──▶ RAKUVISA(様式作成→行政書士→入管申請)
+       ↑ メール置換                        ↑ 提出Excelを読み取り自動反映(v1) / 証明書はOCR(v2)
+```
+- **FunBase**：受入企業の窓口。Excel＋書類の収集・進捗可視化・コメント・OPレビュー・kintone書き込み。
+- **kintone**：登録情報の正（企業・人材マスター、ビザ進捗、管理番号）。既存の kintone→RAKUVISA ボタン連携は不変。
+- **RAKUVISA**：様式作成・行政書士依頼・入管申請（作成以降）＝**スコープ外**。
+- **メール**：廃止（提出・進捗・やり取りをポータル＋コメントへ）。
+
+## 3. スコープ
+### v1でやること
+- 受入企業担当者が **案内ベースUI**（申請の流れ／次にやること）で、**必要書類チェックリスト**（未提出/確認中/承認済み/要修正・有効期限・請求先）を見て、**Excel添付と証明書ファイルをアップロード**。
+- 必要書類は **〔法人/個人事業主〕×〔初回/更新〕×〔分野〕マトリクス**で自動生成。
+- OP（supporter）が **案件作成・確認・承認・差戻し・リマインド**。
+- 案件ごとの **コメント**（企業⇔OP、メール置換）。
+- 提出Excelを読み取り、**kintone登録に必要な項目を集めてkintoneへ書き込み**（転記削減）。
+- 外部企業ユーザーに安全に開放する **office境界の RLS（UUIDで一本化）**。
+
+### v2（次段）
+- **OCR**：証明書（PDF/画像）の中身を自動読取→下書き→OP確認→kintone。自動チェック（有効期限3ヶ月/未納0/マスキング/24か月分/本籍地有無）。
+
+### やらないこと（Non-Goals）
+- **様式生成**（雇用条件書・報酬説明書などの作成）＝RAKUVISA。
+- 行政書士依頼・入管申請＝RAKUVISA。
+- **企業向けの構造化入力フォーム**（企業はExcel＋ファイルを渡すだけ。データ化はFunBase側で行う）。
+
+## 4. 案件の作成フロー（新設・v1の起点）
+> 旧v1で未定義だった「誰が・いつ・どう案件を作り人材を紐付けるか」を定義。これが無いとチェックリストが1件も生成されない。
+
+- **作成主体**：OP（`supporter`）が手動作成（v1）。kintone同期由来の自動生成はv2以降。
+- **作成手順**：
+  1. OPが `POST /api/applications` で案件を作成。入力＝`tenant_id`（受入企業）・`tenant_office_id`（事業所）・`entity_type`（法人/個人）・`application_category`（初回/更新）・`field`（分野）・`management_number`（任意）。
+  2. `POST /api/applications/[caseId]/members` で対象人材を紐付け（kintone同期済みの `people` から選択）。**人材の選択基準**：既定は UI で手動選択（office に属する people を候補表示。候補は `people.tenant_office_id`＝§6 で導入 で絞る）。
+  3. 上記確定後に **`materialize_case_requirements(case_id)`**（SECURITY DEFINER RPC）でテンプレ→`case_document_requirements` を生成。`scope='person'` 行はメンバー人数分に展開。
+- **メンバー後追い**：案件作成後に `case_members` を追加した場合、追加 person の `scope='person'` 必要書類を**追補**するトリガ/アプリ処理を必ず走らせる（materialize は `ON CONFLICT DO NOTHING` で冪等）。
+- **RPCの権限再検査**：`materialize_case_requirements` は SECURITY DEFINER のため、**本体で必ず** `portal_can_access_office((SELECT tenant_id..),(SELECT tenant_office_id..))` により呼び出し元の権限を再検証し、任意 `case_id` への越境書き込みを防ぐ。
+
+## 5. データモデル
+### 5.1 既存スキーマ前提（【事実】）
+- `people.id text` / `tenant_id uuid` / `external_id text`（更新キー候補、ユニークは `20260212100000` で撤廃）/ `company text`（自由文字列）。
+- `visas`（7段階 status、type=認定/変更/更新/特定活動/資格変更）。
+- `tenant_offices(id, tenant_id)` に複合UNIQUE。子は複合FKで同一テナント担保（`user_tenant_offices` が前例）。
+- `person_documents`（人材単位）＋バケット `person-documents`。**制約は `UNIQUE(person_id, document_type) WHERE document_type <> 'other'` の部分ユニーク**（`other` は複数可, `20260609170000`）。再利用する。
+- ネイティブ enum は使わず `text + CHECK`。
+
+### 5.2 office境界キーの一本化【設計・重要】
+検証で「案件側=UUID一致／既存people側=`company`名一致」の二重定義が越境・情報欠落を生むと判明。**v1で `people.tenant_office_id uuid`（FK `tenant_offices(id,tenant_id)` 複合）を導入**し、全ての office 判定を UUID に統一する。
+- 移行で `people.company` × `tenant_offices.name` を突合してバックフィル（§8 移行手順）。以後の突合基準は **1つ**（UUID一致）に統一し、`people-access.ts` のアプリ層フィルタも UUID 基準へ寄せる。
+- `person_documents` にも `tenant_office_id`（people から継承）を持たせる。
+
+### 5.3 新規テーブル（DDL）
+命名 `visa_application_*`。全テーブル `tenant_id` と `tenant_office_id` を非正規化保持。**親子の tenant/office 整合を複合FKで担保**（検証#3の越境書き込み対策）。
+
+```sql
+CREATE TABLE public.visa_application_cases (
+  id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id            uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  tenant_office_id     uuid NOT NULL,
+  entity_type          text NOT NULL CHECK (entity_type IN ('corporate','sole_proprietor')),
+  application_category  text NOT NULL CHECK (application_category IN ('initial','renewal')),
+  field                text NOT NULL CHECK (field IN ('care','food_service','accommodation','food_manufacturing','other')),
+  application_type     text CHECK (application_type IN ('認定申請','変更申請','更新申請','特定活動申請','資格変更（特定技能2号）')),
+  management_number    text,
+  kintone_record_id    text,                         -- 書込先kintone $id 【要確認: external_idの中身】
+  status               text NOT NULL DEFAULT 'draft'
+                         CHECK (status IN ('draft','collecting','reviewing','ready','synced','completed','archived')),
+  title text, note text,
+  kintone_sync_status  text, kintone_last_synced_at timestamptz,
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT vac_office_fk FOREIGN KEY (tenant_office_id, tenant_id)
+    REFERENCES public.tenant_offices(id, tenant_id) ON DELETE RESTRICT,
+  CONSTRAINT vac_id_tenant_office_uniq UNIQUE (id, tenant_id, tenant_office_id)   -- 子の複合FK参照用
+);
+CREATE UNIQUE INDEX uq_vac_mgmt_no ON public.visa_application_cases(tenant_id, management_number) WHERE management_number IS NOT NULL;
+
+CREATE TABLE public.visa_application_case_members (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id uuid NOT NULL, tenant_id uuid NOT NULL, tenant_office_id uuid NOT NULL,
+  person_id text NOT NULL REFERENCES public.people(id) ON DELETE CASCADE,
+  visa_id text REFERENCES public.visas(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  -- tenant/office 整合を親caseと厳密一致させる（越境INSERT防止, 検証#3）
+  CONSTRAINT vacm_case_fk FOREIGN KEY (case_id, tenant_id, tenant_office_id)
+    REFERENCES public.visa_application_cases(id, tenant_id, tenant_office_id) ON DELETE CASCADE,
+  CONSTRAINT uq_case_person UNIQUE (case_id, person_id)
+);
+
+CREATE TABLE public.office_documents (   -- 取得書類8種（企業/事業所単位・複数人材共通）
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  tenant_office_id uuid NOT NULL,
+  document_code text NOT NULL, storage_path text NOT NULL,
+  file_name text, content_type text, file_size_bytes integer,
+  issued_on date, note text, uploaded_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT od_office_fk FOREIGN KEY (tenant_office_id, tenant_id)
+    REFERENCES public.tenant_offices(id, tenant_id) ON DELETE CASCADE,
+  CONSTRAINT uq_od_office_code UNIQUE (tenant_office_id, document_code)
+);
+
+CREATE TABLE public.case_document_requirements (   -- 必要書類チェックリスト
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id uuid NOT NULL, tenant_id uuid NOT NULL, tenant_office_id uuid NOT NULL,
+  document_code text NOT NULL, name text NOT NULL,
+  scope text NOT NULL CHECK (scope IN ('office','person')),
+  person_id text REFERENCES public.people(id) ON DELETE CASCADE,
+  is_required boolean NOT NULL DEFAULT true,
+  copy_type text CHECK (copy_type IN ('original','copy')),
+  issuer text, validity_months integer, expires_on date,
+  status text NOT NULL DEFAULT 'not_submitted'
+    CHECK (status IN ('not_submitted','reviewing','approved','needs_fix')),
+  rejection_reason text,
+  office_document_id uuid REFERENCES public.office_documents(id) ON DELETE SET NULL,
+  person_document_id uuid REFERENCES public.person_documents(id) ON DELETE SET NULL,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT cdr_case_fk FOREIGN KEY (case_id, tenant_id, tenant_office_id)
+    REFERENCES public.visa_application_cases(id, tenant_id, tenant_office_id) ON DELETE CASCADE
+);
+-- 一意性: NULLS DISTINCT の穴を避け、office行/person行で別の部分ユニーク（検証#13）
+CREATE UNIQUE INDEX uq_cdr_office  ON public.case_document_requirements(case_id, document_code) WHERE person_id IS NULL;
+CREATE UNIQUE INDEX uq_cdr_person  ON public.case_document_requirements(case_id, document_code, person_id) WHERE person_id IS NOT NULL;
+
+CREATE TABLE public.case_comments (   -- 案件ごとのやり取り（メール置換）
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id uuid NOT NULL, tenant_id uuid NOT NULL, tenant_office_id uuid NOT NULL,
+  requirement_id uuid REFERENCES public.case_document_requirements(id) ON DELETE SET NULL, -- 任意: 書類に紐付く
+  author uuid REFERENCES auth.users(id), body text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT cc_case_fk FOREIGN KEY (case_id, tenant_id, tenant_office_id)
+    REFERENCES public.visa_application_cases(id, tenant_id, tenant_office_id) ON DELETE CASCADE
+);
+
+CREATE TABLE public.case_document_events (   -- 監査（提出/承認/差戻し/リマインド）
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id uuid NOT NULL, tenant_id uuid NOT NULL, requirement_id uuid,
+  event_type text NOT NULL CHECK (event_type IN ('submitted','approved','rejected','reminded')),
+  actor uuid REFERENCES auth.users(id), comment text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+```
+主要 index（tenant_id, tenant_office_id, status, case_id）は各表に付与。
+
+### 5.4 提出Excelの扱い（v1のkintone連携の入口）
+- 提出Excel（申請書類作成フォーム）は `office_documents` に `document_code='application_workbook'` として保存。
+- 保存後に **パースジョブ**が Excel の該当セルを読み取り、`case_data_extractions`（下記）へステージング→OP確認→kintoneへ書き込み（§7）。
+```sql
+CREATE TABLE public.case_data_extractions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id uuid NOT NULL, tenant_id uuid NOT NULL,
+  source text NOT NULL CHECK (source IN ('workbook','ocr')),  -- v1=workbook, v2=ocr
+  target_kind text NOT NULL,                 -- 'company' | 'person'
+  person_id text,                            -- person向けのとき
+  payload jsonb NOT NULL,                    -- 抽出フィールド（kintoneフィールドコード→値）
+  status text NOT NULL DEFAULT 'draft' CHECK (status IN ('draft','confirmed','synced','error')),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+```
+- **【要確認】** 実Excelは `#REF!`/`#N/A` を含むため、パーサは壊れセルを**スキップ＋要確認フラグ**にする。どのセルを kintone のどのフィールドへ入れるかの**マッピングは実ワークブックから確定**（§10）。
+
+### 5.5 マスタ（マトリクス）
+`document_catalog`（code, name, default_scope, is_acquired_cert）／`document_requirement_templates`（entity_type×application_category×field 複合UNIQUE）／`document_requirement_template_items`（document_code, scope, is_required, copy_type, issuer, validity_months）。テナント非依存グローバル、冪等シード（`ON CONFLICT`）、SELECT=全authenticated・変更=service_roleのみ。案件作成時に一致テンプレの items を `case_document_requirements` へスナップショット。
+
+## 6. 認証・権限・RLS（セキュリティ）
+外部の受入企業担当者に開放するため、**office境界を RLS で強制**（fail-closed）。office 判定は §5.2 の `tenant_office_id`(UUID) に統一。
+
+### 6.1 境界関数（新規・SECURITY DEFINER・search_path固定）
+```sql
+CREATE FUNCTION public.portal_has_tenant_wide_access(p_tenant_id uuid)
+RETURNS boolean LANGUAGE sql SECURITY DEFINER STABLE SET search_path = public AS $$
+  SELECT EXISTS (SELECT 1 FROM public.user_tenants ut
+    WHERE ut.user_id = auth.uid() AND ut.tenant_id = p_tenant_id
+      AND ut.status='active' AND ut.role IN ('owner','admin','supporter'));
+$$;
+
+-- office境界。tenant-wide短絡枝でも office∈tenant を必ず検証（検証#3）。割当なし=false（fail-closed, 検証#2）。
+CREATE FUNCTION public.portal_can_access_office(p_tenant_id uuid, p_office_id uuid)
+RETURNS boolean LANGUAGE sql SECURITY DEFINER STABLE SET search_path = public AS $$
+  SELECT EXISTS (SELECT 1 FROM public.tenant_offices o
+           WHERE o.id = p_office_id AND o.tenant_id = p_tenant_id)   -- office∈tenant 必須
+    AND (public.portal_has_tenant_wide_access(p_tenant_id)
+      OR EXISTS (SELECT 1 FROM public.user_tenants ut
+          JOIN public.user_tenant_offices uto ON uto.user_tenant_id = ut.id
+          WHERE ut.user_id = auth.uid() AND ut.tenant_id = p_tenant_id
+            AND ut.status='active' AND uto.tenant_office_id = p_office_id));
+$$;
+
+CREATE FUNCTION public.portal_is_writer(p_tenant_id uuid)   -- member 以上（承認等）
+RETURNS boolean LANGUAGE sql SECURITY DEFINER STABLE SET search_path = public AS $$
+  SELECT EXISTS (SELECT 1 FROM public.user_tenants ut WHERE ut.user_id=auth.uid()
+    AND ut.tenant_id=p_tenant_id AND ut.status='active'
+    AND ut.role IN ('owner','admin','supporter','member'));
+$$;
+
+CREATE FUNCTION public.portal_can_upload(p_tenant_id uuid)  -- guest も含む（アップロード可）
+RETURNS boolean LANGUAGE sql SECURITY DEFINER STABLE SET search_path = public AS $$
+  SELECT EXISTS (SELECT 1 FROM public.user_tenants ut WHERE ut.user_id=auth.uid()
+    AND ut.tenant_id=p_tenant_id AND ut.status='active'
+    AND ut.role IN ('owner','admin','supporter','member','guest'));
+$$;
+```
+
+### 6.2 新規テーブルのRLS（コマンド別・最小権限）
+- **SELECT**＝`portal_can_access_office`。
+- **INSERT/UPDATE**＝office境界＋`portal_is_writer`。**ただし `office_documents` の INSERT（アップロード）は `portal_can_upload`（guest含む）**（検証#6/#11の矛盾解消）。
+- **DELETE**＝`portal_has_tenant_wide_access`（member/guest には DELETEポリシーを作らない＝default-deny）。
+- `case_comments` INSERT＝`portal_can_upload`（企業もコメント可）、SELECT＝office境界。
+- なりすまし防止：`uploaded_by`/`author = (SELECT auth.uid())` を WITH CHECK。`auth.uid()` は `(SELECT auth.uid())` でラップ。
+
+### 6.3 既存 people / person_documents / storage を締める
+検証#12（SELECT限定で書込が素通り）・#2/#8（人材書類ファイルがoffice非保護）を解消。
+- **people / person_documents に RESTRICTIVE を FOR ALL（SELECT/INSERT/UPDATE/DELETE）で追加**。判定は §5.2 の `tenant_office_id`(UUID)。owner/admin/supporter は `portal_has_tenant_wide_access` で素通り、member/guest は自 office のみ。
+```sql
+CREATE POLICY people_office_boundary ON public.people AS RESTRICTIVE FOR ALL TO authenticated
+  USING (portal_has_tenant_wide_access(tenant_id)
+      OR (tenant_office_id IS NOT NULL AND portal_can_access_office(tenant_id, tenant_office_id)));
+-- person_documents も tenant_office_id を持たせ同型
+```
+- **ファイル本体（Storage）**：人材書類パスに office が無い問題（検証#2/#8）を、**外部ユーザーの署名URL発行はサーバAPI経由に限定**して解決する。サーバが `office_documents`/`person_documents` の `tenant_office_id` と `portal_can_access_office` を検査してから署名URLを返す。storage RLS はテナント単位を defense-in-depth として維持し、**企業書類パスは `${tenantId}/offices/${officeId}/...`、人材書類は既存パス**のまま、`foldername` 依存の RESTRICTIVE は用いない（人材パスで NULL 判定になり自機能を壊すため）。内部staffは直接署名URL可。
+- **突合規則の統一**（検証#9）：office 判定は UUID一致に統一したため、`people.company` 文字列一致は用いない。移行時に company→office の突合で `people.tenant_office_id` をバックフィル（§8）。
+
+### 6.4 既存の穴と対策（検証反映）
+| # | 穴 | 対策 |
+|---|---|---|
+| 越境書込(#3) | 子テーブルが tenant/office を親と一致させる制約なし＋関数短絡 | 子に複合FK `(id,tenant_id,tenant_office_id)`、関数に office∈tenant 検証 |
+| 人材ファイル(#2/#8) | person 書類ファイルが office 非保護 | 外部ユーザーの署名URLはサーバAPIで office 検査 |
+| 書込素通り(#12) | RESTRICTIVE が SELECT のみ | people/person_documents を FOR ALL に |
+| 境界二重定義(#14/#18) | UUID と 名称一致の二系統 | people.tenant_office_id(UUID) で一本化 |
+| 締め出し(#7/#10) | 既存 office未割当 member/guest / office未作成テナント | §8 バックフィルを RESTRICTIVE 適用の前提に |
+| guest上書き矛盾(#6/#11) | INSERT が writer 限定 | office_documents/comments は portal_can_upload |
+| RPC越境(#23) | materialize が DEFINER で権限無検査 | RPC本体で portal_can_access_office 再検査 |
+| feature露出(#24) | feature 欠落=許可で全テナント表示 | `applications` は既定 off（欠落→非表示の特別扱い）＋段階解放 |
+| 旧教訓 | user_metadata 参照RLS禁止 / DEFINER search_path固定 | 新規は遵守 |
+
+## 7. kintone 連携（FunBase → kintone 書き込み）
+**【事実】現状は読み取り専用**（OAuth read のみ）。書込API `createRecords`/`updateRecords`（`lib/kintone/api-client.ts:220-255`）は実装済・未使用。
+
+### 7.1 有効化手順（順序厳守）
+1. **重複トークンのデデュープ＋UNIQUE制約**（検証#4/#5, 先行必須）：`credentials` を `(connector_id,type)` で最新1件に整理するマイグレーション → `CREATE UNIQUE INDEX (connector_id,type)`。※これが無いと upsert は `no unique or exclusion constraint matching ON CONFLICT` で必ず失敗。
+2. **write スコープ追加**：`lib/integrations/kintone.ts:36` の固定スコープに `k:app_record:write`（添付も送るなら `k:file:write`）。スコープの真実source が3箇所に分散しているため、**固定文字列を廃し `KintoneConfig.scope` に一本化**してから追加。
+3. **コールバックの upsert 化**：`callback/route.ts` の `.insert()` を `upsert(onConflict:'connector_id,type')` に（手順1の制約が前提）。※これは行の無限蓄積を防ぐ衛生と再認可の冪等化が目的。**「重複が `.single()` を壊すから先行必須」という理由は誤り**（実際のライブ読取は `order(created_at desc).limit(1)` で最新を取得＝壊れない, 検証#15/#20）。真の先行必須は手順1の制約追加。
+4. **再認可（再同意）必須**：既存トークンは付与時スコープに固定。各コネクタで `start` を再実行して再同意。kintone側 OAuthクライアント設定にも write 許可を追加【要確認】。
+5. **共通クライアントファクトリ配線**：`createKintoneClient(connectorId)`（現状 `throw`）に、`createSyncService()` のトークン取得＋リフレッシュ＋生成ロジックを切り出して実装。read/write 共通化。
+
+### 7.2 何を書くか
+kintone が「登録の正」なので、FunBase は **(a) 提出Excelから抽出した登録項目**（企業・人材・雇用条件などの `kintone登録に必要なもの`）と **(b) 受領/進捗ステータス** を書く。ファイル本体は当面 kintone へ送らない。
+- **書込は FunBase 権威の対象フィールドに限定**し、kintone側に **FunBase専用フィールドは設けず**、登録項目は既存の企業/人材フィールドへ更新キーで反映（(a)）。人手/RAKUVISAが後段で編集する運用のため、**書込トリガはOP確認後（`case_data_extractions.status='confirmed'`）**に限定して競合を避ける。
+
+### 7.3 更新キーと方向管理
+- **更新キー＝管理番号 → kintone `$id`**。`people.external_id`【要確認: `$id` か業務管理番号か】。管理番号なら `updateRecords` を kintone `updateKey` 対応へ拡張（現状 `id`=$id のみ）。撤廃済みユニーク（`20260212100000`）ゆえ重複時は書込中止＋要確認。
+- **逆マッピングは自動対称ではない**（検証#17）：値変換の非可逆・kintone型エンベロープ（`{value}`、USER_SELECT/CHECK_BOX配列、日付書式）・計算/読取専用フィールド除外が必要。→ **少数の書込対象フィールド専用の前方ライタ（逆値マップ＋型整形）を新規実装**。`getUpdateKeys()` のみ再利用可（ただし**サーバ用 supabase client に差し替え**）、payloadビルダは新規。
+- **方向分離**（検証#16）：`sync_direction` を導入するなら **既存の全読取 app-mapping クエリに `sync_direction IN ('read','both')` を追加**（見ないと write 行を非決定的に拾い read 同期を壊す）。または **書込専用の app/field マッピングを別立て**して読取と物理分離（推奨）。FunBase が書くフィールドは read 方向マッピングに含めない（ループ防止）。
+
+### 7.4 トリガー・冪等性・失敗時
+- **トリガ**：OPが抽出内容を確認（`confirmed`）した時、またはOP承認時。サーバAPI（`app/api/applications/[caseId]/kintone-sync`）で実行。**クライアントから直接 kintone を叩かない**（企業ユーザーに書込権限を与えない, 検証のRLS方針と一致）。
+- **冪等性**：`updateRecords` は $id/updateKey 更新で再送安全。ペイロードのハッシュ＋$idで直近成功と同一ならスキップ。
+- **失敗時**：401→再認可導線＋コネクタ error 化 / 404($id不在)→スキップ＋要確認 / その他→**`sync_sessions`**（【事実】`sync_logs` は実在せず, 検証#22。write方向ログは `sync_sessions` か新設テーブルとして【設計】）に記録し指数バックオフでリトライ。非同期キュー化し、ポータルUXは FunBase状態で完結・kintone反映は結果整合。
+
+## 8. 移行・ロールアウト手順（検証#7/#10, RESTRICTIVE適用前の前提）
+外部ユーザーへ RESTRICTIVE を適用すると、既存の office 未割当 member/guest が締め出されるため、**次の順で実施**：
+1. **既定 office 生成**：`tenant_offices` を持たない既存テナントに、既定 office を1つ生成。
+2. **people.tenant_office_id 追加＋バックフィル**：`people.company` × `tenant_offices.name` の突合で `people.tenant_office_id` を投入（不一致は要手動）。`person_documents.tenant_office_id` も people から継承。
+3. **メンバーの office 割当バックフィル**：既存 member/guest の `user_tenant_offices` を（company↔office突合 or 個別再招待で）投入。
+4. **招待APIの officeId 必須化**：member/guest 招待は `officeIds.length>=1` を必須に。
+5. **RESTRICTIVE 有効化**：1〜4完了を前提に people/person_documents の RESTRICTIVE と新テーブルRLSを有効化。
+- バックフィル不能なメンバーの扱い（暫定ブロック or 手動割当）を運用で決める。`applications` feature は既定 off で段階解放（検証#24）。
+
+## 9. 画面・UX（案内ベース）
+最初の画像イメージに沿い、**申請の流れ（今どのステップか）＋ 次にやること ＋ 各書類の状況** が視覚的に分かる案内型。企業/OP は同一ルートを role で出し分け。
+
+| # | 画面 | 対象 | ルート | 再利用/新規 |
+|---|------|------|--------|------------|
+| 1 | 案件ダッシュボード | 企業=自社 / OP=横断 | `/applications` | DataTable/カード＋Stepper 再利用 |
+| 2 | 案件詳細（流れ＋次にやること＋チェックリスト＋コメント） | 企業/OP | `/applications/[caseId]` | 新規レイアウト＋既存部品 |
+| 3 | 提出（Excel添付＋証明書アップロード） | 企業 | 2内インライン | `DocumentUploadCard`（owner を office/case へ一般化） |
+| 4 | 差戻し対応 | 企業 | `/applications/[caseId]?doc=<code>` | 新規（理由表示＋再アップ＋コメント） |
+| 5 | 案件作成 | OP | `/applications/new` | 新規（企業/office/分野/初回更新＋人材選択） |
+| 6 | レビュー（承認/差戻し/リマインド） | OP | `/applications/[caseId]?tab=review` | 新規操作UI＋既存Dialog/Toast |
+| 7 | kintone連携（抽出確認→書込→結果） | OP | `/applications/[caseId]?tab=kintone` | 新規パネル＋既存 api-client |
+
+- 提出は **Excel＋証明書ファイル**のみ（入力フォームは無し）。企業⇔OPの補足は **コメント**（画面2内スレッド）。
+- **リマインド**（検証#19）：**アプリ内通知＋任意でメール（進捗催促のみ）**。書類授受はポータル完結。宛先は office 割当ユーザー、多重送信抑止、テンプレを定義。メール送信は既存 `sendEmail` 再利用。
+- **再利用**：`document-upload-card`（owner一般化）/`data-table`/`page-header`/`stepper`/`deadline-chip`/`status-badge`/`dialog`/`filter-multi-select-popover`＋`result-count-badge`/`toaster`/`tabs`/`person-documents-tab` の `DOCUMENT_SECTIONS`。
+- **新規**：`app/applications/*`（一覧/詳細/new）、`ChecklistRow`/`ReviewActionBar`＋`RejectReasonDialog`/`RemindButton`/`KintoneSyncPanel`/`CaseCommentThread`/`CaseProgressHeader`、必要書類マトリクス resolver、レビュー状態 enum＋色関数。
+- **API**：`app/api/applications/...`（一覧/詳細/`members`/`documents/[code]`/`review`/`comments`/`kintone-sync`）。アクセスガードは office 境界を必ず通す。
+- サイドバー：`applications` エントリ（既定 off ゲート、§6.4#24）。既存 `/documents`（人材書類）とは別メニュー。
+
+## 10. 未確定・要確認事項
+1. **提出Excel → kintone のフィールドマッピング**：実ワークブックのどのセルを kintone のどのフィールド/アプリへ入れるか。`#REF!`/`#N/A` の扱い。＝v1のkintone連携の核。
+2. **取得書類8種の正式名称・コード・分野別の要否/原本写し/請求先**：業務側から受領しカタログ＆テンプレをシード。
+3. **`people.external_id` の中身**（kintone `$id` か業務管理番号か）と書込先 kintone アプリのID対応。
+4. **kintone OAuthクライアント側の write スコープ許可**（cybozu.com 設定）。
+5. **人材選択の基準**（案件へ紐付ける people を office 候補から手動選択で確定か）。
+6. **案件の全体ステータス語彙**（draft/collecting/…）を実運用フローで確定。
+
+## 11. 実装順序（目安）
+1. 移行（§8）：既定office生成→`people.tenant_office_id`追加＋バックフィル→メンバーoffice割当→招待officeId必須化。
+2. 新規テーブル群＋マスタ＋境界関数＋RLS（§5,§6）。people/person_documentsのRESTRICTIVE（FOR ALL）。
+3. マスタのシード（§10-2 確定後）。
+4. 案件作成フロー（§4）：`/applications/new`＋`POST /applications`＋`members`＋`materialize`（権限再検査つき）。
+5. `/applications` 画面・API・コメント・アップロード（§9）。`DocumentUploadCard` の owner 一般化。外部ユーザーの署名URLはサーバAPI経由（§6.3）。
+6. Excel パース → `case_data_extractions` → OP確認。
+7. kintone 書込（§7）：デデュープ＋UNIQUE→スコープ一本化＋write追加→callback upsert→再認可→`createKintoneClient`配線→専用前方ライタ＋方向分離。
+8. E2E（企業=自社のみ提出可 / 他社越境不可(SELECT/INSERT両方) / OP作成→レビュー→抽出確認→kintone反映）。

--- a/docs/superpowers/plans/2026-07-24-visa-portal-phase1-foundation.md
+++ b/docs/superpowers/plans/2026-07-24-visa-portal-phase1-foundation.md
@@ -1,0 +1,750 @@
+# ビザ申請ポータル ― フェーズ1（DB基盤・セキュリティ・移行）実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 受入企業向けビザ申請提出ポータルの土台となるDBスキーマ・office境界セキュリティ（RLS）・既存データ移行を、越境を許さない形で構築する。
+
+**Architecture:** 既存FunBase(Next.js14 + Supabase)にマイグレーションを追加。office境界を `people.tenant_office_id`(UUID) に一本化し、新規テーブル群に SECURITY DEFINER 関数ベースのコマンド別RLSを敷く。親子の tenant/office 整合は複合FKでDB強制。既存の受入企業ユーザーを締め出さないよう、RESTRICTIVE有効化の前にoffice割当をバックフィルする。
+
+**Tech Stack:** Supabase (PostgreSQL, RLS), supabase CLI 2.40.7, vitest, TypeScript。
+
+**このプランの位置づけ:** 全体は3フェーズ。**本書=フェーズ1（基盤）**。フェーズ2=ポータルUI・案件管理・チェックリスト・コメント・アップロード。フェーズ3=kintone書き込み・Excelパース。フェーズ1は他フェーズに依存せず単体で適用・検証できる。仕様書 `docs/specs/2026-07-24-visa-application-portal-design.md` の §5/§6/§8 に対応。
+
+**前提の設計判断（仕様§で確定済み）:**
+- office判定は `tenant_office_id`(UUID) に統一。`people.company` 文字列一致は使わない。
+- 取得書類カタログ/テンプレの「値」シード（8種の正式名称等）は §10-2 の業務確定待ちのため**フェーズ2で投入**。本フェーズは**テーブル作成のみ**。
+- RLS統合テストの専用ハーネスは本リポにないため、DB系タスクの検証は `supabase:reset`(適用) ＋ ロールを模したSQL問い合わせで行う。純ロジック（invite検証）は vitest。
+
+---
+
+## ファイル構成（作成/変更）
+
+**マイグレーション（新規, `supabase/migrations/`）:**
+- `20260724120000_portal_add_tenant_office_id.sql` — people/person_documents に `tenant_office_id` 追加、既定office生成、company→office バックフィル
+- `20260724120100_portal_security_functions.sql` — 境界判定 SECURITY DEFINER 関数4本
+- `20260724120200_portal_core_tables.sql` — 案件・メンバー・企業書類・チェックリスト・コメント・監査・抽出ステージングの各テーブル
+- `20260724120300_portal_master_tables.sql` — カタログ/テンプレ/明細（テーブルのみ、シードなし）
+- `20260724120400_portal_rls_new_tables.sql` — 新規テーブルのコマンド別RLS
+- `20260724120500_portal_restrict_people_documents.sql` — people/person_documents の RESTRICTIVE(FOR ALL) と backfill前提チェック
+- `20260724120600_portal_backfill_member_offices.sql` — 既存 member/guest の user_tenant_offices バックフィル
+
+**アプリコード（変更）:**
+- Modify: `app/api/tenants/[tenantId]/members/invite/route.ts` — member/guest 招待時 `officeIds` 必須化
+- Create: `__tests__/portal-invite-office-required.test.ts` — 上記バリデーションの単体テスト
+- Create: `lib/portal/invite-validation.ts` — 招待バリデーションの純関数（テスト可能に切り出し）
+
+---
+
+## Task 1: office境界キーの導入とバックフィル
+
+**Files:**
+- Create: `supabase/migrations/20260724120000_portal_add_tenant_office_id.sql`
+
+- [ ] **Step 1: マイグレーションを書く**
+
+`supabase/migrations/20260724120000_portal_add_tenant_office_id.sql`:
+
+```sql
+-- 1) tenant_offices を1つも持たないテナントに既定officeを生成（NOT NULL office前提を満たす）
+INSERT INTO public.tenant_offices (tenant_id, name, is_active)
+SELECT t.id, t.name, true
+FROM public.tenants t
+WHERE NOT EXISTS (SELECT 1 FROM public.tenant_offices o WHERE o.tenant_id = t.id);
+
+-- 2) people に office 参照列を追加（複合FKで同一テナント担保）
+ALTER TABLE public.people ADD COLUMN IF NOT EXISTS tenant_office_id uuid;
+ALTER TABLE public.people
+  ADD CONSTRAINT people_office_fk FOREIGN KEY (tenant_office_id, tenant_id)
+  REFERENCES public.tenant_offices(id, tenant_id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS idx_people_office ON public.people(tenant_office_id);
+
+-- 3) company 文字列 × office.name（trim小文字）で backfill。一致するものだけ埋める。
+UPDATE public.people p
+SET tenant_office_id = o.id
+FROM public.tenant_offices o
+WHERE o.tenant_id = p.tenant_id
+  AND p.tenant_office_id IS NULL
+  AND p.company IS NOT NULL
+  AND lower(btrim(o.name)) = lower(btrim(p.company));
+
+-- 4) 4-1) company が空/単一office運用の people は既定office（テナント唯一のoffice）に寄せる
+UPDATE public.people p
+SET tenant_office_id = o.id
+FROM public.tenant_offices o
+WHERE p.tenant_office_id IS NULL
+  AND o.tenant_id = p.tenant_id
+  AND (SELECT count(*) FROM public.tenant_offices o2 WHERE o2.tenant_id = p.tenant_id) = 1;
+
+-- 5) person_documents にも office を継承（RESTRICTIVE 判定用）
+ALTER TABLE public.person_documents ADD COLUMN IF NOT EXISTS tenant_office_id uuid;
+UPDATE public.person_documents pd
+SET tenant_office_id = p.tenant_office_id
+FROM public.people p
+WHERE pd.person_id = p.id AND pd.tenant_office_id IS NULL;
+CREATE INDEX IF NOT EXISTS idx_person_documents_office ON public.person_documents(tenant_office_id);
+
+-- 6) 未マッチ確認用ビュー（運用で手当てするため。0件が理想）
+CREATE OR REPLACE VIEW public.portal_people_without_office AS
+  SELECT id, tenant_id, company FROM public.people WHERE tenant_office_id IS NULL;
+```
+
+- [ ] **Step 2: 適用して成功を確認**
+
+Run: `npm run supabase:reset`
+Expected: 全マイグレーションがエラーなく適用され `Finished supabase db reset`。失敗時はSQL構文/FK名衝突を修正。
+
+- [ ] **Step 3: backfill結果を検証**
+
+Run:
+```bash
+npx supabase@2.40.7 db query "SELECT count(*) AS unmatched FROM public.portal_people_without_office;"
+```
+Expected: シードデータ上で `unmatched` が 0 または少数。0でなければ company/office名の不一致であり、運用で手当て対象（プラン上は許容、本番移行時に手動割当）。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add supabase/migrations/20260724120000_portal_add_tenant_office_id.sql
+git commit -m "feat(portal): add people.tenant_office_id and backfill office scope"
+```
+
+---
+
+## Task 2: 境界判定 SECURITY DEFINER 関数
+
+**Files:**
+- Create: `supabase/migrations/20260724120100_portal_security_functions.sql`
+
+- [ ] **Step 1: マイグレーションを書く**
+
+`supabase/migrations/20260724120100_portal_security_functions.sql`:
+
+```sql
+-- テナント全体アクセス（owner/admin/supporter）
+CREATE OR REPLACE FUNCTION public.portal_has_tenant_wide_access(p_tenant_id uuid)
+RETURNS boolean LANGUAGE sql SECURITY DEFINER STABLE SET search_path = public AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.user_tenants ut
+    WHERE ut.user_id = auth.uid() AND ut.tenant_id = p_tenant_id
+      AND ut.status = 'active' AND ut.role IN ('owner','admin','supporter'));
+$$;
+
+-- office境界。office∈tenant を必ず検証（越境防止）。割当なし=false（fail-closed）。
+CREATE OR REPLACE FUNCTION public.portal_can_access_office(p_tenant_id uuid, p_office_id uuid)
+RETURNS boolean LANGUAGE sql SECURITY DEFINER STABLE SET search_path = public AS $$
+  SELECT EXISTS (SELECT 1 FROM public.tenant_offices o
+           WHERE o.id = p_office_id AND o.tenant_id = p_tenant_id)
+    AND (public.portal_has_tenant_wide_access(p_tenant_id)
+      OR EXISTS (SELECT 1 FROM public.user_tenants ut
+          JOIN public.user_tenant_offices uto ON uto.user_tenant_id = ut.id
+          WHERE ut.user_id = auth.uid() AND ut.tenant_id = p_tenant_id
+            AND ut.status = 'active' AND uto.tenant_office_id = p_office_id));
+$$;
+
+-- 書き込み（承認等）: member 以上
+CREATE OR REPLACE FUNCTION public.portal_is_writer(p_tenant_id uuid)
+RETURNS boolean LANGUAGE sql SECURITY DEFINER STABLE SET search_path = public AS $$
+  SELECT EXISTS (SELECT 1 FROM public.user_tenants ut
+    WHERE ut.user_id = auth.uid() AND ut.tenant_id = p_tenant_id
+      AND ut.status = 'active' AND ut.role IN ('owner','admin','supporter','member'));
+$$;
+
+-- アップロード/コメント: guest も含む
+CREATE OR REPLACE FUNCTION public.portal_can_upload(p_tenant_id uuid)
+RETURNS boolean LANGUAGE sql SECURITY DEFINER STABLE SET search_path = public AS $$
+  SELECT EXISTS (SELECT 1 FROM public.user_tenants ut
+    WHERE ut.user_id = auth.uid() AND ut.tenant_id = p_tenant_id
+      AND ut.status = 'active' AND ut.role IN ('owner','admin','supporter','member','guest'));
+$$;
+
+REVOKE ALL ON FUNCTION public.portal_has_tenant_wide_access(uuid) FROM public;
+REVOKE ALL ON FUNCTION public.portal_can_access_office(uuid, uuid) FROM public;
+REVOKE ALL ON FUNCTION public.portal_is_writer(uuid) FROM public;
+REVOKE ALL ON FUNCTION public.portal_can_upload(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.portal_has_tenant_wide_access(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.portal_can_access_office(uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.portal_is_writer(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.portal_can_upload(uuid) TO authenticated;
+```
+
+- [ ] **Step 2: 適用して成功を確認**
+
+Run: `npm run supabase:reset`
+Expected: エラーなく適用。
+
+- [ ] **Step 3: 関数の健全性を検証（office∈tenant短絡の穴が無いこと）**
+
+Run:
+```bash
+npx supabase@2.40.7 db query "SELECT public.portal_can_access_office('00000000-0000-0000-0000-000000000000'::uuid, '00000000-0000-0000-0000-000000000001'::uuid) AS should_be_false;"
+```
+Expected: `should_be_false = f`（存在しない office/tenant で false。auth.uid() が NULL でも例外なく false）。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add supabase/migrations/20260724120100_portal_security_functions.sql
+git commit -m "feat(portal): add office-boundary security definer functions"
+```
+
+---
+
+## Task 3: 新規コアテーブル
+
+**Files:**
+- Create: `supabase/migrations/20260724120200_portal_core_tables.sql`
+
+- [ ] **Step 1: マイグレーションを書く**
+
+`supabase/migrations/20260724120200_portal_core_tables.sql`:
+
+```sql
+-- 案件
+CREATE TABLE public.visa_application_cases (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  tenant_office_id uuid NOT NULL,
+  entity_type text NOT NULL CHECK (entity_type IN ('corporate','sole_proprietor')),
+  application_category text NOT NULL CHECK (application_category IN ('initial','renewal')),
+  field text NOT NULL CHECK (field IN ('care','food_service','accommodation','food_manufacturing','other')),
+  application_type text CHECK (application_type IN ('認定申請','変更申請','更新申請','特定活動申請','資格変更（特定技能2号）')),
+  management_number text,
+  kintone_record_id text,
+  status text NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft','collecting','reviewing','ready','synced','completed','archived')),
+  title text, note text,
+  kintone_sync_status text, kintone_last_synced_at timestamptz,
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT vac_office_fk FOREIGN KEY (tenant_office_id, tenant_id)
+    REFERENCES public.tenant_offices(id, tenant_id) ON DELETE RESTRICT,
+  CONSTRAINT vac_id_tenant_office_uniq UNIQUE (id, tenant_id, tenant_office_id)
+);
+CREATE INDEX idx_vac_tenant ON public.visa_application_cases(tenant_id, tenant_office_id);
+CREATE INDEX idx_vac_status ON public.visa_application_cases(status);
+CREATE UNIQUE INDEX uq_vac_mgmt_no ON public.visa_application_cases(tenant_id, management_number) WHERE management_number IS NOT NULL;
+
+-- 案件×人材（1:N）。tenant/office を親caseと厳密一致
+CREATE TABLE public.visa_application_case_members (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id uuid NOT NULL, tenant_id uuid NOT NULL, tenant_office_id uuid NOT NULL,
+  person_id text NOT NULL REFERENCES public.people(id) ON DELETE CASCADE,
+  visa_id text REFERENCES public.visas(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT vacm_case_fk FOREIGN KEY (case_id, tenant_id, tenant_office_id)
+    REFERENCES public.visa_application_cases(id, tenant_id, tenant_office_id) ON DELETE CASCADE,
+  CONSTRAINT uq_case_person UNIQUE (case_id, person_id)
+);
+CREATE INDEX idx_vacm_person ON public.visa_application_case_members(person_id);
+CREATE INDEX idx_vacm_case ON public.visa_application_case_members(case_id);
+
+-- 企業/事業所単位の取得書類
+CREATE TABLE public.office_documents (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  tenant_office_id uuid NOT NULL,
+  document_code text NOT NULL, storage_path text NOT NULL,
+  file_name text, content_type text, file_size_bytes integer,
+  issued_on date, note text, uploaded_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT od_office_fk FOREIGN KEY (tenant_office_id, tenant_id)
+    REFERENCES public.tenant_offices(id, tenant_id) ON DELETE CASCADE,
+  CONSTRAINT uq_od_office_code UNIQUE (tenant_office_id, document_code)
+);
+CREATE INDEX idx_od_tenant ON public.office_documents(tenant_id, tenant_office_id);
+
+-- 必要書類チェックリスト
+CREATE TABLE public.case_document_requirements (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id uuid NOT NULL, tenant_id uuid NOT NULL, tenant_office_id uuid NOT NULL,
+  document_code text NOT NULL, name text NOT NULL,
+  scope text NOT NULL CHECK (scope IN ('office','person')),
+  person_id text REFERENCES public.people(id) ON DELETE CASCADE,
+  is_required boolean NOT NULL DEFAULT true,
+  copy_type text CHECK (copy_type IN ('original','copy')),
+  issuer text, validity_months integer, expires_on date,
+  status text NOT NULL DEFAULT 'not_submitted'
+    CHECK (status IN ('not_submitted','reviewing','approved','needs_fix')),
+  rejection_reason text,
+  office_document_id uuid REFERENCES public.office_documents(id) ON DELETE SET NULL,
+  person_document_id uuid REFERENCES public.person_documents(id) ON DELETE SET NULL,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT cdr_case_fk FOREIGN KEY (case_id, tenant_id, tenant_office_id)
+    REFERENCES public.visa_application_cases(id, tenant_id, tenant_office_id) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX uq_cdr_office ON public.case_document_requirements(case_id, document_code) WHERE person_id IS NULL;
+CREATE UNIQUE INDEX uq_cdr_person ON public.case_document_requirements(case_id, document_code, person_id) WHERE person_id IS NOT NULL;
+CREATE INDEX idx_cdr_case ON public.case_document_requirements(case_id);
+CREATE INDEX idx_cdr_status ON public.case_document_requirements(status);
+
+-- 案件コメント（メール置換）
+CREATE TABLE public.case_comments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id uuid NOT NULL, tenant_id uuid NOT NULL, tenant_office_id uuid NOT NULL,
+  requirement_id uuid REFERENCES public.case_document_requirements(id) ON DELETE SET NULL,
+  author uuid REFERENCES auth.users(id), body text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT cc_case_fk FOREIGN KEY (case_id, tenant_id, tenant_office_id)
+    REFERENCES public.visa_application_cases(id, tenant_id, tenant_office_id) ON DELETE CASCADE
+);
+CREATE INDEX idx_cc_case ON public.case_comments(case_id);
+
+-- 監査イベント
+CREATE TABLE public.case_document_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id uuid NOT NULL, tenant_id uuid NOT NULL, requirement_id uuid,
+  event_type text NOT NULL CHECK (event_type IN ('submitted','approved','rejected','reminded')),
+  actor uuid REFERENCES auth.users(id), comment text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_cde_case ON public.case_document_events(case_id);
+
+-- 抽出ステージング（フェーズ3で使用。テーブルは基盤として先に用意）
+CREATE TABLE public.case_data_extractions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id uuid NOT NULL, tenant_id uuid NOT NULL,
+  source text NOT NULL CHECK (source IN ('workbook','ocr')),
+  target_kind text NOT NULL CHECK (target_kind IN ('company','person')),
+  person_id text,
+  payload jsonb NOT NULL,
+  status text NOT NULL DEFAULT 'draft' CHECK (status IN ('draft','confirmed','synced','error')),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_cde_ext_case ON public.case_data_extractions(case_id);
+```
+
+- [ ] **Step 2: 適用して成功を確認**
+
+Run: `npm run supabase:reset`
+Expected: エラーなく適用。
+
+- [ ] **Step 3: 複合FKと部分ユニークが効くことを検証**
+
+Run:
+```bash
+npx supabase@2.40.7 db query "SELECT conname FROM pg_constraint WHERE conname IN ('vacm_case_fk','cdr_case_fk','vac_office_fk') ORDER BY conname;"
+npx supabase@2.40.7 db query "SELECT indexname FROM pg_indexes WHERE indexname IN ('uq_cdr_office','uq_cdr_person');"
+```
+Expected: 3つの複合FKと2つの部分ユニークindexが全て存在。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add supabase/migrations/20260724120200_portal_core_tables.sql
+git commit -m "feat(portal): add core tables (cases, members, docs, checklist, comments, events)"
+```
+
+---
+
+## Task 4: マスタ（カタログ/テンプレ）テーブル ※シードは含めない
+
+**Files:**
+- Create: `supabase/migrations/20260724120300_portal_master_tables.sql`
+
+- [ ] **Step 1: マイグレーションを書く**
+
+`supabase/migrations/20260724120300_portal_master_tables.sql`:
+
+```sql
+CREATE TABLE public.document_catalog (
+  code text PRIMARY KEY,
+  name text NOT NULL,
+  default_scope text NOT NULL CHECK (default_scope IN ('office','person')),
+  is_acquired_cert boolean NOT NULL DEFAULT false,
+  description text
+);
+
+CREATE TABLE public.document_requirement_templates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_type text NOT NULL CHECK (entity_type IN ('corporate','sole_proprietor')),
+  application_category text NOT NULL CHECK (application_category IN ('initial','renewal')),
+  field text NOT NULL CHECK (field IN ('care','food_service','accommodation','food_manufacturing','other')),
+  version integer NOT NULL DEFAULT 1,
+  is_active boolean NOT NULL DEFAULT true,
+  CONSTRAINT uq_template_key UNIQUE (entity_type, application_category, field)
+);
+
+CREATE TABLE public.document_requirement_template_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  template_id uuid NOT NULL REFERENCES public.document_requirement_templates(id) ON DELETE CASCADE,
+  document_code text NOT NULL REFERENCES public.document_catalog(code),
+  scope text NOT NULL CHECK (scope IN ('office','person')),
+  is_required boolean NOT NULL DEFAULT true,
+  copy_type text CHECK (copy_type IN ('original','copy')),
+  issuer text, validity_months integer,
+  sort_order integer NOT NULL DEFAULT 0,
+  CONSTRAINT uq_tpl_item UNIQUE (template_id, document_code, scope)
+);
+
+-- 参照はグローバル（テナント非依存）。変更は service_role のみ。
+ALTER TABLE public.document_catalog ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.document_requirement_templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.document_requirement_template_items ENABLE ROW LEVEL SECURITY;
+CREATE POLICY dc_read ON public.document_catalog FOR SELECT TO authenticated USING (true);
+CREATE POLICY drt_read ON public.document_requirement_templates FOR SELECT TO authenticated USING (true);
+CREATE POLICY drti_read ON public.document_requirement_template_items FOR SELECT TO authenticated USING (true);
+-- 変更ポリシーは作らない＝authenticatedからは書けない。service_role はRLSバイパス。
+```
+
+- [ ] **Step 2: 適用して成功を確認**
+
+Run: `npm run supabase:reset`
+Expected: エラーなく適用。
+
+- [ ] **Step 3: 読み取り専用が効くことを検証**
+
+Run:
+```bash
+npx supabase@2.40.7 db query "SELECT relrowsecurity FROM pg_class WHERE relname='document_catalog';"
+```
+Expected: `relrowsecurity = t`（RLS有効）。シード投入はフェーズ2（§10-2 確定後）。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add supabase/migrations/20260724120300_portal_master_tables.sql
+git commit -m "feat(portal): add document catalog and requirement template tables"
+```
+
+---
+
+## Task 5: 新規テーブルのRLS（コマンド別・最小権限）
+
+**Files:**
+- Create: `supabase/migrations/20260724120400_portal_rls_new_tables.sql`
+
+- [ ] **Step 1: マイグレーションを書く**
+
+`supabase/migrations/20260724120400_portal_rls_new_tables.sql`（`visa_application_cases` の4本を範に、6テーブルに適用）:
+
+```sql
+-- 共通ヘルパを使うマクロ的パターン。各テーブルに SELECT/INSERT/UPDATE/DELETE を貼る。
+-- === visa_application_cases ===
+ALTER TABLE public.visa_application_cases ENABLE ROW LEVEL SECURITY;
+CREATE POLICY vac_select ON public.visa_application_cases FOR SELECT TO authenticated
+  USING (portal_can_access_office(tenant_id, tenant_office_id));
+CREATE POLICY vac_insert ON public.visa_application_cases FOR INSERT TO authenticated
+  WITH CHECK (portal_can_access_office(tenant_id, tenant_office_id) AND portal_is_writer(tenant_id));
+CREATE POLICY vac_update ON public.visa_application_cases FOR UPDATE TO authenticated
+  USING (portal_can_access_office(tenant_id, tenant_office_id) AND portal_is_writer(tenant_id))
+  WITH CHECK (portal_can_access_office(tenant_id, tenant_office_id) AND portal_is_writer(tenant_id));
+CREATE POLICY vac_delete ON public.visa_application_cases FOR DELETE TO authenticated
+  USING (portal_has_tenant_wide_access(tenant_id));
+
+-- === visa_application_case_members ===
+ALTER TABLE public.visa_application_case_members ENABLE ROW LEVEL SECURITY;
+CREATE POLICY vacm_select ON public.visa_application_case_members FOR SELECT TO authenticated
+  USING (portal_can_access_office(tenant_id, tenant_office_id));
+CREATE POLICY vacm_insert ON public.visa_application_case_members FOR INSERT TO authenticated
+  WITH CHECK (portal_can_access_office(tenant_id, tenant_office_id) AND portal_is_writer(tenant_id));
+CREATE POLICY vacm_update ON public.visa_application_case_members FOR UPDATE TO authenticated
+  USING (portal_can_access_office(tenant_id, tenant_office_id) AND portal_is_writer(tenant_id))
+  WITH CHECK (portal_can_access_office(tenant_id, tenant_office_id) AND portal_is_writer(tenant_id));
+CREATE POLICY vacm_delete ON public.visa_application_case_members FOR DELETE TO authenticated
+  USING (portal_has_tenant_wide_access(tenant_id));
+
+-- === office_documents（INSERTはguest可＝portal_can_upload）===
+ALTER TABLE public.office_documents ENABLE ROW LEVEL SECURITY;
+CREATE POLICY od_select ON public.office_documents FOR SELECT TO authenticated
+  USING (portal_can_access_office(tenant_id, tenant_office_id));
+CREATE POLICY od_insert ON public.office_documents FOR INSERT TO authenticated
+  WITH CHECK (portal_can_access_office(tenant_id, tenant_office_id)
+             AND portal_can_upload(tenant_id)
+             AND uploaded_by = (SELECT auth.uid()));
+CREATE POLICY od_update ON public.office_documents FOR UPDATE TO authenticated
+  USING (portal_can_access_office(tenant_id, tenant_office_id) AND portal_can_upload(tenant_id))
+  WITH CHECK (portal_can_access_office(tenant_id, tenant_office_id) AND portal_can_upload(tenant_id));
+CREATE POLICY od_delete ON public.office_documents FOR DELETE TO authenticated
+  USING (portal_has_tenant_wide_access(tenant_id));
+
+-- === case_document_requirements（確定/承認はwriter）===
+ALTER TABLE public.case_document_requirements ENABLE ROW LEVEL SECURITY;
+CREATE POLICY cdr_select ON public.case_document_requirements FOR SELECT TO authenticated
+  USING (portal_can_access_office(tenant_id, tenant_office_id));
+CREATE POLICY cdr_insert ON public.case_document_requirements FOR INSERT TO authenticated
+  WITH CHECK (portal_can_access_office(tenant_id, tenant_office_id) AND portal_is_writer(tenant_id));
+CREATE POLICY cdr_update ON public.case_document_requirements FOR UPDATE TO authenticated
+  USING (portal_can_access_office(tenant_id, tenant_office_id) AND portal_is_writer(tenant_id))
+  WITH CHECK (portal_can_access_office(tenant_id, tenant_office_id) AND portal_is_writer(tenant_id));
+CREATE POLICY cdr_delete ON public.case_document_requirements FOR DELETE TO authenticated
+  USING (portal_has_tenant_wide_access(tenant_id));
+
+-- === case_comments（企業もコメント可＝portal_can_upload）===
+ALTER TABLE public.case_comments ENABLE ROW LEVEL SECURITY;
+CREATE POLICY cc_select ON public.case_comments FOR SELECT TO authenticated
+  USING (portal_can_access_office(tenant_id, tenant_office_id));
+CREATE POLICY cc_insert ON public.case_comments FOR INSERT TO authenticated
+  WITH CHECK (portal_can_access_office(tenant_id, tenant_office_id)
+             AND portal_can_upload(tenant_id)
+             AND author = (SELECT auth.uid()));
+CREATE POLICY cc_delete ON public.case_comments FOR DELETE TO authenticated
+  USING (portal_has_tenant_wide_access(tenant_id));
+
+-- === case_data_extractions（社内のみ: 抽出はサーバ/社内処理）===
+ALTER TABLE public.case_data_extractions ENABLE ROW LEVEL SECURITY;
+CREATE POLICY cde_ext_select ON public.case_data_extractions FOR SELECT TO authenticated
+  USING (portal_has_tenant_wide_access(tenant_id));
+CREATE POLICY cde_ext_write ON public.case_data_extractions FOR ALL TO authenticated
+  USING (portal_has_tenant_wide_access(tenant_id))
+  WITH CHECK (portal_has_tenant_wide_access(tenant_id));
+
+-- === case_document_events（読取=office境界, 追記=writer, 変更/削除なし）===
+ALTER TABLE public.case_document_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY cde_select ON public.case_document_events FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.visa_application_cases c
+    WHERE c.id = case_document_events.case_id
+      AND portal_can_access_office(c.tenant_id, c.tenant_office_id)));
+CREATE POLICY cde_insert ON public.case_document_events FOR INSERT TO authenticated
+  WITH CHECK (portal_is_writer(tenant_id) AND actor = (SELECT auth.uid()));
+```
+
+- [ ] **Step 2: 適用して成功を確認**
+
+Run: `npm run supabase:reset`
+Expected: エラーなく適用。
+
+- [ ] **Step 3: 全新規テーブルでRLS有効かつポリシーが存在することを検証**
+
+Run:
+```bash
+npx supabase@2.40.7 db query "SELECT tablename, count(*) FROM pg_policies WHERE tablename IN ('visa_application_cases','visa_application_case_members','office_documents','case_document_requirements','case_comments','case_document_events','case_data_extractions') GROUP BY tablename ORDER BY tablename;"
+```
+Expected: 7テーブルすべてが1件以上のポリシーを持つ（cases/members/cdr=4本, office_documents=4本, comments=3本, events=2本, extractions=2本）。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add supabase/migrations/20260724120400_portal_rls_new_tables.sql
+git commit -m "feat(portal): command-scoped RLS on new portal tables"
+```
+
+---
+
+## Task 6: 既存 people / person_documents を RESTRICTIVE で締める
+
+**Files:**
+- Create: `supabase/migrations/20260724120500_portal_restrict_people_documents.sql`
+
+> **重要な順序:** この RESTRICTIVE は Task 1（office backfill）と Task 7（メンバーoffice割当）が完了した後にのみ有効化する。未割当メンバーが締め出されるため、reset時は同一マイグレーション列で Task 1 が先に走る（timestampが小さい）ので満たされる。本番はバックフィル完了を確認してから適用。
+
+- [ ] **Step 1: マイグレーションを書く**
+
+`supabase/migrations/20260724120500_portal_restrict_people_documents.sql`:
+
+```sql
+-- people: 既存の permissive tenant ポリシーはそのまま。RESTRICTIVE を AND 合成して office 境界を追加。
+-- owner/admin/supporter は tenant-wide で素通り。member/guest は自 office のみ。
+CREATE POLICY people_office_boundary ON public.people AS RESTRICTIVE FOR ALL TO authenticated
+  USING (
+    portal_has_tenant_wide_access(tenant_id)
+    OR (tenant_office_id IS NOT NULL AND portal_can_access_office(tenant_id, tenant_office_id))
+  );
+
+-- person_documents: 同型（tenant_office_id は Task1 で付与済み）
+CREATE POLICY person_documents_office_boundary ON public.person_documents AS RESTRICTIVE FOR ALL TO authenticated
+  USING (
+    portal_has_tenant_wide_access(tenant_id)
+    OR (tenant_office_id IS NOT NULL AND portal_can_access_office(tenant_id, tenant_office_id))
+  );
+```
+
+- [ ] **Step 2: 適用して成功を確認**
+
+Run: `npm run supabase:reset`
+Expected: エラーなく適用。
+
+- [ ] **Step 3: RESTRICTIVE が FOR ALL で入っていることを検証**
+
+Run:
+```bash
+npx supabase@2.40.7 db query "SELECT polname, polpermissive, polcmd FROM pg_policy WHERE polname IN ('people_office_boundary','person_documents_office_boundary');"
+```
+Expected: 両ポリシーとも `polpermissive = f`（RESTRICTIVE）かつ `polcmd = *`（ALL）。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add supabase/migrations/20260724120500_portal_restrict_people_documents.sql
+git commit -m "feat(portal): restrict people and person_documents to office boundary"
+```
+
+---
+
+## Task 7: 既存 member/guest の office 割当バックフィル
+
+**Files:**
+- Create: `supabase/migrations/20260724120600_portal_backfill_member_offices.sql`
+
+- [ ] **Step 1: マイグレーションを書く**
+
+`supabase/migrations/20260724120600_portal_backfill_member_offices.sql`:
+
+```sql
+-- 既存の active な member/guest で office 未割当の user_tenant を、
+-- そのテナントに office が1つだけなら自動割当。複数officeのテナントは手動割当対象（下のビューで可視化）。
+INSERT INTO public.user_tenant_offices (user_tenant_id, tenant_office_id)
+SELECT ut.id, o.id
+FROM public.user_tenants ut
+JOIN public.tenant_offices o ON o.tenant_id = ut.tenant_id
+WHERE ut.role IN ('member','guest') AND ut.status = 'active'
+  AND NOT EXISTS (SELECT 1 FROM public.user_tenant_offices x WHERE x.user_tenant_id = ut.id)
+  AND (SELECT count(*) FROM public.tenant_offices o2 WHERE o2.tenant_id = ut.tenant_id) = 1
+ON CONFLICT DO NOTHING;
+
+-- 手動割当が必要な（複数office持ちテナントの未割当）member/guest を可視化
+CREATE OR REPLACE VIEW public.portal_members_without_office AS
+  SELECT ut.id AS user_tenant_id, ut.user_id, ut.tenant_id, ut.role
+  FROM public.user_tenants ut
+  WHERE ut.role IN ('member','guest') AND ut.status = 'active'
+    AND NOT EXISTS (SELECT 1 FROM public.user_tenant_offices x WHERE x.user_tenant_id = ut.id);
+```
+
+- [ ] **Step 2: 適用して成功を確認**
+
+Run: `npm run supabase:reset`
+Expected: エラーなく適用。
+
+- [ ] **Step 3: 未割当メンバーが可視化されることを検証**
+
+Run:
+```bash
+npx supabase@2.40.7 db query "SELECT count(*) AS need_manual_office FROM public.portal_members_without_office;"
+```
+Expected: `need_manual_office` が確認できる（本番移行時、0になるまで手動割当してから Task 6 の RESTRICTIVE を本番適用する運用）。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add supabase/migrations/20260724120600_portal_backfill_member_offices.sql
+git commit -m "feat(portal): backfill office assignment for existing members"
+```
+
+---
+
+## Task 8: 招待APIの officeId 必須化（純関数＋テスト＋配線）
+
+**Files:**
+- Create: `lib/portal/invite-validation.ts`
+- Create: `__tests__/portal-invite-office-required.test.ts`
+- Modify: `app/api/tenants/[tenantId]/members/invite/route.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`__tests__/portal-invite-office-required.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { validateInviteOffices } from '@/lib/portal/invite-validation'
+
+describe('validateInviteOffices', () => {
+  it('member/guest は officeIds が空だとエラー', () => {
+    expect(validateInviteOffices('member', [])).toEqual({ ok: false, error: 'officeIds required for member/guest' })
+    expect(validateInviteOffices('guest', undefined)).toEqual({ ok: false, error: 'officeIds required for member/guest' })
+  })
+  it('member/guest は officeIds があればOK', () => {
+    expect(validateInviteOffices('member', ['11111111-1111-1111-1111-111111111111'])).toEqual({ ok: true })
+  })
+  it('owner/admin は officeIds 不要', () => {
+    expect(validateInviteOffices('admin', [])).toEqual({ ok: true })
+    expect(validateInviteOffices('owner', undefined)).toEqual({ ok: true })
+  })
+})
+```
+
+- [ ] **Step 2: テストが落ちることを確認**
+
+Run: `npm test -- portal-invite-office-required`
+Expected: FAIL（`validateInviteOffices` が未定義でモジュール解決エラー）。
+
+- [ ] **Step 3: 純関数を実装**
+
+`lib/portal/invite-validation.ts`:
+
+```ts
+export type InviteRole = 'owner' | 'admin' | 'member' | 'guest' | 'supporter'
+
+export function validateInviteOffices(
+  role: InviteRole,
+  officeIds: string[] | undefined | null,
+): { ok: true } | { ok: false; error: string } {
+  const needsOffice = role === 'member' || role === 'guest'
+  if (needsOffice && (!officeIds || officeIds.length === 0)) {
+    return { ok: false, error: 'officeIds required for member/guest' }
+  }
+  return { ok: true }
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `npm test -- portal-invite-office-required`
+Expected: PASS（3 tests）。
+
+- [ ] **Step 5: 招待ルートに配線**
+
+`app/api/tenants/[tenantId]/members/invite/route.ts` の、role と officeIds を読み取った直後（既存の officeIds 実在チェックの前）に挿入:
+
+```ts
+import { validateInviteOffices } from '@/lib/portal/invite-validation'
+// ... role, officeIds を取得した後:
+const officeCheck = validateInviteOffices(role, officeIds)
+if (!officeCheck.ok) {
+  return NextResponse.json({ error: officeCheck.error }, { status: 400 })
+}
+```
+
+- [ ] **Step 6: 型チェック**
+
+Run: `npm run typecheck`
+Expected: エラーなし（既存の `NextResponse` import を利用。無ければ既存の返却パターンに合わせる）。
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add lib/portal/invite-validation.ts __tests__/portal-invite-office-required.test.ts app/api/tenants/[tenantId]/members/invite/route.ts
+git commit -m "feat(portal): require officeIds when inviting member/guest"
+```
+
+---
+
+## Task 9: フェーズ1の総合検証
+
+**Files:** なし（検証のみ）
+
+- [ ] **Step 1: クリーン適用**
+
+Run: `npm run supabase:reset`
+Expected: 全84+マイグレーションがエラーなく適用。
+
+- [ ] **Step 2: 型チェックとテスト**
+
+Run: `npm run typecheck && npm test`
+Expected: typecheck エラーなし、vitest 全green（既存＋新規invite）。
+
+- [ ] **Step 3: 越境の要ケースをSQLで確認（手動RLSチェック）**
+
+`supabase/README` の手順でローカル起動し、Supabase Studio かサービスロールSQLで、テストユーザー2名（別テナント/別office）を作り、`set request.jwt.claims` を切り替えて `visa_application_cases` を跨いで SELECT/INSERT できないことを確認する。最低限、次を確認:
+- office未割当の member は people を1件も取得できない（RESTRICTIVE fail-closed）。
+- テナントAのユーザーが tenant_id=B の case を INSERT できない（複合FK＋RLSで拒否）。
+
+Expected: いずれも拒否/空。詳細な自動RLSテストはフェーズ2でハーネスを整備する（本フェーズでは手動確認）。
+
+- [ ] **Step 4: 最終コミット（必要なら）**
+
+```bash
+git add -A && git commit -m "chore(portal): phase1 foundation verified" --allow-empty
+```
+
+---
+
+## Self-Review（記入済み）
+
+- **Spec coverage:** §5.2(office一本化=Task1)/§5.3(コアテーブル=Task3)/§5.5(マスタ=Task4)/§6.1(関数=Task2)/§6.2(新表RLS=Task5)/§6.3(RESTRICTIVE=Task6)/§8(移行・招待=Task1,7,8) を網羅。§7(kintone)・§9(UI)・カタログのシード値(§10-2依存)は**フェーズ2/3**（スコープ外を明記）。
+- **Placeholder scan:** カタログの「値」シードは §10-2 業務確定待ちで意図的にフェーズ2送り（プラン内プレースホルダではなく外部依存）。それ以外に TBD/未定義参照なし。
+- **Type consistency:** 関数名 `portal_can_access_office`/`portal_has_tenant_wide_access`/`portal_is_writer`/`portal_can_upload` は Task2 定義を Task5/6 で一貫使用。テーブル/カラム名は Task3 定義と後続で一致。`validateInviteOffices` の戻り型は Task8 内で一貫。
+
+## 既知の限界・後続フェーズへの申し送り
+- RLSの自動統合テスト基盤が本リポに無いため、フェーズ1は手動SQL検証。**フェーズ2でロール別RLSテストハーネス（`set local role` / JWTクレーム切替のvitest統合）を整備**する。
+- 人材書類ファイル本体のoffice保護は「外部ユーザーの署名URLをサーバAPI経由に限定」で実現する方針（仕様§6.3）。このサーバAPIは**フェーズ2**で実装。
+- `materialize_case_requirements` RPC（権限再検査つき）は案件作成フローの一部として**フェーズ2**で実装。

--- a/docs/superpowers/plans/2026-07-24-visa-portal-phase2-portal-ui.md
+++ b/docs/superpowers/plans/2026-07-24-visa-portal-phase2-portal-ui.md
@@ -1,0 +1,204 @@
+# ビザ申請ポータル ― フェーズ2（ポータルUI・案件作成・チェックリスト）実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or executing-plans。checkbox（`- [ ]`）で進捗管理。
+
+**Goal:** OP（supporter）が案件を作成し、必要書類チェックリストが自動生成され、後から人材を追加すると個人書類が増える——という「触れる縦スライス」を FunBase 上に実装する。
+
+**Architecture:** フェーズ1のスキーマ（`visa_application_cases` ほか）の上に、(1) 仮の書類カタログ/テンプレのシード＋`materialize_case_requirements` RPC（SECURITY DEFINER・権限再検査）を1マイグレーションで追加、(2) Next.js14 App Router の画面3つ（一覧/新規/詳細）＋API、を追加する。office境界はフェーズ1のRLSとRPC内再検査で担保。
+
+**Tech Stack:** Next.js 14 (App Router), TypeScript, Supabase SSR (@supabase/ssr), Tailwind v4, shadcn/ui, vitest。
+
+**前提/方針（確定済み）:**
+- 人材選択＝**案件作成時は選ばない。詳細画面で後から追加**（追加時に個人書類を追補）。
+- 書類カタログ＝**仮の標準セット**（本計画で投入、`is_provisional` 扱い。正式8書類は後日差し替え）。
+- ブランチ＝`claude/visa-portal-phase2`（fun-base本体・supabaseサブモジュール両方、`claude/visa-portal-phase1` から分岐）。
+- **file-generation-only**：`supabase:reset` は実行しない。DB適用は稼働中DBへ別途（docker exec）。検証は `typecheck`＋`vitest`＋開発サーバのライブ確認。
+
+**既存パターン厳守（実装前に必ず読む）:**
+- APIルート例：`app/api/tenants/[tenantId]/members/invite/route.ts`（サーバSupabaseクライアント・認可の型）
+- データアクセス層：`lib/supabase/*`（people/visas の read パターン）
+- 一覧画面：`app/people/`（DataTable・PageHeader・フィルタの使い方）
+- サーバ/クライアント分離、認証ガード：`lib/security/*`、`middleware.ts`
+- UI部品：`components/ui/*`（button/card/badge/dialog/table/tabs/select）、`components/layout/*`（sidebar）
+
+---
+
+## ファイル構成
+
+**マイグレーション（submodule `supabase/migrations/`）:**
+- `20260724130000_portal_seed_and_materialize.sql` — 仮カタログ＋テンプレ＋テンプレ明細のシード、`materialize_case_requirements(uuid)` RPC
+
+**アプリ（fun-base）:**
+- `lib/portal/types.ts` — 案件/要件/メンバーの型
+- `lib/portal/applications.ts` — データアクセス（list/get/create/addMember、サーバクライアント使用）
+- `lib/portal/requirements.ts` — チェックリスト取得＋office/person グループ化
+- `app/api/applications/route.ts` — `GET`（一覧）/`POST`（作成→materialize呼び出し）
+- `app/api/applications/[caseId]/route.ts` — `GET`（詳細＋要件＋メンバー）
+- `app/api/applications/[caseId]/members/route.ts` — `POST`（人材追加→materialize再実行）
+- `app/applications/page.tsx` — 一覧＋「新規案件」
+- `app/applications/new/page.tsx` — 作成フォーム
+- `app/applications/[caseId]/page.tsx` — 詳細（流れヘッダ＋チェックリスト＋メンバー追加）
+- `components/portal/*` — `CaseProgressHeader` / `ChecklistTable` / `NewCaseForm` / `AddMembersDialog`
+- サイドバー：`components/layout/`（該当ファイル）に「申請ポータル」= `/applications` を追加
+- テスト：`__tests__/portal-materialize.test.ts`（要件グループ化ロジック）、`__tests__/portal-create-case-validation.test.ts`（作成バリデーション純関数）
+
+---
+
+## Task 1: 仮カタログ＋テンプレ＋materialize RPC（マイグレーション）
+
+**Files:** Create `supabase/migrations/20260724130000_portal_seed_and_materialize.sql`
+
+- [ ] **Step 1: マイグレーションを書く**
+
+```sql
+-- ===== 仮カタログ（provisional）=====
+INSERT INTO public.document_catalog (code, name, default_scope, is_acquired_cert, description) VALUES
+  ('company_registry',       '登記事項証明書',                 'office', true,  '法人の登記事項証明書（発行3ヶ月以内）'),
+  ('tax_payment_cert',       '納税証明書',                     'office', true,  '法人/個人事業主の納税証明書'),
+  ('financial_statements',   '決算文書（貸借対照表・損益計算書）', 'office', false, '直近年度の決算書'),
+  ('labor_insurance_cert',   '労働保険料納付証明書',           'office', true,  NULL),
+  ('social_insurance_cert',  '社会保険料納入証明書',           'office', true,  NULL),
+  ('company_overview',       '会社案内・事業内容資料',         'office', false, NULL),
+  ('wage_ledger',            '賃金台帳',                       'office', false, NULL),
+  ('application_workbook',   '申請書類作成フォーム（Excel）',   'office', false, '会社が記入して提出するExcel'),
+  ('residence_card',         '在留カードの写し',               'person', false, NULL),
+  ('passport_copy',          'パスポートの写し',               'person', false, NULL),
+  ('employment_contract',    '特定技能雇用契約書',             'person', false, NULL),
+  ('employment_conditions',  '雇用条件書',                     'person', false, NULL),
+  ('health_checkup',         '健康診断個人票',                 'person', false, NULL),
+  ('skill_test_cert',        '技能試験合格証',                 'person', false, NULL),
+  ('jlpt_cert',              '日本語試験合格証',               'person', false, NULL)
+ON CONFLICT (code) DO NOTHING;
+
+-- ===== テンプレ（全 entity×category×field。仮運用のため共通明細を全テンプレに付与）=====
+INSERT INTO public.document_requirement_templates (entity_type, application_category, field)
+SELECT e, c, f
+FROM unnest(ARRAY['corporate','sole_proprietor']) e
+CROSS JOIN unnest(ARRAY['initial','renewal']) c
+CROSS JOIN unnest(ARRAY['care','food_service','accommodation','food_manufacturing','other']) f
+ON CONFLICT (entity_type, application_category, field) DO NOTHING;
+
+-- 共通明細（office項目 / person項目）。全テンプレに同一セットを付与（仮）。
+WITH office_items(code, req, copyt, sort) AS (VALUES
+  ('company_registry', true, 'original', 10),
+  ('tax_payment_cert', true, 'original', 20),
+  ('financial_statements', true, 'copy', 30),
+  ('labor_insurance_cert', true, 'copy', 40),
+  ('social_insurance_cert', true, 'copy', 50),
+  ('company_overview', false, 'copy', 60),
+  ('wage_ledger', false, 'copy', 70),
+  ('application_workbook', true, 'copy', 80)
+), person_items(code, req, copyt, sort) AS (VALUES
+  ('residence_card', true, 'copy', 110),
+  ('passport_copy', true, 'copy', 120),
+  ('employment_contract', true, 'original', 130),
+  ('employment_conditions', true, 'original', 140),
+  ('health_checkup', true, 'copy', 150),
+  ('skill_test_cert', false, 'copy', 160),
+  ('jlpt_cert', false, 'copy', 170)
+)
+INSERT INTO public.document_requirement_template_items (template_id, document_code, scope, is_required, copy_type, sort_order)
+SELECT t.id, oi.code, 'office', oi.req, oi.copyt, oi.sort FROM public.document_requirement_templates t CROSS JOIN office_items oi
+ON CONFLICT (template_id, document_code, scope) DO NOTHING;
+INSERT INTO public.document_requirement_template_items (template_id, document_code, scope, is_required, copy_type, sort_order)
+SELECT t.id, pi.code, 'person', pi.req, pi.copyt, pi.sort FROM public.document_requirement_templates t CROSS JOIN person_items pi
+ON CONFLICT (template_id, document_code, scope) DO NOTHING;
+
+-- ===== materialize RPC（SECURITY DEFINER・権限再検査・冪等）=====
+CREATE OR REPLACE FUNCTION public.materialize_case_requirements(p_case_id uuid)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_tenant uuid; v_office uuid; v_entity text; v_cat text; v_field text;
+BEGIN
+  SELECT tenant_id, tenant_office_id, entity_type, application_category, field
+    INTO v_tenant, v_office, v_entity, v_cat, v_field
+    FROM public.visa_application_cases WHERE id = p_case_id;
+  IF v_tenant IS NULL THEN RAISE EXCEPTION 'case not found'; END IF;
+  IF NOT public.portal_can_access_office(v_tenant, v_office) THEN
+    RAISE EXCEPTION 'not authorized for this office';
+  END IF;
+  -- office項目（case毎に1件、person_id NULL）
+  INSERT INTO public.case_document_requirements
+    (case_id, tenant_id, tenant_office_id, document_code, name, scope, is_required, copy_type, issuer, validity_months, sort_order)
+  SELECT p_case_id, v_tenant, v_office, i.document_code, dc.name, 'office', i.is_required, i.copy_type, i.issuer, i.validity_months, i.sort_order
+  FROM public.document_requirement_templates t
+  JOIN public.document_requirement_template_items i ON i.template_id = t.id AND i.scope='office'
+  JOIN public.document_catalog dc ON dc.code = i.document_code
+  WHERE t.entity_type=v_entity AND t.application_category=v_cat AND t.field=v_field AND t.is_active
+  ON CONFLICT DO NOTHING;
+  -- person項目（メンバー×person明細）
+  INSERT INTO public.case_document_requirements
+    (case_id, tenant_id, tenant_office_id, document_code, name, scope, person_id, is_required, copy_type, issuer, validity_months, sort_order)
+  SELECT p_case_id, v_tenant, v_office, i.document_code, dc.name, 'person', m.person_id, i.is_required, i.copy_type, i.issuer, i.validity_months, i.sort_order
+  FROM public.visa_application_case_members m
+  JOIN public.document_requirement_templates t ON t.entity_type=v_entity AND t.application_category=v_cat AND t.field=v_field AND t.is_active
+  JOIN public.document_requirement_template_items i ON i.template_id=t.id AND i.scope='person'
+  JOIN public.document_catalog dc ON dc.code=i.document_code
+  WHERE m.case_id = p_case_id
+  ON CONFLICT DO NOTHING;
+END; $$;
+REVOKE ALL ON FUNCTION public.materialize_case_requirements(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.materialize_case_requirements(uuid) TO authenticated;
+```
+
+- [ ] **Step 2**: 稼働中ローカルDBに適用（`docker exec -i supabase_db_fun-studio-v0 psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < 該当ファイル`）。エラーなしを確認。
+- [ ] **Step 3**: `SELECT count(*) FROM document_catalog;`（=15）、`SELECT count(*) FROM document_requirement_templates;`（=20）、`document_requirement_template_items`（=20×15=300）を確認。
+- [ ] **Step 4**: サブモジュールでコミット。
+
+## Task 2: 作成バリデーション純関数＋テスト（TDD）
+
+**Files:** Create `lib/portal/case-validation.ts`, `__tests__/portal-create-case-validation.test.ts`
+
+- [ ] テスト先行：`validateNewCase({tenant_office_id, entity_type, application_category, field})` が必須欠落・enum外を弾き、正常入力で `{ok:true}`。
+- [ ] 実装：enumチェック（entity_type∈corporate/sole_proprietor、category∈initial/renewal、field∈5値、office必須）。
+- [ ] `npm test -- portal-create-case-validation` green。
+
+## Task 3: データアクセス層＋型
+
+**Files:** `lib/portal/types.ts`, `lib/portal/applications.ts`, `lib/portal/requirements.ts`
+
+- [ ] 既存 `lib/supabase/*` のサーバクライアント生成に倣う（ユーザーセッション・RLS適用）。
+- [ ] `listCases()`／`getCase(caseId)`（案件＋メンバー＋people表示名）／`createCase(input)`（insert→`rpc('materialize_case_requirements')`）／`addMember(caseId, personId, visaId?)`（insert→rpc再実行）。
+- [ ] `getRequirements(caseId)`：`case_document_requirements` を取得し office/person（person_id別）でグループ化。
+- [ ] 型はスキーマに一致（status enum・scope・copy_type）。
+
+## Task 4: API ルート
+
+**Files:** `app/api/applications/route.ts`, `app/api/applications/[caseId]/route.ts`, `app/api/applications/[caseId]/members/route.ts`
+
+- [ ] `POST /api/applications`：認証必須。`validateNewCase`→`createCase`。作成者=`auth.uid()`。RLS違反/未認可は403/400。
+- [ ] `GET /api/applications`：自分がアクセス可能な案件（RLSが自動で絞る）。
+- [ ] `GET /api/applications/[caseId]`：案件＋要件（グループ化）＋メンバー。
+- [ ] `POST /api/applications/[caseId]/members`：`person_id`（＋任意`visa_id`）で追加→materialize再実行→更新後の要件を返す。
+- [ ] 既存 invite ルートの認可・エラー返却パターンに合わせる。
+
+## Task 5: 画面（一覧・新規・詳細）
+
+**Files:** `app/applications/page.tsx`, `app/applications/new/page.tsx`, `app/applications/[caseId]/page.tsx`, `components/portal/*`
+
+- [ ] 一覧：案件カード/テーブル（会社・事業所・分野・初回/更新・ステータス）＋「新規案件」ボタン。空状態あり。
+- [ ] 新規：フォーム（事業所select＝アクセス可能なtenant_offices、entity_type、initial/renewal、field、任意の管理番号/タイトル）。送信→作成→詳細へ遷移。
+- [ ] 詳細：
+  - `CaseProgressHeader`：申請の流れ（draft→collecting→reviewing→ready→…）を Stepper 風に。
+  - `ChecklistTable`：office項目と person項目（人材ごとにグルーピング）を表示（書類名・必須/任意・原本/写し・ステータスbadge）。まだ未提出（`not_submitted`）で表示。
+  - 「人材を追加」ボタン（`AddMembersDialog`：事業所の people から選択）→追加すると person 書類行が増える。
+- [ ] shadcn/ui 部品を使用。日本語ラベル。やさしい表現。
+- [ ] サイドバーに「申請ポータル」= `/applications` を追加。
+
+## Task 6: ライブ検証（開発サーバ）
+
+- [ ] `typecheck` green（新規/変更ファイルに型エラーなし）、`npm test` の新規テスト green。
+- [ ] 開発サーバ（既に起動中 http://localhost:3000）で：案件作成→一覧表示→詳細でofficeチェックリスト表示→人材追加→person書類が増える、を実機確認（スクリーンショット）。
+- [ ] office境界：別officeの案件が見えないこと（RLS）をログイン後に確認（可能なら）。
+
+---
+
+## Self-Review 観点
+- スキーマ整合：INSERT列・enum・複合キーがフェーズ1定義と一致。RPCの ON CONFLICT が partial unique（uq_cdr_office/uq_cdr_person）で冪等。
+- 認可：API・RPCともユーザーセッションで動き、`portal_can_access_office` が効く（サービスロール直叩きで境界を迂回しない）。
+- No placeholder：カタログは「仮」だが具体値入り（正式版差し替えは別タスク）。
+- 既存パターン踏襲：APIの認可・返却、データアクセスのクライアント生成、UI部品。
+
+## 後続（フェーズ2の残り／フェーズ3）
+- 書類アップロード（`office_documents`/`person_documents`＋Storage署名URLをサーバAPI経由）、コメント（`case_comments`）、レビュー承認/差戻し＋リマインド。
+- 正式な8書類への差し替え（§10-2）。
+- フェーズ3：kintone書き込み・Excelパース（§10-1 マッピング確定後）。

--- a/docs/superpowers/plans/2026-07-24-visa-portal-phase2b-upload-review-comments.md
+++ b/docs/superpowers/plans/2026-07-24-visa-portal-phase2b-upload-review-comments.md
@@ -1,0 +1,64 @@
+# ビザ申請ポータル ― フェーズ2b（アップロード・レビュー・コメント）実装計画
+
+**Goal:** 案件詳細で、書類の**アップロード**、OPの**レビュー（承認/差戻し＋理由）**、**コメント**、簡易**リマインド**を行えるようにし、「会社が出す→ファントコが確認」を一気通貫にする。
+
+**前提:** フェーズ2（案件作成・チェックリスト）実装済・ローカル動作確認済。ブランチ `claude/visa-portal-phase2`（継続）。file-generation-only（`supabase:reset`不使用、マイグレは稼働中DBに docker exec で適用）。ローカルStorage起動済。バケット `person-documents`/`people-images` 実在、`office-documents` は本計画で新設。
+
+**安全方式（重要）:** アップロード/ダウンロードは **サーバAPI経由**。APIで `portal_can_access_office` によりアクセス確認 → **サービスロールクライアント**で storage 操作・署名URL発行。storage.objects へのauthenticated直アクセスは付与しない（server-mediated）。クライアントに書込権限を渡さない。
+
+**既存パターン参照:** `lib/supabase/`（サーバ/サービスロールのクライアント生成）、既存の person-documents アップロード実装（`app/people/[id]` の書類タブ／`lib/supabase` 周辺）、`app/api/tenants/.../invite/route.ts`（API認可）、`components/ui/*`。
+
+---
+
+## Task 1: office-documents バケット（マイグレーション）
+**Files:** Create `supabase/migrations/20260724140000_portal_office_documents_bucket.sql`
+```sql
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('office-documents', 'office-documents', false)
+ON CONFLICT (id) DO NOTHING;
+-- authenticated への storage ポリシーは付与しない（server-mediated=サービスロールのみ）。
+```
+- docker exec で適用、`SELECT id FROM storage.buckets;` に `office-documents` が出ることを確認。submoduleでコミット。
+
+## Task 2: ストレージ／データ層
+**Files:** `lib/portal/storage.ts`, `lib/portal/documents.ts`, `lib/portal/comments.ts`（＋`applications.ts`拡張）
+- `getServiceClient()`：既存のサービスロールクライアント生成に倣う（無ければ `@supabase/supabase-js` の createClient(URL, SERVICE_ROLE_KEY)）。
+- `uploadRequirementDocument({caseId, requirementId, file})`：
+  - サーバでアクセス確認（`portal_can_access_office`）。requirement を取得し scope 判定。
+  - パス：office項目=`office-documents/${tenantId}/${officeId}/${caseId}/${requirementId}/${filename}`、person項目=`person-documents/${tenantId}/${personId}/portal/${caseId}/${requirementId}/${filename}`。
+  - サービスロールで upload → `office_documents` または `person_documents` に行作成 → `case_document_requirements` を `office_document_id`/`person_document_id` 紐付け＋`status='reviewing'` に更新 → `case_document_events('submitted')`。
+- `createSignedUrl(docKind, docId)`：アクセス確認後、サービスロールで署名URL（60分）を返す。
+- `listComments(caseId)` / `addComment(caseId, body, requirementId?)`：RLS準拠（ユーザーセッション）。
+- 既存 `person_documents` の必須列（`document_type` 等）に注意。`document_type` は `'other'`（複数可）を使い、ポータル用途を `note` で区別（既存の一意制約 `UNIQUE(person_id, document_type) WHERE document_type<>'other'` に衝突しないため）。
+
+## Task 3: API ルート
+**Files:**
+- `app/api/applications/[caseId]/requirements/[requirementId]/documents/route.ts`：`POST`（multipart 受け→`uploadRequirementDocument`）。認証・アクセス確認・サイズ/型チェック。
+- `app/api/applications/[caseId]/requirements/[requirementId]/route.ts`：`PATCH`（`{action:'approve'}` or `{action:'reject', reason}` or `{action:'reset'}`→ status 更新＋`case_document_events`。承認/差戻しは `portal_is_writer` 必須）。
+- `app/api/documents/[kind]/[docId]/url/route.ts`：`GET`（署名URL返却。kind=office|person）。
+- `app/api/applications/[caseId]/comments/route.ts`：`GET`/`POST`。
+- `app/api/applications/[caseId]/remind/route.ts`：`POST`（`case_document_events('reminded')` 記録＋トースト用メッセージ返却。メール送信は任意・本計画では実施しない＝`nodemailer` 未導入のため。将来フック）。
+- 返却・認可は既存 invite ルート型に準拠。
+
+## Task 4: UI（案件詳細に統合）
+**Files:** `app/applications/[caseId]/page.tsx` 拡張、`components/portal/*` 追加
+- `RequirementRow`（`checklist-table.tsx` を行アクション対応に）：
+  - 会社/企業ユーザー：**アップロード**（未提出/差戻し時）。ファイル選択→送信→`reviewing`。提出済みは「表示」（署名URLを新規タブ）。
+  - OP（writer）：**承認**／**差戻し**（理由入力ダイアログ `RejectReasonDialog`）。差戻し理由をバッジ/ツールチップ表示。
+  - ステータスbadge色分け（未提出=グレー / 確認中=青 / 承認済み=緑 / 要修正=赤）。
+- `CommentThread`（`components/portal/comment-thread.tsx`）：一覧＋投稿フォーム。詳細下部に配置。
+- `RemindButton`：ヘッダに「リマインド」。押下で記録＋トースト。
+- クライアントComponentはmutationのみAPI経由、表示はServer Componentがセッションで取得→`router.refresh()`で更新。
+
+## Task 5: 検証
+- `typecheck`（新規/変更ファイルにエラーなし）、既存テスト維持。可能なら `lib/portal` の純ロジックに軽いユニットテスト（パス生成・ステータス遷移）。
+- ライブ（localhost:3000, ログイン済セッション）：
+  1. 既存の「動作確認テスト案件」で office 書類を1件アップロード→`確認中`
+  2. OPとして承認→`承認済み`（緑）、別の書類を差戻し（理由入力）→`要修正`（赤）
+  3. コメント投稿→表示
+  4. リマインド→トースト
+  5. アップロード済み書類を「表示」（署名URLで開く）
+- スクリーンショットで確認。
+
+## 後続
+- 正式8書類への差し替え（別途、業務確定後）。フェーズ3=kintone/Excel（マッピング確定後）。メール送信（`nodemailer` 導入後）。

--- a/lib/portal/applications.ts
+++ b/lib/portal/applications.ts
@@ -1,0 +1,515 @@
+import { createClient } from '@/lib/supabase/server'
+import { groupRequirements, type MemberNameRef } from './requirements'
+import type {
+  AccessibleOffice,
+  CaseDetail,
+  CaseDocumentRequirement,
+  CaseMember,
+  GroupedRequirements,
+  VisaApplicationCase,
+} from './types'
+import type { ValidatedNewCase } from './case-validation'
+
+const TENANT_WIDE_ROLES = new Set(['owner', 'admin', 'supporter'])
+
+type CaseRow = {
+  id: string
+  tenant_id: string
+  tenant_office_id: string
+  entity_type: string
+  application_category: string
+  field: string
+  application_type: string | null
+  management_number: string | null
+  status: string
+  title: string | null
+  note: string | null
+  created_at: string
+  updated_at: string
+}
+
+type RequirementRow = {
+  id: string
+  case_id: string
+  document_code: string
+  name: string
+  scope: string
+  person_id: string | null
+  is_required: boolean
+  copy_type: string | null
+  issuer: string | null
+  validity_months: number | null
+  status: string
+  sort_order: number
+}
+
+type MemberRow = {
+  id: string
+  case_id: string
+  person_id: string
+  visa_id: string | null
+  created_at: string
+}
+
+function mapCase(row: CaseRow, officeName: string | null): VisaApplicationCase {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    tenantOfficeId: row.tenant_office_id,
+    officeName,
+    entityType: row.entity_type as VisaApplicationCase['entityType'],
+    applicationCategory:
+      row.application_category as VisaApplicationCase['applicationCategory'],
+    field: row.field as VisaApplicationCase['field'],
+    applicationType: row.application_type,
+    managementNumber: row.management_number,
+    status: row.status as VisaApplicationCase['status'],
+    title: row.title,
+    note: row.note,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+function mapRequirement(row: RequirementRow): CaseDocumentRequirement {
+  return {
+    id: row.id,
+    caseId: row.case_id,
+    documentCode: row.document_code,
+    name: row.name,
+    scope: row.scope as CaseDocumentRequirement['scope'],
+    personId: row.person_id,
+    isRequired: row.is_required,
+    copyType: row.copy_type as CaseDocumentRequirement['copyType'],
+    issuer: row.issuer,
+    validityMonths: row.validity_months,
+    status: row.status as CaseDocumentRequirement['status'],
+    sortOrder: row.sort_order,
+  }
+}
+
+/**
+ * ログインユーザーのセッションで、案件作成に使える事業所を返す。
+ * portal_can_access_office と同じ境界:
+ *  - owner/admin/supporter は所属テナントの全事業所
+ *  - member/guest は割当のある事業所のみ
+ */
+export async function getAccessibleOffices(): Promise<AccessibleOffice[]> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return []
+  }
+
+  const { data: memberships, error: membershipError } = await supabase
+    .from('user_tenants')
+    .select('id, tenant_id, role, tenant:tenant_id (name)')
+    .eq('user_id', user.id)
+    .eq('status', 'active')
+
+  if (membershipError) {
+    console.error('Error fetching memberships for accessible offices:', membershipError)
+    return []
+  }
+
+  const rows = (memberships || []) as Array<{
+    id: string
+    tenant_id: string
+    role: string
+    tenant: { name: string | null } | { name: string | null }[] | null
+  }>
+  if (rows.length === 0) {
+    return []
+  }
+
+  const tenantNameById = new Map<string, string | null>()
+  const wideTenantIds = new Set<string>()
+  const membershipIds: string[] = []
+  for (const row of rows) {
+    const tenant = Array.isArray(row.tenant) ? row.tenant[0] : row.tenant
+    tenantNameById.set(row.tenant_id, tenant?.name ?? null)
+    membershipIds.push(row.id)
+    if (TENANT_WIDE_ROLES.has(row.role)) {
+      wideTenantIds.add(row.tenant_id)
+    }
+  }
+
+  // 割当ベース（member/guest 用）
+  const assignedOfficeIds = new Set<string>()
+  if (membershipIds.length > 0) {
+    const { data: assignments, error: assignError } = await supabase
+      .from('user_tenant_offices')
+      .select('tenant_office_id')
+      .in('user_tenant_id', membershipIds)
+    if (assignError) {
+      console.error('Error fetching office assignments:', assignError)
+    } else {
+      for (const a of assignments || []) {
+        assignedOfficeIds.add((a as { tenant_office_id: string }).tenant_office_id)
+      }
+    }
+  }
+
+  const tenantIds = Array.from(tenantNameById.keys())
+  const { data: offices, error: officesError } = await supabase
+    .from('tenant_offices')
+    .select('id, tenant_id, name')
+    .in('tenant_id', tenantIds)
+    .eq('is_active', true)
+
+  if (officesError) {
+    console.error('Error fetching tenant offices:', officesError)
+    return []
+  }
+
+  const accessible: AccessibleOffice[] = []
+  for (const office of (offices || []) as Array<{
+    id: string
+    tenant_id: string
+    name: string
+  }>) {
+    const isWide = wideTenantIds.has(office.tenant_id)
+    if (isWide || assignedOfficeIds.has(office.id)) {
+      accessible.push({
+        id: office.id,
+        tenantId: office.tenant_id,
+        tenantName: tenantNameById.get(office.tenant_id) ?? null,
+        name: office.name,
+      })
+    }
+  }
+
+  accessible.sort((a, b) => a.name.localeCompare(b.name, 'ja-JP'))
+  return accessible
+}
+
+async function resolveOfficeNames(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  officeIds: string[]
+): Promise<Map<string, string | null>> {
+  const map = new Map<string, string | null>()
+  const unique = Array.from(new Set(officeIds)).filter(Boolean)
+  if (unique.length === 0) {
+    return map
+  }
+  const { data, error } = await supabase
+    .from('tenant_offices')
+    .select('id, name')
+    .in('id', unique)
+  if (error) {
+    console.error('Error resolving office names:', error)
+    return map
+  }
+  for (const o of (data || []) as Array<{ id: string; name: string | null }>) {
+    map.set(o.id, o.name ?? null)
+  }
+  return map
+}
+
+/**
+ * アクセス可能な案件の一覧（RLS が自動で office 境界に絞る）。
+ */
+export async function listCases(): Promise<VisaApplicationCase[]> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return []
+  }
+
+  const { data, error } = await supabase
+    .from('visa_application_cases')
+    .select(
+      'id, tenant_id, tenant_office_id, entity_type, application_category, field, application_type, management_number, status, title, note, created_at, updated_at'
+    )
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('Error listing cases:', error)
+    throw error
+  }
+
+  const rows = (data || []) as CaseRow[]
+  const officeNames = await resolveOfficeNames(
+    supabase,
+    rows.map((r) => r.tenant_office_id)
+  )
+  return rows.map((r) => mapCase(r, officeNames.get(r.tenant_office_id) ?? null))
+}
+
+async function fetchMembersWithNames(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  caseId: string
+): Promise<CaseMember[]> {
+  const { data, error } = await supabase
+    .from('visa_application_case_members')
+    .select('id, case_id, person_id, visa_id, created_at')
+    .eq('case_id', caseId)
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    console.error('Error fetching case members:', error)
+    throw error
+  }
+
+  const memberRows = (data || []) as MemberRow[]
+  const personIds = Array.from(new Set(memberRows.map((m) => m.person_id)))
+  const nameByPerson = new Map<string, string | null>()
+  if (personIds.length > 0) {
+    const { data: people, error: peopleError } = await supabase
+      .from('people')
+      .select('id, name')
+      .in('id', personIds)
+    if (peopleError) {
+      console.error('Error fetching member names:', peopleError)
+    } else {
+      for (const p of (people || []) as Array<{ id: string; name: string | null }>) {
+        nameByPerson.set(p.id, p.name ?? null)
+      }
+    }
+  }
+
+  return memberRows.map((m) => ({
+    id: m.id,
+    caseId: m.case_id,
+    personId: m.person_id,
+    visaId: m.visa_id,
+    personName: nameByPerson.get(m.person_id) ?? null,
+    createdAt: m.created_at,
+  }))
+}
+
+/**
+ * 案件詳細（案件 + メンバー + people 表示名）。アクセス不可/存在しない場合は null。
+ */
+export async function getCase(caseId: string): Promise<CaseDetail | null> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return null
+  }
+
+  const { data, error } = await supabase
+    .from('visa_application_cases')
+    .select(
+      'id, tenant_id, tenant_office_id, entity_type, application_category, field, application_type, management_number, status, title, note, created_at, updated_at'
+    )
+    .eq('id', caseId)
+    .maybeSingle()
+
+  if (error) {
+    console.error('Error fetching case:', error)
+    return null
+  }
+  if (!data) {
+    return null
+  }
+
+  const row = data as CaseRow
+  const officeNames = await resolveOfficeNames(supabase, [row.tenant_office_id])
+  const members = await fetchMembersWithNames(supabase, caseId)
+
+  return {
+    ...mapCase(row, officeNames.get(row.tenant_office_id) ?? null),
+    members,
+  }
+}
+
+/**
+ * 案件を作成し、必要書類チェックリストを materialize する。
+ * insert は RLS（portal_can_access_office + portal_is_writer）で境界検査。
+ * created_by は auth.uid()。materialize RPC 内でも office 権限を再検査する。
+ */
+export async function createCase(input: ValidatedNewCase): Promise<string> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    throw new Error('unauthorized')
+  }
+
+  // office から tenant_id を解決（複合FK vac_office_fk 用に整合させる）
+  const { data: office, error: officeError } = await supabase
+    .from('tenant_offices')
+    .select('id, tenant_id')
+    .eq('id', input.tenant_office_id)
+    .maybeSingle()
+
+  if (officeError || !office) {
+    throw new Error('office not found or not accessible')
+  }
+
+  const officeRow = office as { id: string; tenant_id: string }
+
+  const { data: created, error: insertError } = await supabase
+    .from('visa_application_cases')
+    .insert({
+      tenant_id: officeRow.tenant_id,
+      tenant_office_id: officeRow.id,
+      entity_type: input.entity_type,
+      application_category: input.application_category,
+      field: input.field,
+      management_number: input.management_number,
+      title: input.title,
+      created_by: user.id,
+    })
+    .select('id')
+    .single()
+
+  if (insertError || !created) {
+    console.error('Error inserting case:', insertError)
+    throw insertError ?? new Error('failed to create case')
+  }
+
+  const caseId = (created as { id: string }).id
+
+  const { error: rpcError } = await supabase.rpc('materialize_case_requirements', {
+    p_case_id: caseId,
+  })
+  if (rpcError) {
+    console.error('Error materializing case requirements:', rpcError)
+    throw rpcError
+  }
+
+  return caseId
+}
+
+/**
+ * 案件に人材を追加し、materialize を再実行して person 書類を追補する。
+ */
+export async function addMember(
+  caseId: string,
+  personId: string,
+  visaId?: string | null
+): Promise<void> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    throw new Error('unauthorized')
+  }
+
+  // 親 case の tenant/office を取得（members は複合FKで一致必須）
+  const { data: caseRow, error: caseError } = await supabase
+    .from('visa_application_cases')
+    .select('id, tenant_id, tenant_office_id')
+    .eq('id', caseId)
+    .maybeSingle()
+
+  if (caseError || !caseRow) {
+    throw new Error('case not found or not accessible')
+  }
+  const c = caseRow as { id: string; tenant_id: string; tenant_office_id: string }
+
+  const { error: insertError } = await supabase
+    .from('visa_application_case_members')
+    .insert({
+      case_id: c.id,
+      tenant_id: c.tenant_id,
+      tenant_office_id: c.tenant_office_id,
+      person_id: personId,
+      visa_id: visaId ?? null,
+    })
+
+  // 既に追加済み（uq_case_person）の場合は成功扱いにして materialize へ進む
+  if (insertError && insertError.code !== '23505') {
+    console.error('Error adding case member:', insertError)
+    throw insertError
+  }
+
+  const { error: rpcError } = await supabase.rpc('materialize_case_requirements', {
+    p_case_id: caseId,
+  })
+  if (rpcError) {
+    console.error('Error re-materializing case requirements:', rpcError)
+    throw rpcError
+  }
+}
+
+/**
+ * 案件の必要書類を取得し office / person（人材ごと）にグループ化して返す。
+ */
+export async function getRequirements(caseId: string): Promise<GroupedRequirements> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return { office: [], persons: [] }
+  }
+
+  const { data, error } = await supabase
+    .from('case_document_requirements')
+    .select(
+      'id, case_id, document_code, name, scope, person_id, is_required, copy_type, issuer, validity_months, status, sort_order'
+    )
+    .eq('case_id', caseId)
+
+  if (error) {
+    console.error('Error fetching requirements:', error)
+    throw error
+  }
+
+  const requirements = ((data || []) as RequirementRow[]).map(mapRequirement)
+  const members = await fetchMembersWithNames(supabase, caseId)
+  const memberRefs: MemberNameRef[] = members.map((m) => ({
+    personId: m.personId,
+    personName: m.personName,
+  }))
+
+  return groupRequirements(requirements, memberRefs)
+}
+
+/**
+ * 案件詳細 + グループ化済み要件をまとめて取得（詳細画面用）。
+ */
+export async function getCaseWithRequirements(caseId: string): Promise<{
+  case: CaseDetail
+  requirements: GroupedRequirements
+} | null> {
+  const detail = await getCase(caseId)
+  if (!detail) {
+    return null
+  }
+  const requirements = await getRequirements(caseId)
+  return { case: detail, requirements }
+}
+
+/**
+ * 指定事業所に所属し、まだ案件に含まれていない人材の候補を返す（AddMembersDialog 用）。
+ */
+export async function getOfficePeopleForCase(
+  officeId: string,
+  excludePersonIds: string[] = []
+): Promise<Array<{ id: string; name: string | null; visaId: string | null }>> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return []
+  }
+
+  const { data, error } = await supabase
+    .from('people')
+    .select('id, name, visa_id, tenant_office_id')
+    .eq('tenant_office_id', officeId)
+    .order('name', { ascending: true })
+
+  if (error) {
+    console.error('Error fetching office people:', error)
+    return []
+  }
+
+  const exclude = new Set(excludePersonIds)
+  return ((data || []) as Array<{ id: string; name: string | null; visa_id: string | null }>)
+    .filter((p) => !exclude.has(p.id))
+    .map((p) => ({ id: p.id, name: p.name ?? null, visaId: p.visa_id ?? null }))
+}

--- a/lib/portal/applications.ts
+++ b/lib/portal/applications.ts
@@ -40,8 +40,14 @@ type RequirementRow = {
   issuer: string | null
   validity_months: number | null
   status: string
+  rejection_reason: string | null
+  office_document_id: string | null
+  person_document_id: string | null
   sort_order: number
 }
+
+const REQUIREMENT_COLUMNS =
+  'id, case_id, document_code, name, scope, person_id, is_required, copy_type, issuer, validity_months, status, rejection_reason, office_document_id, person_document_id, sort_order'
 
 type MemberRow = {
   id: string
@@ -84,6 +90,9 @@ function mapRequirement(row: RequirementRow): CaseDocumentRequirement {
     issuer: row.issuer,
     validityMonths: row.validity_months,
     status: row.status as CaseDocumentRequirement['status'],
+    rejectionReason: row.rejection_reason,
+    officeDocumentId: row.office_document_id,
+    personDocumentId: row.person_document_id,
     sortOrder: row.sort_order,
   }
 }
@@ -447,9 +456,7 @@ export async function getRequirements(caseId: string): Promise<GroupedRequiremen
 
   const { data, error } = await supabase
     .from('case_document_requirements')
-    .select(
-      'id, case_id, document_code, name, scope, person_id, is_required, copy_type, issuer, validity_months, status, sort_order'
-    )
+    .select(REQUIREMENT_COLUMNS)
     .eq('case_id', caseId)
 
   if (error) {
@@ -468,18 +475,36 @@ export async function getRequirements(caseId: string): Promise<GroupedRequiremen
 }
 
 /**
- * 案件詳細 + グループ化済み要件をまとめて取得（詳細画面用）。
+ * 案件のテナントでレビュー権限（承認/差戻し=writer）があるかを判定する。
+ * portal_is_writer と同じ境界（owner/admin/supporter/member）。
+ */
+export async function isPortalWriter(tenantId: string): Promise<boolean> {
+  const supabase = await createClient()
+  const { data, error } = await supabase.rpc('portal_is_writer', {
+    p_tenant_id: tenantId,
+  })
+  if (error) {
+    console.error('Error checking portal writer:', error)
+    return false
+  }
+  return data === true
+}
+
+/**
+ * 案件詳細 + グループ化済み要件 + 閲覧者のレビュー権限をまとめて取得（詳細画面用）。
  */
 export async function getCaseWithRequirements(caseId: string): Promise<{
   case: CaseDetail
   requirements: GroupedRequirements
+  isWriter: boolean
 } | null> {
   const detail = await getCase(caseId)
   if (!detail) {
     return null
   }
   const requirements = await getRequirements(caseId)
-  return { case: detail, requirements }
+  const isWriter = await isPortalWriter(detail.tenantId)
+  return { case: detail, requirements, isWriter }
 }
 
 /**

--- a/lib/portal/case-validation.ts
+++ b/lib/portal/case-validation.ts
@@ -1,0 +1,95 @@
+export const ENTITY_TYPES = ['corporate', 'sole_proprietor'] as const
+export const APPLICATION_CATEGORIES = ['initial', 'renewal'] as const
+export const FIELDS = [
+  'care',
+  'food_service',
+  'accommodation',
+  'food_manufacturing',
+  'other',
+] as const
+
+export type EntityType = (typeof ENTITY_TYPES)[number]
+export type ApplicationCategory = (typeof APPLICATION_CATEGORIES)[number]
+export type Field = (typeof FIELDS)[number]
+
+export interface NewCaseInput {
+  tenant_office_id?: string | null
+  entity_type?: string | null
+  application_category?: string | null
+  field?: string | null
+  // 任意項目（バリデーション対象外だが受け取れるようにしておく）
+  management_number?: string | null
+  title?: string | null
+}
+
+export interface ValidatedNewCase {
+  tenant_office_id: string
+  entity_type: EntityType
+  application_category: ApplicationCategory
+  field: Field
+  management_number: string | null
+  title: string | null
+}
+
+export type ValidateNewCaseResult =
+  | { ok: true; value: ValidatedNewCase }
+  | { ok: false; error: string }
+
+function trimOrNull(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * 案件作成入力の純粋バリデーション。必須欠落・enum外を弾き、
+ * 正常入力では正規化した値を返す。DBアクセスや副作用は持たない。
+ */
+export function validateNewCase(input: NewCaseInput | null | undefined): ValidateNewCaseResult {
+  if (!input || typeof input !== 'object') {
+    return { ok: false, error: 'input is required' }
+  }
+
+  const officeId = trimOrNull(input.tenant_office_id)
+  if (!officeId) {
+    return { ok: false, error: 'tenant_office_id is required' }
+  }
+
+  const entityType = trimOrNull(input.entity_type)
+  if (!entityType) {
+    return { ok: false, error: 'entity_type is required' }
+  }
+  if (!(ENTITY_TYPES as readonly string[]).includes(entityType)) {
+    return { ok: false, error: 'invalid entity_type' }
+  }
+
+  const category = trimOrNull(input.application_category)
+  if (!category) {
+    return { ok: false, error: 'application_category is required' }
+  }
+  if (!(APPLICATION_CATEGORIES as readonly string[]).includes(category)) {
+    return { ok: false, error: 'invalid application_category' }
+  }
+
+  const field = trimOrNull(input.field)
+  if (!field) {
+    return { ok: false, error: 'field is required' }
+  }
+  if (!(FIELDS as readonly string[]).includes(field)) {
+    return { ok: false, error: 'invalid field' }
+  }
+
+  return {
+    ok: true,
+    value: {
+      tenant_office_id: officeId,
+      entity_type: entityType as EntityType,
+      application_category: category as ApplicationCategory,
+      field: field as Field,
+      management_number: trimOrNull(input.management_number),
+      title: trimOrNull(input.title),
+    },
+  }
+}

--- a/lib/portal/comments.ts
+++ b/lib/portal/comments.ts
@@ -1,0 +1,141 @@
+import { createClient } from '@/lib/supabase/server'
+import type { CaseComment } from './types'
+import type { ActionResult } from './documents'
+import { getServiceClient } from './storage'
+
+type CommentRow = {
+  id: string
+  case_id: string
+  requirement_id: string | null
+  author: string | null
+  body: string
+  created_at: string
+}
+
+/**
+ * 投稿者 id → 表示ラベル（email）を解決する。auth.users には RLS 経由で触れないため、
+ * サービスロールで user_tenants の email を引く（メンバーは必ず行を持つ）。
+ */
+async function resolveAuthorLabels(
+  authorIds: string[]
+): Promise<Map<string, string | null>> {
+  const labels = new Map<string, string | null>()
+  const ids = Array.from(new Set(authorIds.filter(Boolean)))
+  if (ids.length === 0) {
+    return labels
+  }
+  const service = getServiceClient()
+  const { data, error } = await service
+    .from('user_tenants')
+    .select('user_id, email')
+    .in('user_id', ids)
+  if (error) {
+    console.error('Error resolving comment author labels:', error)
+    return labels
+  }
+  for (const row of (data || []) as Array<{ user_id: string; email: string | null }>) {
+    if (!labels.has(row.user_id)) {
+      labels.set(row.user_id, row.email ?? null)
+    }
+  }
+  return labels
+}
+
+function mapComment(row: CommentRow, label: string | null): CaseComment {
+  return {
+    id: row.id,
+    caseId: row.case_id,
+    requirementId: row.requirement_id,
+    authorId: row.author,
+    authorLabel: label,
+    body: row.body,
+    createdAt: row.created_at,
+  }
+}
+
+/**
+ * 案件のコメント一覧（古い順）。RLS が office 境界に絞る。
+ */
+export async function listComments(caseId: string): Promise<CaseComment[]> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return []
+  }
+
+  const { data, error } = await supabase
+    .from('case_comments')
+    .select('id, case_id, requirement_id, author, body, created_at')
+    .eq('case_id', caseId)
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    console.error('Error listing case comments:', error)
+    return []
+  }
+
+  const rows = (data || []) as CommentRow[]
+  const labels = await resolveAuthorLabels(
+    rows.map((r) => r.author).filter((a): a is string => Boolean(a))
+  )
+  return rows.map((r) => mapComment(r, r.author ? labels.get(r.author) ?? null : null))
+}
+
+/**
+ * 案件にコメントを投稿する。RLS（portal_can_upload + author=auth.uid()）で認可。
+ */
+export async function addComment(params: {
+  caseId: string
+  body: string
+  requirementId?: string | null
+}): Promise<ActionResult<CaseComment>> {
+  const body = params.body.trim()
+  if (!body) {
+    return { ok: false, status: 400, error: 'コメントを入力してください' }
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return { ok: false, status: 401, error: 'ログインが必要です' }
+  }
+
+  const { data: caseRow, error: caseError } = await supabase
+    .from('visa_application_cases')
+    .select('id, tenant_id, tenant_office_id')
+    .eq('id', params.caseId)
+    .maybeSingle()
+
+  if (caseError || !caseRow) {
+    return { ok: false, status: 404, error: '案件が見つかりません' }
+  }
+  const c = caseRow as { id: string; tenant_id: string; tenant_office_id: string }
+
+  const { data: inserted, error: insertError } = await supabase
+    .from('case_comments')
+    .insert({
+      case_id: c.id,
+      tenant_id: c.tenant_id,
+      tenant_office_id: c.tenant_office_id,
+      requirement_id: params.requirementId ?? null,
+      author: user.id,
+      body,
+    })
+    .select('id, case_id, requirement_id, author, body, created_at')
+    .single()
+
+  if (insertError || !inserted) {
+    console.error('Error inserting case comment:', insertError)
+    return { ok: false, status: 500, error: 'コメントの投稿に失敗しました' }
+  }
+
+  const labels = await resolveAuthorLabels([user.id])
+  return {
+    ok: true,
+    data: mapComment(inserted as CommentRow, labels.get(user.id) ?? null),
+  }
+}

--- a/lib/portal/documents.ts
+++ b/lib/portal/documents.ts
@@ -1,0 +1,498 @@
+import { createClient } from '@/lib/supabase/server'
+import type { DocumentKind } from './types'
+import {
+  OFFICE_BUCKET,
+  PERSON_BUCKET,
+  SIGNED_URL_TTL_SECONDS,
+  buildOfficeObjectKey,
+  buildPersonObjectKey,
+  getServiceClient,
+  validateUploadFile,
+} from './storage'
+
+// すべての mutation はサーバAPI経由でここを通す。
+// アクセス確認はユーザーセッション（RLS）で行い、確認後の storage 操作・
+// 監査イベント追記はサービスロール（RLSバイパス）で行う。
+
+export type ActionResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; status: number; error: string }
+
+type RequirementContext = {
+  id: string
+  case_id: string
+  tenant_id: string
+  tenant_office_id: string
+  scope: 'office' | 'person'
+  person_id: string | null
+  document_code: string
+  name: string
+  status: string
+  office_document_id: string | null
+  person_document_id: string | null
+}
+
+/**
+ * 案件+要件をユーザーセッション（RLS）で取得する。RLS が office 境界に絞るため、
+ * 行が返れば「この要件へのアクセス権あり」と判断できる。
+ */
+async function loadRequirementContext(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  caseId: string,
+  requirementId: string
+): Promise<RequirementContext | null> {
+  const { data, error } = await supabase
+    .from('case_document_requirements')
+    .select(
+      'id, case_id, tenant_id, tenant_office_id, scope, person_id, document_code, name, status, office_document_id, person_document_id'
+    )
+    .eq('id', requirementId)
+    .eq('case_id', caseId)
+    .maybeSingle()
+
+  if (error) {
+    console.error('Error loading requirement context:', error)
+    return null
+  }
+  return (data as RequirementContext | null) ?? null
+}
+
+/**
+ * 会社/企業ユーザーが必要書類を1件アップロードする。
+ * office 項目 → office_documents、person 項目 → person_documents に行を作り、
+ * 要件を紐付け＋status='reviewing' に更新し、'submitted' イベントを記録する。
+ */
+export async function uploadRequirementDocument(params: {
+  caseId: string
+  requirementId: string
+  file: File
+}): Promise<ActionResult<{ kind: DocumentKind; documentId: string }>> {
+  const { caseId, requirementId, file } = params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return { ok: false, status: 401, error: 'ログインが必要です' }
+  }
+
+  const validationError = validateUploadFile({ size: file.size, type: file.type })
+  if (validationError) {
+    return { ok: false, status: 400, error: validationError }
+  }
+
+  const requirement = await loadRequirementContext(supabase, caseId, requirementId)
+  if (!requirement) {
+    return { ok: false, status: 404, error: '対象の書類が見つかりません' }
+  }
+
+  const service = getServiceClient()
+  const contentType = file.type
+  const buffer = Buffer.from(await file.arrayBuffer())
+
+  if (requirement.scope === 'office') {
+    const objectKey = buildOfficeObjectKey({
+      tenantId: requirement.tenant_id,
+      officeId: requirement.tenant_office_id,
+      caseId: requirement.case_id,
+      requirementId: requirement.id,
+      fileName: file.name,
+    })
+
+    // 差し替え時に消す旧オブジェクトのパスを控える（office は uq_od_office_code で1件/コード）
+    const { data: existingDoc } = await service
+      .from('office_documents')
+      .select('id, storage_path')
+      .eq('tenant_office_id', requirement.tenant_office_id)
+      .eq('document_code', requirement.document_code)
+      .maybeSingle()
+
+    const { error: uploadError } = await service.storage
+      .from(OFFICE_BUCKET)
+      .upload(objectKey, buffer, { contentType, upsert: false })
+    if (uploadError) {
+      console.error('Office storage upload error:', uploadError)
+      return { ok: false, status: 500, error: 'ファイルのアップロードに失敗しました' }
+    }
+
+    const { data: upserted, error: upsertError } = await service
+      .from('office_documents')
+      .upsert(
+        {
+          ...(existingDoc ? { id: (existingDoc as { id: string }).id } : {}),
+          tenant_id: requirement.tenant_id,
+          tenant_office_id: requirement.tenant_office_id,
+          document_code: requirement.document_code,
+          storage_path: objectKey,
+          file_name: file.name,
+          content_type: contentType,
+          file_size_bytes: file.size,
+          uploaded_by: user.id,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'tenant_office_id,document_code' }
+      )
+      .select('id')
+      .single()
+
+    if (upsertError || !upserted) {
+      await service.storage.from(OFFICE_BUCKET).remove([objectKey])
+      console.error('office_documents upsert error:', upsertError)
+      return { ok: false, status: 500, error: '書類の保存に失敗しました' }
+    }
+
+    const documentId = (upserted as { id: string }).id
+    const linkResult = await linkAndSubmit(service, {
+      requirementId: requirement.id,
+      caseId: requirement.case_id,
+      tenantId: requirement.tenant_id,
+      column: 'office_document_id',
+      documentId,
+      actorId: user.id,
+    })
+    if (!linkResult.ok) {
+      await service.storage.from(OFFICE_BUCKET).remove([objectKey])
+      return linkResult
+    }
+
+    // 旧オブジェクトの掃除（パスが変わった場合のみ）
+    const oldPath = existingDoc
+      ? (existingDoc as { storage_path: string }).storage_path
+      : null
+    if (oldPath && oldPath !== objectKey) {
+      await service.storage.from(OFFICE_BUCKET).remove([oldPath])
+    }
+
+    return { ok: true, data: { kind: 'office', documentId } }
+  }
+
+  // scope === 'person'
+  if (!requirement.person_id) {
+    return { ok: false, status: 400, error: '人材が特定できません' }
+  }
+
+  const objectKey = buildPersonObjectKey({
+    tenantId: requirement.tenant_id,
+    personId: requirement.person_id,
+    caseId: requirement.case_id,
+    requirementId: requirement.id,
+    fileName: file.name,
+  })
+
+  const { error: uploadError } = await service.storage
+    .from(PERSON_BUCKET)
+    .upload(objectKey, buffer, { contentType, upsert: false })
+  if (uploadError) {
+    console.error('Person storage upload error:', uploadError)
+    return { ok: false, status: 500, error: 'ファイルのアップロードに失敗しました' }
+  }
+
+  // 一意制約 UNIQUE(person_id, document_type) WHERE document_type<>'other' を避けるため
+  // document_type='other' を使い、ポータル用途は note で区別する。
+  const { data: insertedDoc, error: insertError } = await service
+    .from('person_documents')
+    .insert({
+      person_id: requirement.person_id,
+      tenant_id: requirement.tenant_id,
+      tenant_office_id: requirement.tenant_office_id,
+      document_type: 'other',
+      storage_path: objectKey,
+      title: requirement.name,
+      file_name: file.name,
+      content_type: contentType,
+      file_size_bytes: file.size,
+      uploaded_by: user.id,
+      note: `portal:${requirement.document_code}`,
+    })
+    .select('id')
+    .single()
+
+  if (insertError || !insertedDoc) {
+    await service.storage.from(PERSON_BUCKET).remove([objectKey])
+    console.error('person_documents insert error:', insertError)
+    return { ok: false, status: 500, error: '書類の保存に失敗しました' }
+  }
+
+  const documentId = (insertedDoc as { id: string }).id
+  const linkResult = await linkAndSubmit(service, {
+    requirementId: requirement.id,
+    caseId: requirement.case_id,
+    tenantId: requirement.tenant_id,
+    column: 'person_document_id',
+    documentId,
+    actorId: user.id,
+  })
+  if (!linkResult.ok) {
+    await service.storage.from(PERSON_BUCKET).remove([objectKey])
+    await service.from('person_documents').delete().eq('id', documentId)
+    return linkResult
+  }
+
+  // 旧 person_document（差戻し後の再提出など）を掃除
+  const oldDocId = requirement.person_document_id
+  if (oldDocId && oldDocId !== documentId) {
+    const { data: oldDoc } = await service
+      .from('person_documents')
+      .select('storage_path')
+      .eq('id', oldDocId)
+      .maybeSingle()
+    const oldPath = (oldDoc as { storage_path: string } | null)?.storage_path
+    await service.from('person_documents').delete().eq('id', oldDocId)
+    if (oldPath) {
+      await service.storage.from(PERSON_BUCKET).remove([oldPath])
+    }
+  }
+
+  return { ok: true, data: { kind: 'person', documentId } }
+}
+
+/** 要件へのドキュメント紐付け＋reviewing 化＋submitted イベント（サービスロール）。 */
+async function linkAndSubmit(
+  service: ReturnType<typeof getServiceClient>,
+  params: {
+    requirementId: string
+    caseId: string
+    tenantId: string
+    column: 'office_document_id' | 'person_document_id'
+    documentId: string
+    actorId: string
+  }
+): Promise<ActionResult<null>> {
+  const { error: updateError } = await service
+    .from('case_document_requirements')
+    .update({
+      [params.column]: params.documentId,
+      status: 'reviewing',
+      rejection_reason: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', params.requirementId)
+
+  if (updateError) {
+    console.error('requirement link/update error:', updateError)
+    return { ok: false, status: 500, error: '書類の紐付けに失敗しました' }
+  }
+
+  const { error: eventError } = await service.from('case_document_events').insert({
+    case_id: params.caseId,
+    tenant_id: params.tenantId,
+    requirement_id: params.requirementId,
+    event_type: 'submitted',
+    actor: params.actorId,
+  })
+  if (eventError) {
+    // イベントは監査用途。失敗しても致命ではないためログのみ。
+    console.error('submitted event insert error:', eventError)
+  }
+
+  return { ok: true, data: null }
+}
+
+export type ReviewAction = 'approve' | 'reject' | 'reset'
+
+/**
+ * OP（writer）が書類をレビューする。承認→approved、差戻し→needs_fix（理由必須）、
+ * reset→not_submitted。承認/差戻しは 'approved'/'rejected' イベントを記録する。
+ */
+export async function reviewRequirement(params: {
+  caseId: string
+  requirementId: string
+  action: ReviewAction
+  reason?: string | null
+}): Promise<ActionResult<{ status: string }>> {
+  const { caseId, requirementId, action } = params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return { ok: false, status: 401, error: 'ログインが必要です' }
+  }
+
+  const requirement = await loadRequirementContext(supabase, caseId, requirementId)
+  if (!requirement) {
+    return { ok: false, status: 404, error: '対象の書類が見つかりません' }
+  }
+
+  // レビューは writer（owner/admin/supporter/member）のみ
+  const { data: isWriter, error: writerError } = await supabase.rpc('portal_is_writer', {
+    p_tenant_id: requirement.tenant_id,
+  })
+  if (writerError) {
+    console.error('portal_is_writer error:', writerError)
+    return { ok: false, status: 500, error: '権限の確認に失敗しました' }
+  }
+  if (isWriter !== true) {
+    return { ok: false, status: 403, error: 'この操作を行う権限がありません' }
+  }
+
+  let nextStatus: string
+  let rejectionReason: string | null = null
+  let eventType: 'approved' | 'rejected' | null = null
+
+  if (action === 'approve') {
+    nextStatus = 'approved'
+    eventType = 'approved'
+  } else if (action === 'reject') {
+    const reason = (params.reason ?? '').trim()
+    if (!reason) {
+      return { ok: false, status: 400, error: '差戻しの理由を入力してください' }
+    }
+    nextStatus = 'needs_fix'
+    rejectionReason = reason
+    eventType = 'rejected'
+  } else {
+    nextStatus = 'not_submitted'
+  }
+
+  const service = getServiceClient()
+  const { error: updateError } = await service
+    .from('case_document_requirements')
+    .update({
+      status: nextStatus,
+      rejection_reason: rejectionReason,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', requirementId)
+
+  if (updateError) {
+    console.error('review update error:', updateError)
+    return { ok: false, status: 500, error: 'ステータスの更新に失敗しました' }
+  }
+
+  if (eventType) {
+    const { error: eventError } = await service.from('case_document_events').insert({
+      case_id: requirement.case_id,
+      tenant_id: requirement.tenant_id,
+      requirement_id: requirement.id,
+      event_type: eventType,
+      actor: user.id,
+      comment: rejectionReason,
+    })
+    if (eventError) {
+      console.error('review event insert error:', eventError)
+    }
+  }
+
+  return { ok: true, data: { status: nextStatus } }
+}
+
+/**
+ * アップロード済み書類の署名URL（60分）を返す。
+ * この案件の要件に紐づく書類のみが対象で、要件への RLS アクセス確認をもって認可とする。
+ */
+export async function createRequirementDocumentSignedUrl(params: {
+  kind: DocumentKind
+  documentId: string
+}): Promise<ActionResult<{ url: string }>> {
+  const { kind, documentId } = params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return { ok: false, status: 401, error: 'ログインが必要です' }
+  }
+
+  const linkColumn =
+    kind === 'office' ? 'office_document_id' : 'person_document_id'
+
+  // ユーザーセッション（RLS=office境界）で「この書類を参照する要件」を確認 → 認可
+  const { data: reqRow, error: reqError } = await supabase
+    .from('case_document_requirements')
+    .select('id')
+    .eq(linkColumn, documentId)
+    .limit(1)
+    .maybeSingle()
+
+  if (reqError) {
+    console.error('signed url access check error:', reqError)
+    return { ok: false, status: 500, error: 'アクセス確認に失敗しました' }
+  }
+  if (!reqRow) {
+    return { ok: false, status: 404, error: '書類が見つかりません' }
+  }
+
+  const service = getServiceClient()
+  const table = kind === 'office' ? 'office_documents' : 'person_documents'
+  const bucket = kind === 'office' ? OFFICE_BUCKET : PERSON_BUCKET
+
+  const { data: doc, error: docError } = await service
+    .from(table)
+    .select('storage_path')
+    .eq('id', documentId)
+    .maybeSingle()
+
+  if (docError || !doc) {
+    console.error('signed url doc fetch error:', docError)
+    return { ok: false, status: 404, error: '書類が見つかりません' }
+  }
+
+  const storagePath = (doc as { storage_path: string }).storage_path
+  const { data: signed, error: signError } = await service.storage
+    .from(bucket)
+    .createSignedUrl(storagePath, SIGNED_URL_TTL_SECONDS)
+
+  if (signError || !signed) {
+    console.error('createSignedUrl error:', signError)
+    return { ok: false, status: 500, error: '表示URLの発行に失敗しました' }
+  }
+
+  return { ok: true, data: { url: signed.signedUrl } }
+}
+
+/**
+ * 案件のリマインドを記録する（'reminded' イベント）。writer のみ。
+ * NOTE: メール送信は未実装（nodemailer 未導入）。導入後はここから通知を送る。
+ */
+export async function remindCase(params: {
+  caseId: string
+}): Promise<ActionResult<{ message: string }>> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return { ok: false, status: 401, error: 'ログインが必要です' }
+  }
+
+  const { data: caseRow, error: caseError } = await supabase
+    .from('visa_application_cases')
+    .select('id, tenant_id')
+    .eq('id', params.caseId)
+    .maybeSingle()
+
+  if (caseError || !caseRow) {
+    return { ok: false, status: 404, error: '案件が見つかりません' }
+  }
+  const tenantId = (caseRow as { tenant_id: string }).tenant_id
+
+  const { data: isWriter, error: writerError } = await supabase.rpc('portal_is_writer', {
+    p_tenant_id: tenantId,
+  })
+  if (writerError) {
+    console.error('portal_is_writer error:', writerError)
+    return { ok: false, status: 500, error: '権限の確認に失敗しました' }
+  }
+  if (isWriter !== true) {
+    return { ok: false, status: 403, error: 'この操作を行う権限がありません' }
+  }
+
+  const service = getServiceClient()
+  const { error: eventError } = await service.from('case_document_events').insert({
+    case_id: params.caseId,
+    tenant_id: tenantId,
+    event_type: 'reminded',
+    actor: user.id,
+  })
+  if (eventError) {
+    console.error('reminded event insert error:', eventError)
+    return { ok: false, status: 500, error: 'リマインドの記録に失敗しました' }
+  }
+
+  // TODO(future): nodemailer 導入後、ここで会社担当者宛にリマインドメールを送る。
+  return {
+    ok: true,
+    data: { message: 'リマインドを記録しました（メール送信は今後対応予定です）' },
+  }
+}

--- a/lib/portal/requirements.ts
+++ b/lib/portal/requirements.ts
@@ -1,0 +1,71 @@
+import type {
+  CaseDocumentRequirement,
+  GroupedRequirements,
+  PersonRequirementGroup,
+} from './types'
+
+// 案件メンバー（人材）の表示名解決に使う最小情報
+export interface MemberNameRef {
+  personId: string
+  personName: string | null
+}
+
+function bySortOrder(a: CaseDocumentRequirement, b: CaseDocumentRequirement): number {
+  if (a.sortOrder !== b.sortOrder) {
+    return a.sortOrder - b.sortOrder
+  }
+  return a.documentCode.localeCompare(b.documentCode)
+}
+
+/**
+ * 必要書類の行を office / person（人材ごと）にグループ化する純関数。
+ *
+ * - office 行は sort_order 昇順。
+ * - person 行は person_id ごとにまとめ、各グループ内は sort_order 昇順。
+ * - members を渡すと、まだ書類行が無い（materialize 前など）メンバーも
+ *   空グループとして順序を保って表示できる。
+ * - 表示名は members 由来を優先し、無ければ requirement 行由来を使う。
+ */
+export function groupRequirements(
+  requirements: CaseDocumentRequirement[],
+  members: MemberNameRef[] = []
+): GroupedRequirements {
+  const office = requirements
+    .filter((r) => r.scope === 'office')
+    .sort(bySortOrder)
+
+  // person_id ごとの行を集約
+  const itemsByPerson = new Map<string, CaseDocumentRequirement[]>()
+  for (const r of requirements) {
+    if (r.scope !== 'person' || !r.personId) {
+      continue
+    }
+    const list = itemsByPerson.get(r.personId) ?? []
+    list.push(r)
+    itemsByPerson.set(r.personId, list)
+  }
+
+  // 表示順序: members の並び順を尊重し、members に無い person_id は後ろに追加
+  const orderedPersonIds: string[] = []
+  const nameByPerson = new Map<string, string | null>()
+  for (const m of members) {
+    if (!orderedPersonIds.includes(m.personId)) {
+      orderedPersonIds.push(m.personId)
+    }
+    nameByPerson.set(m.personId, m.personName)
+  }
+  for (const personId of itemsByPerson.keys()) {
+    if (!orderedPersonIds.includes(personId)) {
+      orderedPersonIds.push(personId)
+    }
+  }
+
+  const persons: PersonRequirementGroup[] = orderedPersonIds.map((personId) => {
+    const items = (itemsByPerson.get(personId) ?? []).slice().sort(bySortOrder)
+    // person 書類行は氏名を持たないため、表示名は members 由来のみ解決する
+    const personName = nameByPerson.get(personId) ?? null
+    return { personId, personName, items }
+  })
+
+  return { office, persons }
+}

--- a/lib/portal/storage.ts
+++ b/lib/portal/storage.ts
@@ -1,0 +1,82 @@
+import { createAdminClient } from '@/lib/supabase/client'
+
+// ポータル書類のストレージ規約とサービスロール操作をまとめる。
+// アップロード/署名URL発行はすべてサーバAPI経由でこのモジュールを使い、
+// クライアントには storage への書込権限を渡さない（server-mediated）。
+
+export const OFFICE_BUCKET = 'office-documents'
+export const PERSON_BUCKET = 'person-documents'
+
+export const MAX_UPLOAD_BYTES = 10 * 1024 * 1024 // 10MB（person-documents バケットと同じ上限）
+export const ALLOWED_CONTENT_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+  'application/pdf',
+]
+
+export const SIGNED_URL_TTL_SECONDS = 60 * 60 // 60分
+
+/**
+ * サービスロール（RLSバイパス）クライアント。既存の createAdminClient に倣う。
+ * サーバ側でアクセス確認を済ませたあとの storage 操作・行作成にのみ使う。
+ */
+export function getServiceClient() {
+  return createAdminClient()
+}
+
+/** アップロードファイルの型・サイズ検証。問題があればエラーメッセージ、無ければ null。 */
+export function validateUploadFile(file: {
+  size: number
+  type: string
+}): string | null {
+  if (!file.size || file.size <= 0) {
+    return 'ファイルが空です'
+  }
+  if (file.size > MAX_UPLOAD_BYTES) {
+    return 'ファイルサイズは10MB以下にしてください'
+  }
+  if (!ALLOWED_CONTENT_TYPES.includes(file.type)) {
+    return '対応していないファイル形式です（PDF・画像のみ）'
+  }
+  return null
+}
+
+/** 拡張子（小文字・英数字のみ）。取得できなければ 'bin'。 */
+function safeExtension(fileName: string): string {
+  const dot = fileName.lastIndexOf('.')
+  if (dot < 0 || dot === fileName.length - 1) {
+    return 'bin'
+  }
+  const ext = fileName.slice(dot + 1).toLowerCase()
+  return /^[a-z0-9]{1,10}$/.test(ext) ? ext : 'bin'
+}
+
+/**
+ * バケット内のオブジェクトキーを生成する。ファイル名はタイムスタンプ+拡張子で正規化し、
+ * 元のファイル名は DB 行の file_name 列で保持する（storage キーにユーザー入力を持ち込まない）。
+ */
+export function buildOfficeObjectKey(params: {
+  tenantId: string
+  officeId: string
+  caseId: string
+  requirementId: string
+  fileName: string
+}): string {
+  const ext = safeExtension(params.fileName)
+  return `${params.tenantId}/${params.officeId}/${params.caseId}/${params.requirementId}/${Date.now()}.${ext}`
+}
+
+export function buildPersonObjectKey(params: {
+  tenantId: string
+  personId: string
+  caseId: string
+  requirementId: string
+  fileName: string
+}): string {
+  const ext = safeExtension(params.fileName)
+  return `${params.tenantId}/${params.personId}/portal/${params.caseId}/${params.requirementId}/${Date.now()}.${ext}`
+}

--- a/lib/portal/types.ts
+++ b/lib/portal/types.ts
@@ -1,0 +1,146 @@
+// フェーズ1スキーマ（visa_application_cases ほか）に一致するポータル用の型。
+
+export type EntityType = 'corporate' | 'sole_proprietor'
+export type ApplicationCategory = 'initial' | 'renewal'
+export type Field =
+  | 'care'
+  | 'food_service'
+  | 'accommodation'
+  | 'food_manufacturing'
+  | 'other'
+export type CaseStatus =
+  | 'draft'
+  | 'collecting'
+  | 'reviewing'
+  | 'ready'
+  | 'synced'
+  | 'completed'
+  | 'archived'
+export type RequirementScope = 'office' | 'person'
+export type CopyType = 'original' | 'copy'
+export type RequirementStatus =
+  | 'not_submitted'
+  | 'reviewing'
+  | 'approved'
+  | 'needs_fix'
+
+// 新規案件作成でユーザーが選べる事業所（アクセス可能なもの）
+export interface AccessibleOffice {
+  id: string
+  tenantId: string
+  tenantName: string | null
+  name: string
+}
+
+// 案件に紐づく人材
+export interface CaseMember {
+  id: string
+  caseId: string
+  personId: string
+  visaId: string | null
+  personName: string | null
+  createdAt: string
+}
+
+// 案件（一覧・詳細共通のコア）
+export interface VisaApplicationCase {
+  id: string
+  tenantId: string
+  tenantOfficeId: string
+  officeName: string | null
+  entityType: EntityType
+  applicationCategory: ApplicationCategory
+  field: Field
+  applicationType: string | null
+  managementNumber: string | null
+  status: CaseStatus
+  title: string | null
+  note: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+// 案件詳細（メンバー込み）
+export interface CaseDetail extends VisaApplicationCase {
+  members: CaseMember[]
+}
+
+// 必要書類チェックリスト1行
+export interface CaseDocumentRequirement {
+  id: string
+  caseId: string
+  documentCode: string
+  name: string
+  scope: RequirementScope
+  personId: string | null
+  isRequired: boolean
+  copyType: CopyType | null
+  issuer: string | null
+  validityMonths: number | null
+  status: RequirementStatus
+  sortOrder: number
+}
+
+// 人材ごとにまとめた person 書類グループ
+export interface PersonRequirementGroup {
+  personId: string
+  personName: string | null
+  items: CaseDocumentRequirement[]
+}
+
+// office / person にグループ化した要件
+export interface GroupedRequirements {
+  office: CaseDocumentRequirement[]
+  persons: PersonRequirementGroup[]
+}
+
+// 日本語ラベル（画面表示用）
+export const ENTITY_TYPE_LABELS: Record<EntityType, string> = {
+  corporate: '法人',
+  sole_proprietor: '個人事業主',
+}
+
+export const APPLICATION_CATEGORY_LABELS: Record<ApplicationCategory, string> = {
+  initial: '初回',
+  renewal: '更新',
+}
+
+export const FIELD_LABELS: Record<Field, string> = {
+  care: '介護',
+  food_service: '外食業',
+  accommodation: '宿泊',
+  food_manufacturing: '飲食料品製造業',
+  other: 'その他',
+}
+
+export const CASE_STATUS_LABELS: Record<CaseStatus, string> = {
+  draft: '下書き',
+  collecting: '書類収集中',
+  reviewing: '確認中',
+  ready: '申請準備完了',
+  synced: '連携済み',
+  completed: '完了',
+  archived: 'アーカイブ',
+}
+
+export const REQUIREMENT_STATUS_LABELS: Record<RequirementStatus, string> = {
+  not_submitted: '未提出',
+  reviewing: '確認中',
+  approved: '承認済み',
+  needs_fix: '要修正',
+}
+
+export const COPY_TYPE_LABELS: Record<CopyType, string> = {
+  original: '原本',
+  copy: '写し',
+}
+
+// 申請の流れ（Stepper 表示順）。archived は途中経路ではないため除外。
+export const CASE_FLOW_STEPS: CaseStatus[] = [
+  'draft',
+  'collecting',
+  'reviewing',
+  'ready',
+  'synced',
+  'completed',
+]

--- a/lib/portal/types.ts
+++ b/lib/portal/types.ts
@@ -78,7 +78,24 @@ export interface CaseDocumentRequirement {
   issuer: string | null
   validityMonths: number | null
   status: RequirementStatus
+  rejectionReason: string | null
+  officeDocumentId: string | null
+  personDocumentId: string | null
   sortOrder: number
+}
+
+// アップロード済み書類（署名URL取得の対象）の種別
+export type DocumentKind = 'office' | 'person'
+
+// 案件コメント（メール置換）の1件
+export interface CaseComment {
+  id: string
+  caseId: string
+  requirementId: string | null
+  authorId: string | null
+  authorLabel: string | null
+  body: string
+  createdAt: string
 }
 
 // 人材ごとにまとめた person 書類グループ


### PR DESCRIPTION
## 概要
受入企業向けビザ申請 提出ポータルの**フェーズ2＋2b**（アプリ側）。フェーズ1（#138）にスタック。ローカルで実データ動作確認済み。

## できること
- **案件作成**（OP）：事業所・法人/個人・初回/更新・分野を選ぶ → 必要書類チェックリストを自動生成（`materialize_case_requirements`）
- **一覧／詳細**：申請の流れ（Stepper）＋会社・事業所の書類チェックリスト。対象人材はチップ表示（人材は記録用に後追い追加）
- **アップロード**：書類ごとに提出（サーバAPIでoffice境界を確認→サービスロールで `office-documents` バケットに保存。中身の読み取りはしない＝提出状況の管理が目的）→ 状態が「確認中」に
- **レビュー**：OPが承認／差戻し（理由入力）。ステータス色分け（未提出/確認中/承認済み/要修正）
- **コメント**：案件ごとのやり取り（メール置換）
- **リマインド**：記録＋通知（メール送信は今後・`nodemailer`未導入）
- **署名URL表示**：提出済み書類をサーバ経由の署名URLで閲覧

## 実データ反映
- 必要書類は「ご案内資料」の**実際の取得書類**（会社書類のみ）。法人/個人×初回/更新、営業許可証は外食・宿泊のみ。

## 設計方針（確定事項）
- 証明書類はFunBase上では**提出済みか否かの進捗管理**が目的（OCR/解析なし）。将来ファイル実体はGoogleドライブ等でも可。
- **次フェーズ（キモ）＝提出Excel→kintone自動転記**（本PRには未含。別途）。

## セキュリティ
- 表示系はユーザーセッション（RLS/office境界）、変更系はサーバAPI経由。人材書類/企業書類の署名URLはサーバでアクセス確認後に発行。

## 検証（ローカル）
- [x] typecheck（新規/変更ファイル型エラーなし）／既存テスト維持（162 pass）
- [x] 案件作成→チェックリスト→アップロード→承認/差戻し→コメント→リマインド→署名URL(200) をブラウザでE2E確認
- [x] 法人・初回・介護＝会社書類8件（営業許可証なし）

## 関連
- アプリ フェーズ1: #138（先にマージ）
- DB側フェーズ2: funtoco/fun-base-infra#67

🤖 Generated with [Claude Code](https://claude.com/claude-code)