### PR TITLE
fix(portal): 確認中の書類も差し替え(再アップロード)できるように

### DIFF
--- a/components/portal/checklist-table.tsx
+++ b/components/portal/checklist-table.tsx
@@ -81,7 +81,8 @@ function RequirementRow({
 
   const busy = actions.busyId === item.id
   const doc = requirementDoc(item)
-  const canUpload = item.status === 'not_submitted' || item.status === 'needs_fix'
+  // 未提出/要修正はもちろん、確認中(提出済み・未承認)も差し替え可能にする。承認済みのみロック。
+  const canUpload = item.status !== 'approved'
 
   function setBusy(on: boolean) {
     setActions((prev) => ({ ...prev, busyId: on ? item.id : null }))
@@ -198,7 +199,11 @@ function RequirementRow({
               className="gap-1"
             >
               <Upload className="h-3.5 w-3.5" />
-              {item.status === 'needs_fix' ? '再提出' : 'アップロード'}
+              {item.status === 'needs_fix'
+                ? '再提出'
+                : item.status === 'reviewing'
+                  ? '差し替え'
+                  : 'アップロード'}
             </Button>
           )}
           {doc && (

--- a/lib/portal/documents.ts
+++ b/lib/portal/documents.ts
@@ -107,9 +107,10 @@ export async function uploadRequirementDocument(params: {
       .eq('document_code', requirement.document_code)
       .maybeSingle()
 
+    // 差し替えで同名ファイルを上げ直しても同一パスを上書きできるよう upsert:true。
     const { error: uploadError } = await service.storage
       .from(OFFICE_BUCKET)
-      .upload(objectKey, buffer, { contentType, upsert: false })
+      .upload(objectKey, buffer, { contentType, upsert: true })
     if (uploadError) {
       console.error('Office storage upload error:', uploadError)
       return { ok: false, status: 500, error: 'ファイルのアップロードに失敗しました' }
@@ -179,9 +180,10 @@ export async function uploadRequirementDocument(params: {
     fileName: file.name,
   })
 
+  // 差し替えで同名ファイルを上げ直しても同一パスを上書きできるよう upsert:true。
   const { error: uploadError } = await service.storage
     .from(PERSON_BUCKET)
-    .upload(objectKey, buffer, { contentType, upsert: false })
+    .upload(objectKey, buffer, { contentType, upsert: true })
   if (uploadError) {
     console.error('Person storage upload error:', uploadError)
     return { ok: false, status: 500, error: 'ファイルのアップロードに失敗しました' }


### PR DESCRIPTION
## 問題
申請書類作成フォーム等を一度アップロードすると「確認中」になり、**アップロードボタンが消えて再アップロードできない**。設定後の再テストや、間違えた時の差し替えができない。

## 修正
1. `checklist-table.tsx`: `canUpload` を「承認済み(approved)以外」に拡大。確認中(reviewing)ではボタン文言を「差し替え」に。
2. `documents.ts`: storage.upload を `upsert:true` に（従来 `upsert:false` で**同名ファイルを上げ直すと「already exists」で失敗**していた）。office/person 両方。

差し替え時は既存 `office_documents` を upsert 更新し、status を確認中に戻して、アップロードAPIが自動転記(`maybeAutoTranscribeOnUpload`)を再実行する。

型チェック通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)