### PR TITLE
fix: persist document office scope

### DIFF
--- a/app/api/people/[id]/documents/route.ts
+++ b/app/api/people/[id]/documents/route.ts
@@ -159,10 +159,10 @@ export async function POST(
       )
     }
 
-    // Get person's tenant_id
+    // Get person's tenant/office scope so RLS allows office-scoped company users to save documents.
     const { data: person, error: personError } = await supabase
       .from('people')
-      .select('tenant_id')
+      .select('tenant_id, tenant_office_id')
       .eq('id', personId)
       .single()
 
@@ -254,6 +254,7 @@ export async function POST(
       .insert({
         person_id: personId,
         tenant_id: tenantId,
+        tenant_office_id: person.tenant_office_id ?? null,
         document_type: documentType,
         storage_path: filePath,
         title: title?.trim() || documentToReplace?.title || null,

--- a/lib/supabase/person-documents.ts
+++ b/lib/supabase/person-documents.ts
@@ -115,10 +115,10 @@ export async function uploadDocumentDirect(
     return { success: false, error: '人材情報が見つかりません' }
   }
 
-  // Get person's tenant_id
+  // Get person's tenant/office scope so RLS allows office-scoped company users to save documents.
   const { data: person, error: personError } = await supabase
     .from('people')
-    .select('tenant_id')
+    .select('tenant_id, tenant_office_id')
     .eq('id', personId)
     .single()
 
@@ -188,6 +188,7 @@ export async function uploadDocumentDirect(
     .insert({
       person_id: personId,
       tenant_id: tenantId,
+      tenant_office_id: person.tenant_office_id ?? null,
       document_type: documentType,
       storage_path: filePath,
       title: options.title?.trim() || documentToReplace?.title || null,


### PR DESCRIPTION
## 概要
会社ユーザー（事業所スコープあり）がFunBaseの書類アップロードで「ドキュメントの保存に失敗しました」となる問題を修正します。

## 元 Slack
C06676D4L10 / thread 1785893672.689979

## 分類
bug / high confidence

## 変更点
- 書類保存時に、対象人材の `tenant_office_id` も取得
- `person_documents` insert 時に `tenant_office_id` を保存
- クライアント直アップロード経路とAPI POST経路の両方を修正

## テスト
- `git diff --check` 成功
- `./node_modules/.bin/tsc -p /tmp/funbase-doc-tsconfig.json` 成功（対象ファイルのみ）
- `./node_modules/.bin/next build` 成功
  - 既存警告: `/api/connectors/[id]/sync` の `maxDuration` config 警告、Supabase Edge Runtime 警告、Browserslist 警告
  - 既存ログ: `/api/users/search` などの Dynamic server usage ログ（build自体は exit 0）
- `./node_modules/.bin/tsc --noEmit` は既存の connector / tenant-management 型エラーで失敗（今回変更ファイル外）
- `codex review --base origin/main` で追加指摘なし

## リスク / ロールバック
- DB schema は既に `person_documents.tenant_office_id` が本番に存在するため migration 追加なし
- 問題があればこのPRをrevertすると従来挙動に戻せます
