### PR TITLE
fix(portal): 申請書類作成フォームのアップロードで.xlsxを選択可能に

### DIFF
--- a/components/portal/checklist-table.tsx
+++ b/components/portal/checklist-table.tsx
@@ -175,7 +175,12 @@ function RequirementRow({
             ref={fileInputRef}
             type="file"
             className="hidden"
-            accept="image/png,image/jpeg,image/webp,image/heic,image/heif,application/pdf"
+            // 申請書類作成フォーム(application_workbook)はExcel(.xlsx)、それ以外は画像/PDF。
+            accept={
+              item.documentCode === 'application_workbook'
+                ? '.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+                : 'image/png,image/jpeg,image/webp,image/heic,image/heif,application/pdf'
+            }
             onChange={(e) => {
               const file = e.target.files?.[0]
               if (file) {


### PR DESCRIPTION
## 問題
案件チェックリストで「申請書類作成フォーム(Excel)」をアップロードしようとすると、ファイル選択ダイアログで .xlsx が**グレーアウトして選べない**（macOSの「開く」ボタンが無効）。

## 原因
`components/portal/checklist-table.tsx` のファイル input の `accept` が `image/*,application/pdf` のみで、xlsx が除外されていた。サーバ側 `lib/portal/storage.ts` は xlsx/xls を許可済みなのに、フロントの選択で弾かれていた。

## 修正
要件の `documentCode === 'application_workbook'`（＝申請書類作成フォーム）の時だけ `accept` を `.xlsx, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` にする。それ以外の書類は従来どおり画像/PDF。

型チェック通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)