### PR TITLE
fix: add login link to tenant invite email

### DIFF
--- a/lib/tenant-invitation-email.test.ts
+++ b/lib/tenant-invitation-email.test.ts
@@ -1,15 +1,25 @@
 import { describe, expect, it } from "vitest"
 
-import { buildTenantInvitationEmail, buildTenantInviteUrl } from "./tenant-invitation-email"
+import {
+  buildTenantInvitationEmail,
+  buildTenantInviteUrl,
+  buildTenantLoginUrl,
+} from "./tenant-invitation-email"
 
 describe("tenant invitation email", () => {
   it("builds a reusable app invite URL instead of a Supabase one-time auth link", () => {
-    expect(buildTenantInviteUrl("https://funbase.funtoco.jp", "token-123")).toBe(
+    expect(buildTenantInviteUrl("https://funbase.funtoco.jp/auth/set-password", "token-123")).toBe(
       "https://funbase.funtoco.jp/invite/token-123"
     )
   })
 
-  it("includes the reusable invite URL in text and html bodies", () => {
+  it("builds a login URL from the invite URL origin", () => {
+    expect(buildTenantLoginUrl("https://funbase.funtoco.jp/invite/token-123")).toBe(
+      "https://funbase.funtoco.jp/login"
+    )
+  })
+
+  it("includes the reusable invite URL and post-registration login URL in text and html bodies", () => {
     const email = buildTenantInvitationEmail({
       tenantName: "株式会社テスト",
       inviteUrl: "https://funbase.funtoco.jp/invite/token-123",
@@ -18,5 +28,9 @@ describe("tenant invitation email", () => {
     expect(email.subject).toBe("FunBaseへの招待: 株式会社テスト")
     expect(email.text).toContain("https://funbase.funtoco.jp/invite/token-123")
     expect(email.html).toContain("https://funbase.funtoco.jp/invite/token-123")
+    expect(email.text).toContain("参加完了後、次回以降は以下のログインページからFunBaseをご利用ください。")
+    expect(email.text).toContain("https://funbase.funtoco.jp/login")
+    expect(email.html).toContain("FunBaseにログインする")
+    expect(email.html).toContain("https://funbase.funtoco.jp/login")
   })
 })

--- a/lib/tenant-invitation-email.ts
+++ b/lib/tenant-invitation-email.ts
@@ -9,13 +9,21 @@ export function buildTenantInviteUrl(baseUrl: string, token: string): string {
   return url.toString()
 }
 
+export function buildTenantLoginUrl(inviteUrl: string): string {
+  return new URL("/login", inviteUrl).toString()
+}
+
 export function buildTenantInvitationEmail({ tenantName, inviteUrl }: TenantInvitationEmailInput) {
+  const loginUrl = buildTenantLoginUrl(inviteUrl)
   const subject = `FunBaseへの招待: ${tenantName}`
   const text = [
     `${tenantName} のFunBaseに招待されました。`,
     "",
     "以下のリンクから参加してください。",
     inviteUrl,
+    "",
+    "参加完了後、次回以降は以下のログインページからFunBaseをご利用ください。",
+    loginUrl,
     "",
     "この招待リンクは参加が完了するまで再度開けます。",
   ].join("\n")
@@ -25,6 +33,9 @@ export function buildTenantInvitationEmail({ tenantName, inviteUrl }: TenantInvi
     <p><a href="${escapeHtml(inviteUrl)}">FunBaseに参加する</a></p>
     <p>リンクが開けない場合は、以下のURLをブラウザに貼り付けてください。</p>
     <p>${escapeHtml(inviteUrl)}</p>
+    <p>参加完了後、次回以降は以下のログインページからFunBaseをご利用ください。</p>
+    <p><a href="${escapeHtml(loginUrl)}">FunBaseにログインする</a></p>
+    <p>${escapeHtml(loginUrl)}</p>
     <p>この招待リンクは参加が完了するまで再度開けます。</p>
   `
 


### PR DESCRIPTION
## 概要
FunBaseのテナント招待メールに、参加完了後に次回以降利用するログインページの案内文とリンクを追加しました。

## 元 Slack
Slackスレッド: FunBase招待メールにログイン後URLの案内を追加する依頼

## 分類
bugfix / high

## 変更点
- 招待メール本文（text/html）に「参加完了後、次回以降はログインページから利用」の案内を追加
- 招待URLと同じ信頼済みoriginから `/login` URLを生成する `buildTenantLoginUrl` を追加
- 招待URL生成・ログインURL生成・メール本文の回帰テストを更新

## テスト
- `npm test -- lib/tenant-invitation-email.test.ts` ✅
- `./node_modules/.bin/tsc --noEmit --pretty false -p /tmp/fun-base-invite-email-tsconfig.json` ✅（対象ファイルのfocused typecheck）
- `./node_modules/.bin/next build` ✅（既存警告あり: route config / Edge Runtime / Browserslist）
- `npm run lint` ⚠️ 未完了: ESLint未設定のため `next lint` が対話式セットアップを要求
- `./node_modules/.bin/tsc --noEmit --pretty false` ⚠️ 既存の型エラー多数（connector/tenant-management周辺）で失敗
- Codex review ✅ No blocking findings。指摘された本番構成に近いテストケースも追加済み

## リスク / ロールバック
- メール文面のみの変更で、招待/認証フロー自体は変更していません
- ロールバックは本PRのrevertで可能です
