### PR TITLE
fix(portal): 連続アップロード時に前の行のローディング表示が消える

### DIFF
--- a/__tests__/portal-busy-ids.test.ts
+++ b/__tests__/portal-busy-ids.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { NO_BUSY, markBusy, clearBusy, isBusy } from '@/lib/portal/busy-ids'
+
+describe('busy-ids: 行ごとの処理中状態', () => {
+  it('複数の行を同時に処理中にできる（連続アップロードで前の行の表示が消えない）', () => {
+    const busy = markBusy(markBusy(NO_BUSY, 'r1'), 'r2')
+    expect(isBusy(busy, 'r1')).toBe(true)
+    expect(isBusy(busy, 'r2')).toBe(true)
+  })
+
+  it('完了した行だけ解除し、他の行は処理中のまま残る', () => {
+    const busy = clearBusy(markBusy(markBusy(NO_BUSY, 'r1'), 'r2'), 'r1')
+    expect(isBusy(busy, 'r1')).toBe(false)
+    expect(isBusy(busy, 'r2')).toBe(true)
+  })
+
+  it('同じ行を二重に開始しても1件として扱う', () => {
+    const busy = markBusy(markBusy(NO_BUSY, 'r1'), 'r1')
+    expect(busy.size).toBe(1)
+  })
+
+  it('処理中でない行の解除は何も壊さない', () => {
+    expect(isBusy(clearBusy(NO_BUSY, 'r1'), 'r1')).toBe(false)
+  })
+
+  it('毎回新しい Set を返す（React が再描画できるよう参照を変える）', () => {
+    const a = markBusy(NO_BUSY, 'r1')
+    expect(a).not.toBe(NO_BUSY)
+    expect(clearBusy(a, 'r1')).not.toBe(a)
+    // 元の状態は書き換えない
+    expect(isBusy(NO_BUSY, 'r1')).toBe(false)
+    expect(isBusy(a, 'r1')).toBe(true)
+  })
+})

--- a/components/portal/checklist-table.tsx
+++ b/components/portal/checklist-table.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/ui/table'
 import { useToast } from '@/lib/hooks/use-toast'
 import { cn } from '@/lib/utils'
+import { NO_BUSY, markBusy, clearBusy, isBusy, type BusyIds } from '@/lib/portal/busy-ids'
 import {
   COPY_TYPE_LABELS,
   REQUIREMENT_STATUS_LABELS,
@@ -60,34 +61,31 @@ function requirementDoc(
   return null
 }
 
-interface RowActionsState {
-  busyId: string | null
-}
-
 function RequirementRow({
   caseId,
   item,
-  actions,
-  setActions,
+  busyIds,
+  setBusyIds,
 }: {
   caseId: string
   item: CaseDocumentRequirement
-  actions: RowActionsState
-  setActions: React.Dispatch<React.SetStateAction<RowActionsState>>
+  busyIds: BusyIds
+  setBusyIds: React.Dispatch<React.SetStateAction<BusyIds>>
 }) {
   const router = useRouter()
   const { toast } = useToast()
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  const busy = actions.busyId === item.id
+  const busy = isBusy(busyIds, item.id)
   const doc = requirementDoc(item)
   // 未提出/要修正はもちろん、確認中(提出済み・未承認)も差し替え可能にする。承認済みのみロック。
   const canUpload = item.status !== 'approved'
   // 申請書類作成フォームは提出時に内容登録・連携が走る（時間がかかる）ので進捗表示を出し分ける。
   const isWorkbook = item.documentCode === 'application_workbook'
 
+  // 行ごとに独立して管理する。連続アップロード中に他の行の表示を消さないため。
   function setBusy(on: boolean) {
-    setActions((prev) => ({ ...prev, busyId: on ? item.id : null }))
+    setBusyIds((prev) => (on ? markBusy(prev, item.id) : clearBusy(prev, item.id)))
   }
 
   async function handleUpload(file: File) {
@@ -267,16 +265,16 @@ function ChecklistSection({
   icon,
   items,
   emptyLabel,
-  actions,
-  setActions,
+  busyIds,
+  setBusyIds,
 }: {
   caseId: string
   title: string
   icon: React.ReactNode
   items: CaseDocumentRequirement[]
   emptyLabel: string
-  actions: RowActionsState
-  setActions: React.Dispatch<React.SetStateAction<RowActionsState>>
+  busyIds: BusyIds
+  setBusyIds: React.Dispatch<React.SetStateAction<BusyIds>>
 }) {
   return (
     <div className="rounded-xl border border-border bg-card shadow-sm">
@@ -305,8 +303,8 @@ function ChecklistSection({
                   key={item.id}
                   caseId={caseId}
                   item={item}
-                  actions={actions}
-                  setActions={setActions}
+                  busyIds={busyIds}
+                  setBusyIds={setBusyIds}
                 />
               ))}
             </TableBody>
@@ -324,7 +322,7 @@ export function ChecklistTable({
   caseId: string
   requirements: GroupedRequirements
 }) {
-  const [actions, setActions] = useState<RowActionsState>({ busyId: null })
+  const [busyIds, setBusyIds] = useState<BusyIds>(NO_BUSY)
 
   return (
     <div className="space-y-6">
@@ -334,8 +332,8 @@ export function ChecklistTable({
         icon={<Building2 className="h-4 w-4 text-muted-foreground" />}
         items={requirements.office}
         emptyLabel="会社の必要書類はまだありません。"
-        actions={actions}
-        setActions={setActions}
+        busyIds={busyIds}
+        setBusyIds={setBusyIds}
       />
     </div>
   )

--- a/lib/portal/busy-ids.ts
+++ b/lib/portal/busy-ids.ts
@@ -1,0 +1,27 @@
+// チェックリストの「処理中」状態を行ごとに保持する不変ヘルパ。
+// 単一の busyId を共有していると、2件目のアップロードを始めた時点で1件目の表示が消え、
+// 1件目が終わった時点で2件目の表示まで消える。行ごとに独立させるための最小の道具。
+
+export type BusyIds = ReadonlySet<string>
+
+/** 処理中の行が無い初期状態。 */
+export const NO_BUSY: BusyIds = new Set<string>()
+
+/** 行を処理中にする（元の状態は変更せず、新しい Set を返す）。 */
+export function markBusy(prev: BusyIds, id: string): BusyIds {
+  const next = new Set(prev)
+  next.add(id)
+  return next
+}
+
+/** 行の処理中を解除する（他の行はそのまま）。 */
+export function clearBusy(prev: BusyIds, id: string): BusyIds {
+  const next = new Set(prev)
+  next.delete(id)
+  return next
+}
+
+/** その行が処理中か。 */
+export function isBusy(busy: BusyIds, id: string): boolean {
+  return busy.has(id)
+}


### PR DESCRIPTION
## 症状

書類を複数連続でアップロードすると、2件目を開始した時点で1件目のボタンのローディング表示が消える。さらに1件目が完了すると2件目の表示まで消える。

## 原因

`components/portal/checklist-table.tsx` の処理中状態が `busyId: string | null` という**全行で共有された単一の id** だった。

- 2件目開始 → `busyId` が2件目の id に上書きされ、1件目の spinner が消える
- 1件目完了 → `busyId = null` になり、まだ処理中の2件目の spinner も消える

## 修正

行ごとに独立した `Set<string>` で保持する。状態遷移は `lib/portal/busy-ids.ts` に純粋関数（`markBusy` / `clearBusy` / `isBusy`）として切り出し、ユニットテストで固定した。

これで各ボタンが自分の処理中だけを表示し、他の行の操作に影響されなくなる。

## テスト

- 新規5件（複数行の同時処理中・該当行だけ解除・二重開始・未処理行の解除・不変性）
- 全体 288件パス、変更ファイルの型エラー 0件
- `npm run build` 成功（44/44ページ生成）

🤖 Generated with [Claude Code](https://claude.com/claude-code)