### PR TITLE
docs(skill): 申請書類フォーム→kintone転記マッピングのスキルを追加

### DIFF
--- a/.claude/skills/kintone-transcribe-mapping/SKILL.md
+++ b/.claude/skills/kintone-transcribe-mapping/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: kintone-transcribe-mapping
+description: >-
+  FunBaseの申請書類作成フォーム(Excel)→kintone(app55=就労_ビザ書類作成_雇用条件書 / app34=マスタ_法人)
+  への「転記マッピング」を追加・修正・検証する時の手順とハマりどころ。以下のような時は必ずこのスキルを使うこと：
+  Excelの欄をkintoneに転記したい／マッピングを追加・修正したい／雇用条件書(app55)や法人(app34)のフィールドを増やしたい／
+  「転記したのにkintoneに入らない・空になる」を調べたい／アップロード用のテスト用Excelを作りたい／
+  lib/portal/kintone-sync/ 配下(mappings/transcribe/transforms/build-records/run-transcription)を触る時。
+  Excel⇄kintone・雇用条件書・転記・マッピング・提出フォームといった話題なら明示的に頼まれなくても発動する。
+---
+
+# 申請書類フォーム(Excel) → kintone 転記マッピング
+
+FunBaseの提出Excel「申請書類作成フォーム」を kintone へ転記する仕組みの**マッピング作業ガイド**。
+セル↔フィールド対応を足す／直す／検証する時に使う。ハマりどころは実際に踏んだものばかりなので必ず目を通すこと。
+
+## 転記の全体像
+- 発生源 = kintone「就労_ビザ案件管理」**app296**。案件レコードが company_ref(→app34) と koyou_details サブテーブル(→app55を複数人)を**事前紐付け**（Aモデル＝照合レス）。
+- 転記先 = **app34**(マスタ_法人 / company_ref) と **app55**(雇用条件書 / 各人)。app36(事業所)は対象外。
+- 提出Excelの共通payloadを各人の app55 へ **fan-out**。人固有(氏名/性別/経験年数)は転記せず kintone の HRIDルックアップが補完。
+
+## 主要ファイル
+- `lib/portal/kintone-sync/mappings/app34.ts` / `app55.ts` — セル↔フィールドのマッピング定義（`fields[]` / `derived[]` / `subtables[]`）
+- `transcribe.ts` — 転記エンジン。`transcribeWorkbook`(app34転記＋app55 payload生成)、`buildApp55Record`、`APP55_PERSON_SPECIFIC_CODES`
+- `build-records.ts` — `buildRecord`（fields先勝ち／CHECK_BOXはOR合成／derived合成／subtable展開）
+- `types.ts` — `FieldMapping` / `DerivedFieldMapping` / `SubtableMapping`
+- `transforms.ts` — `asText/asNumber/asDate/checkboxOn/checkboxFromText/checkboxAlways/radioFromText/keepIfEquals/constantText/combineYmdDate`
+- `run-transcription.ts` — `runCaseTranscription`(紐付け解決→app34 update＋app55 fan-out→app296書戻し) / `maybeAutoTranscribeOnUpload`(アップロード時自動トリガー)
+- kintone認証(ローカル) = `~/workspace/funtoco/fun-hubspot-to-kintone/.env`（KINTONE_BASE_URL / KINTONE_USERNAME / KINTONE_PASSWORD、password認証）
+- 同梱スクリプトは `scripts/`（下記手順で使う。パスは冒頭のTODOを書き換える）
+
+## マッピングを追加する手順
+1. **kintoneフィールドの実在・型を確認**：`/k/v1/app/form/fields.json?app=55` を取得（`X-Cybozu-Authorization: base64(user:pass)`）。
+2. **書込可能か確認【最重要 → ハマり①】**：ルックアップのコピー先／CALCは書けない。`scripts/scan_locked_fields.py` で除外。
+3. **Excelの入力セルを特定【ハマり④】**：`scripts/detect_inputs.py`（条件付き書式から入力欄を検出）。
+4. **app55.ts / app34.ts にフィールド追加**：`{ sheetName, cell, code, kind, transform }`。日付分割は `derived`【ハマり②】、■/□は `checkboxFromText`【ハマり③】、サブテーブルは `subtables`。
+5. **検証**：全項目フォーム(`scripts/build_test_form.py`)を作り `transcribeWorkbook` を dryRun → **payloadだけでなく実際にkintoneへ書いて再取得**して入ったか確認【ハマり①/検証の型】。
+6. `pnpm`（npmではない）で `npx tsc --noEmit` と `npx vitest run __tests__/portal-kintone-transcribe.test.ts`。マッピングのみの変更ならDBマイグレ無し。
+
+## ハマりどころ（実際に踏んだ学び）
+
+### ① kintoneの「ルックアップ自動コピー先」は書込不可 ★最重要
+app55の多くのフィールドは、別ルックアップ（**事業所OFID / COID / HRID / 相談担当者 / 連絡先ID_資料作成者**等）が
+app36やマスタから**自動供給するコピー先**。`updateRecord`は**成功するのに値が入らない**（エラーにならず無視される）。CALCも書込不可。
+- 検出：app fields JSON の各フィールド `lookup.fieldMappings[].field`（=コピー先）を全走査 → `scripts/scan_locked_fields.py`。
+- 確証：`{"app":55,"id":<rec>,"record":{"<code>":{"value":"TEST"}}}` を PUT → 再取得して消えていれば書込ロック確定。
+- 対処：マッピングから外す。これらは app55 に OFID 等が設定されれば kintone 側で自動的に入る（Excel転記対象外が正しい）。
+- 実例で外したもの：事業所名/郵便/住所/連絡先・労働保険番号/雇用保険番号・所定労働時間(週月年)・所定労働日数(週月年)・年間休日・契約更新の有無・相談窓口・特定技能所属機関名・資料作成者。
+
+### ② 日付が「年/月/日」の3セルに分かれている
+kintoneの年/月/日フィールドは単一DATEからの**CALC**＝書けるのは日付フィールド1つだけ。
+Excelの3セルを `combineYmdDate([年,月,日])` ＋ `derived` マッピング（複数セル→1フィールドの合成機構）で1日付に組み立てる。単位付き('2026年')も吸収、欠け/範囲外はnull。
+
+### ③ ■/□ マーカーのチェックは checkboxFromText(['■'])
+■のときON。`checkboxOn` は「非空なら真」なので **□ も誤ってONになる**。exact一致の `checkboxFromText(['■'])` を使う。
+
+### ④ Excelの入力セルは「条件付き書式」で分かる
+入力欄は空だとピンク＝`containsBlanks`の条件付き書式（`LEN(TRIM(cell))=0`）。そのCF範囲＝入力セル。テンプレでは空なので、
+`scripts/detect_inputs.py` でCF範囲→結合アンカー→ラベル(テンプレに値ありの左見出し)を除外して抽出。
+入力位置の規則：**単位ラベル(時/分/月/日/回)のすぐ左のセル**＝入力、**赤い結合枠**＝入力欄。
+
+### ⑤ テスト用Excelは openpyxl 再保存禁止（画像消失・破損の元）
+openpyxlでテンプレを再保存すると**全シートの画像が消え**（1-6は10枚等）、結合の一括解除で見た目が崩れ、exceljsが`anchors`エラーで読めなくなる。
+→ **lxmlで `xl/worksheets/sheetN.xml` の該当セル値だけ書き換えてzip再パッケージ**（`scripts/build_test_form.py`）。画像/結合/書式/図形を100%保持し、exceljsも元形式のまま読める。値は inlineStr(text)/`<v>`(number)/`t="b"`(bool)。
+- **数式セルを値で上書きしたら `xl/calcChain.xml` を除去**（＋`[Content_Types].xml`のOverrideと`xl/_rels/workbook.xml.rels`のRelationshipも）。残すと索引と矛盾→**Excelが「修復」して結合を消す**（openpyxl読取では正常に見えるので気づけない）。
+- **Excel修復の主因チェック順**：(a)結合の非アンカーに値／(b)セル・行の順序不正・重複・spans外／(c)calcChain矛盾。
+- テンプレ(ユーザー添付)は即 scratchpad にバックアップ（Downloadsは消える）。
+
+### ⑥ テストデータの安全
+- **app34は転記先が実在法人**(company_ref)。適当な値を入れると法人マスタを壊す → **no-op（その法人の現在値をそのまま入れる）**で保護。
+- app55は**捨てレコード**へfan-out。**掃除はID指定のみ**（kintoneのlike検索は全文/トークン一致で誤爆し、無関係レコードを消す事故がある）。
+- 事業所名などは**kintoneとFunBaseで名寄せが一致するテナント**を選ぶ（不一致だとWebhookミラーが `office_not_resolved` でサイレントskip）。
+
+## 本番で「転記されない」時の切り分け
+- **Vercel(fun-studio-v0)にkintone書込認証(`KINTONE_BASE_URL`/`KINTONE_USERNAME`/`KINTONE_PASSWORD` or `KINTONE_API_TOKEN_APP34`)が未設定 → `createKintoneWriteClientFromEnv()`がnull → 転記がドライラン → 無反映**。app296の `sync_log` 空・`synced_at` 空で判別。API tokenは1アプリのみ＝複数アプリ(34/55/296)書込は**ユーザー/パス方式**が必要。**パスワードをフォームに入力する設定は安全ルール上こちらでは行わない**＝ユーザーがVercel画面で設定→Redeploy。
+- 回避で今すぐ流すなら、ローカル認証を読み込んで tsx 直接実行（`set -a; . fun-hubspot-to-kintone/.env; set +a; tsx script.ts`）。
+- アップロード欄でExcelが**選べない**＝`components/portal/checklist-table.tsx`のfile input `accept`にxlsxが無い（`application_workbook`の時だけ `.xlsx` を許可）。
+- 一度提出すると「確認中」で再アップロード不可＝`canUpload`を承認済み以外に拡大＋storage `upsert:true`（同名上書き）で差し替え可能に。
+
+## 検証の型（合言葉）
+「**updateRecord が成功するのに値が入らない**」＝ハマり①（ルックアップ書込ロック/CALC）を疑う。
+payloadに入っていても書けていないことがあるので、**必ずkintone側を再取得して確認**する。dryRunのpayload一致だけで「OK」としない。

--- a/.claude/skills/kintone-transcribe-mapping/scripts/build_test_form.py
+++ b/.claude/skills/kintone-transcribe-mapping/scripts/build_test_form.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""テスト用の記入済み申請書類フォームを「テンプレの見た目を壊さずに」作る（ハマり⑤）。
+
+openpyxl でテンプレを再保存すると全シートの画像が消え、結合一括解除で崩れ、exceljsが
+`anchors` エラーで読めなくなる。→ lxml で xl/worksheets/sheetN.xml の該当セル値だけ
+書き換えて zip 再パッケージする。画像/結合/書式/図形を100%保持し、exceljsも読める。
+
+さらに、数式セルを値で上書きすると xl/calcChain.xml と矛盾し Excel が「修復」して結合を
+消すため、calcChain.xml とその宣言(Content_Types / workbook.rels)も出力から除去する。
+
+使い方:
+  1. SRC/OUT を実パスに。SRC はユーザー添付テンプレ（消える前に scratchpad へコピーしておく）。
+  2. FILL に {シート名: {セル: 値}} を書く。値の型で自動判定:
+       str -> inlineStr / int|float -> 数値 / bool(True/False) -> チェックボックス等の真偽
+     ※ app34(実在法人)に書くセルは現在値そのまま(no-op)にして法人マスタを壊さない。
+  3. 実行 -> OUT が生成される。openpyxl で結合/画像がテンプレと一致するか確認し、
+     transcribeWorkbook(dryRun) で payload を、実書込で kintone を再取得して検証する。
+"""
+import re
+import zipfile
+from lxml import etree
+
+# TODO: 実パスに変更
+SRC = "template.xlsx"
+OUT = "test_form.xlsx"
+
+# TODO: {シート名: {セル参照: 値}} を埋める
+FILL = {
+    # "はじめに": {"E14": "8011405000064", "E16": "12345678901"},
+    # "1-6": {"B17": 2026, "E17": 9, "G17": 1, "B32": True, "M25": "■"},
+}
+
+NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+RELNS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+XML_SPACE = "{http://www.w3.org/XML/1998/namespace}space"
+
+
+def col_to_num(col):
+    n = 0
+    for ch in col:
+        n = n * 26 + (ord(ch) - 64)
+    return n
+
+
+def split_ref(ref):
+    m = re.match(r"([A-Z]+)(\d+)", ref)
+    return m.group(1), int(m.group(2))
+
+
+def set_cell(sheet_data, ref, val):
+    col, row = split_ref(ref)
+    colnum = col_to_num(col)
+    # find/create <row> (行番号昇順を維持)
+    row_el = None
+    for r in sheet_data.findall(f"{{{NS}}}row"):
+        if int(r.get("r")) == row:
+            row_el = r
+            break
+    if row_el is None:
+        row_el = etree.Element(f"{{{NS}}}row")
+        row_el.set("r", str(row))
+        placed = False
+        for r in sheet_data.findall(f"{{{NS}}}row"):
+            if int(r.get("r")) > row:
+                r.addprevious(row_el)
+                placed = True
+                break
+        if not placed:
+            sheet_data.append(row_el)
+    # find/create <c> (列昇順・style属性 s は保持)
+    c_el = None
+    for c in row_el.findall(f"{{{NS}}}c"):
+        if c.get("r") == ref:
+            c_el = c
+            break
+    if c_el is None:
+        c_el = etree.Element(f"{{{NS}}}c")
+        c_el.set("r", ref)
+        placed = False
+        for c in row_el.findall(f"{{{NS}}}c"):
+            ccol, _ = split_ref(c.get("r"))
+            if col_to_num(ccol) > colnum:
+                c.addprevious(c_el)
+                placed = True
+                break
+        if not placed:
+            row_el.append(c_el)
+    # 値を設定（既存の子要素・t属性をクリア、s=styleは残す）
+    for ch in list(c_el):
+        c_el.remove(ch)
+    if c_el.get("t") is not None:
+        del c_el.attrib["t"]
+    if isinstance(val, bool):
+        c_el.set("t", "b")
+        etree.SubElement(c_el, f"{{{NS}}}v").text = "1" if val else "0"
+    elif isinstance(val, (int, float)):
+        etree.SubElement(c_el, f"{{{NS}}}v").text = ("%g" % val) if isinstance(val, float) else str(val)
+    else:
+        c_el.set("t", "inlineStr")
+        t_el = etree.SubElement(etree.SubElement(c_el, f"{{{NS}}}is"), f"{{{NS}}}t")
+        t_el.set(XML_SPACE, "preserve")
+        t_el.text = str(val)
+
+
+def build(src=SRC, out=OUT, fill=FILL):
+    zin = zipfile.ZipFile(src)
+    wb = etree.fromstring(zin.read("xl/workbook.xml"))
+    rels = etree.fromstring(zin.read("xl/_rels/workbook.xml.rels"))
+    rid_to_target = {rel.get("Id"): rel.get("Target") for rel in rels}
+    name_to_path = {}
+    for sh in wb.find(f"{{{NS}}}sheets"):
+        tgt = rid_to_target[sh.get(f"{{{RELNS}}}id")]
+        name_to_path[sh.get("name")] = tgt if tgt.startswith("xl/") else "xl/" + tgt
+
+    edited = {}
+    for sheet, cells in fill.items():
+        path = name_to_path[sheet]
+        tree = etree.fromstring(zin.read(path))
+        sd = tree.find(f"{{{NS}}}sheetData")
+        for ref, val in cells.items():
+            set_cell(sd, ref, val)
+        edited[path] = etree.tostring(tree, xml_declaration=True, encoding="UTF-8", standalone=True)
+
+    # calcChain.xml を除去（数式セルを値で上書きした矛盾でExcelが修復→結合を消すのを防ぐ）
+    ct = zin.read("[Content_Types].xml").decode("utf-8")
+    ct = re.sub(r'<Override[^>]*PartName="/xl/calcChain\.xml"[^>]*/>', "", ct)
+    rels_wb = zin.read("xl/_rels/workbook.xml.rels").decode("utf-8")
+    rels_wb = re.sub(r'<Relationship[^>]*Target="calcChain\.xml"[^>]*/>', "", rels_wb)
+
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as zout:
+        for item in zin.infolist():
+            if item.filename == "xl/calcChain.xml":
+                continue
+            if item.filename == "[Content_Types].xml":
+                zout.writestr(item, ct)
+                continue
+            if item.filename == "xl/_rels/workbook.xml.rels":
+                zout.writestr(item, rels_wb)
+                continue
+            zout.writestr(item, edited.get(item.filename, zin.read(item.filename)))
+    zin.close()
+    print("SAVED (画像/結合/書式を保持・calcChain除去):", out)
+
+
+if __name__ == "__main__":
+    build()

--- a/.claude/skills/kintone-transcribe-mapping/scripts/detect_inputs.py
+++ b/.claude/skills/kintone-transcribe-mapping/scripts/detect_inputs.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""申請書類フォームのExcel入力セルを検出する（ハマり④）。
+
+入力欄は「空だとピンク」＝条件付き書式 containsBlanks(LEN(TRIM(cell))=0)。
+そのCF範囲＝入力セル。テンプレでは空なので、CF範囲→結合アンカー→
+ラベル(テンプレに値ありの左見出し)を除外して抽出する。
+
+使い方: TEMPLATE を実テンプレのパスに書き換えて実行。
+  未マッピング入力欄だけ見たい時は MAPPED_CODES / MAPPED_CELLS を渡して除外する。
+"""
+import json
+import re
+import openpyxl
+from openpyxl.utils import range_boundaries, get_column_letter, coordinate_to_tuple
+
+# TODO: 実テンプレのパスに変更
+TEMPLATE = "template.xlsx"
+# 企業が実際に記入する表示シートだけ対象にする（DATA/dekisugi用/1-23等の非表示は除外）
+INPUT_SHEETS = ["はじめに", "1-4", "1-6", "1-6別紙", "居住費の詳細",
+                "【介護分野】事業所概要1"]
+# app34(法人マスタ=実在企業)に書くセルは仮データ禁止。マッピングに応じて調整。
+APP34_CELLS = set()  # 例: {("はじめに","E14"), ("1-11-1","K32"), ...}
+
+
+def label_left(ws, ref):
+    r, c = coordinate_to_tuple(ref)
+    for cc in range(c - 1, max(0, c - 8), -1):
+        v = ws.cell(row=r, column=cc).value
+        if v not in (None, "") and not str(v).startswith("="):
+            return str(v).replace("\n", " ").strip()[:32]
+    return "?"
+
+
+def anchor_of(ws, ref):
+    r, c = coordinate_to_tuple(ref)
+    for m in ws.merged_cells.ranges:
+        mc, mr, xc, xr = range_boundaries(str(m))
+        if mr <= r <= xr and mc <= c <= xc:
+            return f"{get_column_letter(mc)}{mr}"
+    return ref
+
+
+def detect(template=TEMPLATE, mapped=frozenset()):
+    wb = openpyxl.load_workbook(template)
+    out = {}
+    for s in INPUT_SHEETS:
+        if s not in wb.sheetnames:
+            continue
+        ws = wb[s]
+        anchors = {}
+        for cf_range in ws.conditional_formatting:
+            for rule in ws.conditional_formatting[cf_range]:
+                if rule.type != "containsBlanks":
+                    continue
+                for part in str(cf_range.sqref).split():
+                    mc, mr, xc, xr = range_boundaries(part)
+                    for r in range(mr, xr + 1):
+                        for c in range(mc, xc + 1):
+                            ref = f"{get_column_letter(c)}{r}"
+                            a = anchor_of(ws, ref)
+                            if ws[a].value not in (None, ""):
+                                continue  # ラベルは入力欄でない
+                            if (s, a) in APP34_CELLS or (s, a) in mapped:
+                                continue
+                            anchors[a] = label_left(ws, a)
+        out[s] = anchors
+    return out
+
+
+if __name__ == "__main__":
+    res = detect()
+    for sheet, cells in res.items():
+        print(f"\n### {sheet} （{len(cells)}欄） ###")
+        for a, lab in cells.items():
+            print(f"  {a}: {lab}")
+    print("\n合計:", sum(len(v) for v in res.values()))

--- a/.claude/skills/kintone-transcribe-mapping/scripts/scan_locked_fields.py
+++ b/.claude/skills/kintone-transcribe-mapping/scripts/scan_locked_fields.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""kintone app の「書込ロック項目」を洗い出す（ハマり①）。
+
+ルックアップのコピー先(lookup.fieldMappings[].field)と CALC は updateRecord で書いても
+エラーにならず無視される。マッピングに入れても no-op になるので事前に除外する。
+
+使い方:
+  1. app fields を保存: curl -H "X-Cybozu-Authorization: $AUTH" \
+       "$BASE/k/v1/app/form/fields.json?app=55" > app55_fields.json
+  2. python scan_locked_fields.py app55_fields.json [チェックしたいコード...]
+     引数のコードを省略すると、ロック対象フィールドを全部一覧する。
+
+確証したい時は直接PUTして消えるか見る:
+  curl -X PUT "$BASE/k/v1/record.json" -H "Content-Type: application/json" \
+    -d '{"app":55,"id":<rec>,"record":{"<code>":{"value":"TEST"}}}'
+  → 再取得して空なら書込ロック確定。
+"""
+import json
+import sys
+
+
+def load_locked(fields_json_path):
+    props = json.load(open(fields_json_path))["properties"]
+    copy_dest = {}  # コピー先フィールド -> それを供給するルックアップ元
+    for code, v in props.items():
+        lk = v.get("lookup")
+        if lk:
+            for fm in lk.get("fieldMappings", []):
+                copy_dest[fm.get("field")] = code
+    calc = {c for c, v in props.items() if v.get("type") == "CALC"}
+    return copy_dest, calc
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: python scan_locked_fields.py <app_fields.json> [code ...]")
+        sys.exit(1)
+    copy_dest, calc = load_locked(sys.argv[1])
+    check = sys.argv[2:]
+    if check:
+        for c in check:
+            base = c.split(".")[0]  # サブテーブルは code.sub 形式
+            if base in copy_dest:
+                print(f"  ★ロック {c} ← {copy_dest[base]}ルックアップ自動コピー")
+            elif base in calc:
+                print(f"  ★ロック {c} ← CALC(自動計算)")
+            else:
+                print(f"    OK   {c} (書込可)")
+    else:
+        print("=== ルックアップ自動コピー先 (書込ロック) ===")
+        for dest, src in sorted(copy_dest.items()):
+            print(f"  {dest} ← {src}")
+        print("\n=== CALC (書込不可) ===")
+        for c in sorted(calc):
+            print(f"  {c}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要
今回のセッションの学びを **`.claude/skills/kintone-transcribe-mapping`** に集約したスキル。申請書類作成フォーム(Excel)→kintone(app55雇用条件書/app34法人)の転記マッピングを追加・修正・検証する時の手順とハマりどころ＋再利用スクリプトをまとめる。

## ハマりどころ（実際に踏んだ学び）
1. **ルックアップ自動コピー先/CALCは書込不可** — updateRecordが成功するのに値が入らない。事前に走査して除外。
2. **年/月/日3セル分割** → `combineYmdDate` + `derived` で1日付に合成。
3. **■/□マーカー** → `checkboxFromText(['■'])`（checkboxOnは□も誤ON）。
4. **入力セルは条件付き書式(containsBlanks)で検出**。
5. **テストExcelはopenpyxl再保存禁止**（画像消失・破損）→ lxml外科的XML編集＋`calcChain.xml`除去（画像/結合/書式を保持）。
6. **app34はno-op（実在法人保護）／掃除はID指定のみ**。
- ＋本番でkintone書込認証未設定だとドライランで無反映になる切り分け。

## 同梱スクリプト
- `scan_locked_fields.py` — 書込ロック(ルックアップコピー先/CALC)検出
- `detect_inputs.py` — Excel入力欄検出（条件付き書式ベース）
- `build_test_form.py` — 外科的XML編集でテスト用Excel生成（画像/結合保持）

py構文チェック済み。ドキュメント/スキルのみ（コード非依存）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)