### PR TITLE
docs: add manual person registration FAQ

### DIFF
--- a/__tests__/funbase-faq.test.ts
+++ b/__tests__/funbase-faq.test.ts
@@ -17,6 +17,21 @@ describe("FunBase FAQ content", () => {
     expect(questions).toContain("まず何を見れば良いですか？")
     expect(questions).toContain("ビザの進捗はどこで確認できますか？")
     expect(questions).toContain("面談や日々のサポート内容はどこで見られますか？")
+    expect(questions).toContain("人材情報を手動で新規登録する方法を教えてください")
     expect(questions).toContain("困ったときは誰に連絡すれば良いですか？")
+  })
+
+  it("adds a shareable manual person registration guide with FunBase-specific cautions", () => {
+    const manualRegistrationItem = faqSections
+      .flatMap((section) => section.items)
+      .find((item) => item.id === "manual-person-registration")
+
+    expect(manualRegistrationItem).toBeDefined()
+    expect(manualRegistrationItem?.question).toBe("人材情報を手動で新規登録する方法を教えてください")
+    expect(manualRegistrationItem?.answer).toContain("左メニューの「人材一覧」")
+    expect(manualRegistrationItem?.answer).toContain("右上の「新規登録」")
+    expect(manualRegistrationItem?.answer).toContain("Funtocoの支援内容や面談・サポート記録は自動では連携されません")
+    expect(manualRegistrationItem?.answer).toContain("FunEdu側には反映されません")
+    expect(manualRegistrationItem?.answer).not.toContain("Kintone")
   })
 })

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -59,9 +59,13 @@ export default function FaqPage() {
                 </CardHeader>
                 <CardContent className="space-y-4">
                   {section.items.map((item) => (
-                    <div key={item.question} className="rounded-xl border bg-muted/20 p-4">
+                    <div
+                      key={item.question}
+                      id={item.id}
+                      className="scroll-mt-6 rounded-xl border bg-muted/20 p-4"
+                    >
                       <h3 className="font-medium text-foreground">Q. {item.question}</h3>
-                      <p className="mt-2 text-sm leading-6 text-muted-foreground">A. {item.answer}</p>
+                      <p className="mt-2 whitespace-pre-line text-sm leading-6 text-muted-foreground">A. {item.answer}</p>
                     </div>
                   ))}
                 </CardContent>

--- a/lib/funbase-faq.ts
+++ b/lib/funbase-faq.ts
@@ -4,6 +4,7 @@ export type QuickStartStep = {
 }
 
 export type FaqItem = {
+  id?: string
   question: string
   answer: string
 }
@@ -55,6 +56,12 @@ export const faqSections: FaqSection[] = [
     title: "人材・ビザの確認",
     description: "人材ごとの状況やビザ進捗を確認する方法です。",
     items: [
+      {
+        id: "manual-person-registration",
+        question: "人材情報を手動で新規登録する方法を教えてください",
+        answer:
+          "左メニューの「人材一覧」を開き、右上の「新規登録」から登録します。登録先の会社を選び、氏名・所属先・連絡先・在留カード情報・メモなど必要な項目を入力して保存してください。必要に応じて写真も登録できます。\n\n手動登録した人材には「手動登録」ラベルが表示されます。あとから人材詳細の編集画面で基本情報を更新できます。\n\n注意点：手動登録した人材はFunBase内の人材情報として追加されますが、Funtocoの支援内容や面談・サポート記録は自動では連携されません。FunEdu側には反映されません。支援内容まで管理したい場合は、通常の連絡ルートでFuntoco担当者へご相談ください。現時点では、手動登録による追加料金は発生しません。",
+      },
       {
         question: "人材の情報はどこで確認できますか？",
         answer:


### PR DESCRIPTION
## 概要
FunBaseの「よくある問い合わせ」に、人材情報を手動で新規登録する方法のFAQを追加しました。

## 元 Slack
https://funtoco.slack.com/archives/C0B7NT5T7TK/p1782959775733669

## 分類
feature / high confidence

## 変更点
- `/faq#manual-person-registration` で直接共有できるアンカー付きFAQを追加
- 人材一覧 → 新規登録 → 必要情報入力 → 保存、という登録手順を記載
- 注意点として、Funtocoの支援内容・面談・サポート記録は自動連携されないこと、FunEdu側には反映されないこと、追加料金なしを明記
- FAQ本文の改行を表示できるよう `whitespace-pre-line` を追加

## テスト
- `./node_modules/.bin/vitest run __tests__/funbase-faq.test.ts` passed
- `./node_modules/.bin/vitest run` は既存の「No test suite found」4件で失敗（259 tests passed）
- `./node_modules/.bin/tsc --noEmit --project /tmp/funbase-faq-tsconfig.json` passed（変更対象のfocused typecheck）
- `./node_modules/.bin/tsc --noEmit` は既存の型エラーで失敗
- `./node_modules/.bin/next build` passed（既存warningあり）
- `npm run lint` は既存のNext ESLint初期設定プロンプトで停止
- `codex review --base origin/main` passed（指摘なし）

## リスク / ロールバック
- 文言・FAQ表示のみのため低リスク
- 問題があれば `lib/funbase-faq.ts` の追加FAQを戻せばロールバック可能
