### PR TITLE
feat(portal): 申請書類フォーム提出時の登録・連携中の進捗表示

### DIFF
--- a/components/portal/checklist-table.tsx
+++ b/components/portal/checklist-table.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { Building2, Eye, Upload } from 'lucide-react'
+import { Building2, Eye, Loader2, Upload } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -83,6 +83,8 @@ function RequirementRow({
   const doc = requirementDoc(item)
   // 未提出/要修正はもちろん、確認中(提出済み・未承認)も差し替え可能にする。承認済みのみロック。
   const canUpload = item.status !== 'approved'
+  // 申請書類作成フォームは提出時に内容登録・連携が走る（時間がかかる）ので進捗表示を出し分ける。
+  const isWorkbook = item.documentCode === 'application_workbook'
 
   function setBusy(on: boolean) {
     setActions((prev) => ({ ...prev, busyId: on ? item.id : null }))
@@ -106,7 +108,33 @@ function RequirementRow({
         })
         return
       }
-      toast({ title: '提出しました', description: `「${item.name}」を提出しました（確認中）。` })
+      // 申請書類作成フォームは提出時に内容を登録・連携する。その結果をメッセージに反映（社内名は出さない）。
+      const auto = (
+        result as {
+          autoTranscribe?: {
+            triggered?: boolean
+            summary?: { dryRun: boolean; app55Ok: number; app55Error: number; app55Total: number }
+          }
+        }
+      ).autoTranscribe
+      const s = auto?.summary
+      if (s && !s.dryRun && s.app55Error > 0) {
+        toast({
+          variant: 'destructive',
+          title: '提出しました（一部の登録・連携に失敗）',
+          description: `内容を登録・連携しました（成功 ${s.app55Ok}件・エラー ${s.app55Error}件／計 ${s.app55Total}件）。`,
+        })
+      } else if (s && !s.dryRun) {
+        toast({
+          title: '提出・登録が完了しました',
+          description:
+            s.app55Total > 0
+              ? `内容を確認して登録・連携しました（${s.app55Total}件）。`
+              : '内容を確認して登録・連携しました。',
+        })
+      } else {
+        toast({ title: '提出しました', description: `「${item.name}」を提出しました（確認中）。` })
+      }
       router.refresh()
     } catch {
       toast({
@@ -198,12 +226,21 @@ function RequirementRow({
               onClick={() => fileInputRef.current?.click()}
               className="gap-1"
             >
-              <Upload className="h-3.5 w-3.5" />
-              {item.status === 'needs_fix'
-                ? '再提出'
-                : item.status === 'reviewing'
-                  ? '差し替え'
-                  : 'アップロード'}
+              {busy ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  {isWorkbook ? '内容を確認して登録・連携中…' : 'アップロード中…'}
+                </>
+              ) : (
+                <>
+                  <Upload className="h-3.5 w-3.5" />
+                  {item.status === 'needs_fix'
+                    ? '再提出'
+                    : item.status === 'reviewing'
+                      ? '差し替え'
+                      : 'アップロード'}
+                </>
+              )}
             </Button>
           )}
           {doc && (

--- a/lib/portal/kintone-sync/run-transcription.ts
+++ b/lib/portal/kintone-sync/run-transcription.ts
@@ -169,6 +169,26 @@ export async function runCaseTranscription(params: {
   }
 }
 
+/** アップロード時自動転記の結果サマリ（UIの「連携中→反映済/エラー」表示用）。 */
+export interface AutoTranscribeSummary {
+  /** 認証未設定などでドライラン（実書き込みなし）だったか。 */
+  dryRun: boolean
+  /** 法人(app34)の操作。 */
+  app34Action: TranscribeResult['plan']['action']
+  /** 雇用条件書(app55)の反映成功件数。 */
+  app55Ok: number
+  /** 雇用条件書(app55)のエラー件数。 */
+  app55Error: number
+  /** 雇用条件書(app55)の対象人数。 */
+  app55Total: number
+}
+
+export interface MaybeAutoTranscribeResult {
+  triggered: boolean
+  reason?: string
+  summary?: AutoTranscribeSummary
+}
+
 /**
  * アップロード自動トリガー。
  * 対象要件が application_workbook（office 提出Excel）で、案件が app296 と紐付いていれば、
@@ -177,7 +197,7 @@ export async function runCaseTranscription(params: {
 export async function maybeAutoTranscribeOnUpload(params: {
   caseId: string
   requirementId: string
-}): Promise<{ triggered: boolean; reason?: string }> {
+}): Promise<MaybeAutoTranscribeResult> {
   const service = getServiceClient()
 
   // 要件の document_code を確認（application_workbook 以外は対象外）。
@@ -204,10 +224,19 @@ export async function maybeAutoTranscribeOnUpload(params: {
     return { triggered: false, reason: 'no_kintone_link' }
   }
 
-  await runCaseTranscription({
+  const result = await runCaseTranscription({
     caseId: params.caseId,
     kintoneCaseId,
     dryRun: false,
   })
-  return { triggered: true }
+  return {
+    triggered: true,
+    summary: {
+      dryRun: result.dryRun,
+      app34Action: result.app34.plan.action,
+      app55Ok: result.app55Writes.filter((w) => w.action === 'update').length,
+      app55Error: result.app55Writes.filter((w) => w.action === 'error').length,
+      app55Total: result.app55Writes.length,
+    },
+  }
 }


### PR DESCRIPTION
## 概要
申請書類作成フォーム(Excel)の提出時、内容の登録・連携（kintone転記）が同一リクエストで走り時間がかかるが、UI上はボタンがグレーになるだけで「何か動いているか」分からなかった（ユーザー要望）。

## 変更
- アップロード中は**スピナー＋「内容を確認して登録・連携中…」**を表示（企業ユーザー向けに社内システム名は出さない）。
- 提出結果のサマリ（反映件数/エラー件数）をトーストに反映：「提出・登録が完了しました（N件）」／一部エラー時は件数付きで警告。
- `maybeAutoTranscribeOnUpload` が転記サマリ（app55反映件数・エラー・dryRun）を返すよう拡張。ドライラン時は連携完了を謳わない。

型チェック・テスト(35)通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)