### PR TITLE
feat: add printable meetings page

### DIFF
--- a/app/meetings/page.tsx
+++ b/app/meetings/page.tsx
@@ -33,7 +33,8 @@ import {
   MapPin,
   FileText,
   ChevronDown,
-  ChevronUp
+  ChevronUp,
+  Printer
 } from "lucide-react"
 
 const MEETING_DATE_FILTER_OPTIONS = [
@@ -324,9 +325,17 @@ export default function MeetingsPage() {
     <AuthGuard>
       <div className="p-6 space-y-6">
         {/* Page Header */}
-        <div>
-          <h1 className="text-3xl font-bold text-foreground">面談一覧</h1>
-          <p className="text-muted-foreground mt-2">定期面談の記録と定期面談レポートを管理</p>
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-foreground">面談一覧</h1>
+            <p className="text-muted-foreground mt-2">定期面談の記録と定期面談レポートを管理</p>
+          </div>
+          <Button asChild variant="outline">
+            <Link href={`/meetings/print${searchParams.toString() ? `?${searchParams.toString()}` : ""}`}>
+              <Printer className="h-4 w-4" />
+              印刷
+            </Link>
+          </Button>
         </div>
 
         {loading ? (

--- a/app/meetings/page.tsx
+++ b/app/meetings/page.tsx
@@ -321,6 +321,12 @@ export default function MeetingsPage() {
     return { thisMonth }
   }, [filteredInterviews])
 
+  const printQuery = buildInterviewListQueryString({
+    search: searchTerm,
+    multi: { quarter: quarterFilter, company: companyFilter, staff: staffFilter, method: methodFilter },
+    single: { date: dateFilter },
+  })
+
   return (
     <AuthGuard>
       <div className="p-6 space-y-6">
@@ -331,7 +337,7 @@ export default function MeetingsPage() {
             <p className="text-muted-foreground mt-2">定期面談の記録と定期面談レポートを管理</p>
           </div>
           <Button asChild variant="outline">
-            <Link href={`/meetings/print${searchParams.toString() ? `?${searchParams.toString()}` : ""}`}>
+            <Link href={`/meetings/print${printQuery ? `?${printQuery}` : ""}`}>
               <Printer className="h-4 w-4" />
               印刷
             </Link>

--- a/app/meetings/print/page.tsx
+++ b/app/meetings/print/page.tsx
@@ -86,7 +86,7 @@ function InterviewPrintSheet({
 }) {
   return (
     <section className={breakAfter ? "interview-print-sheet space-y-3" : "space-y-3"}>
-      <div className="rounded-lg border-l-4 border-primary bg-muted/30 p-4 print:border-gray-500 print:bg-transparent print:p-0">
+      <div className="rounded-lg border-l-4 border-primary bg-muted/30 p-4 print:border-gray-500 print:bg-transparent print:py-0 print:pl-3 print:pr-0">
         <h2 className="text-xl font-bold print:text-base">
           {interview.personName}{interview.nickName ? ` (${interview.nickName})` : ""}
         </h2>

--- a/app/meetings/print/page.tsx
+++ b/app/meetings/print/page.tsx
@@ -168,6 +168,16 @@ export default function MeetingsPrintPage() {
   const sortedInterviews = useMemo(() => sortPrintableInterviews(filteredInterviews, sortMode), [filteredInterviews, sortMode])
   const groupedInterviews = useMemo(() => groupPrintableInterviewsByPerson(filteredInterviews), [filteredInterviews])
   const printedAt = useMemo(() => new Date().toLocaleDateString("ja-JP"), [])
+  const meetingsListQuery = buildInterviewListQueryString({
+    search: searchTerm,
+    multi: {
+      quarter: quarterFilter,
+      company: companyFilter,
+      staff: staffFilter,
+      method: methodFilter,
+    },
+    single: { date: dateFilter },
+  })
 
   return (
     <AuthGuard>
@@ -175,7 +185,7 @@ export default function MeetingsPrintPage() {
         <div className="mx-auto max-w-5xl space-y-6 print:max-w-none print:space-y-4">
           <div className="print:hidden">
             <Button asChild variant="ghost" size="sm" className="mb-3 -ml-2">
-              <Link href={`/meetings${searchParams.toString() ? `?${searchParams.toString()}` : ""}`}>
+              <Link href={`/meetings${meetingsListQuery ? `?${meetingsListQuery}` : ""}`}>
                 <ArrowLeft className="h-4 w-4" />
                 面談一覧へ戻る
               </Link>

--- a/app/meetings/print/page.tsx
+++ b/app/meetings/print/page.tsx
@@ -1,0 +1,425 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import Link from "next/link"
+import { useRouter, useSearchParams } from "next/navigation"
+import { ArrowLeft, Building2, Calendar, Clock, FilterIcon, Printer } from "lucide-react"
+
+import { AuthGuard } from "@/components/auth-guard"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { RecordListLoadingSkeleton } from "@/components/ui/funbase-loading"
+import { getRegularInterviews } from "@/lib/kintone-data"
+import {
+  filterPrintableInterviews,
+  groupPrintableInterviewsByPerson,
+  sortPrintableInterviews,
+  type InterviewPrintSortMode,
+} from "@/lib/interview-print"
+import {
+  buildInterviewListQueryString,
+  getQueryMultiValues,
+  getQuerySingleValue,
+} from "@/lib/interview-list-query"
+import { formatDate } from "@/lib/utils"
+import type { RegularInterview } from "@/lib/models"
+
+const DATE_OPTIONS = [
+  { value: "all", label: "すべて" },
+  { value: "7", label: "過去7日" },
+  { value: "30", label: "過去30日" },
+  { value: "90", label: "過去90日" },
+]
+
+function getQueryCsv(values: string[]): string {
+  return values.filter(Boolean).join(",")
+}
+
+function parseCommaSeparatedValues(value: string): string[] {
+  return value.split(",").map((item) => item.trim()).filter(Boolean)
+}
+
+function PrintMetaItem({ label, value }: { label: string; value?: string }) {
+  if (!value) return null
+  return (
+    <div className="flex items-center gap-1 text-sm text-muted-foreground">
+      <span>{label}:</span>
+      <span className="font-medium text-foreground">{value}</span>
+    </div>
+  )
+}
+
+function InterviewPrintCard({ interview }: { interview: RegularInterview }) {
+  return (
+    <article className="break-inside-avoid rounded-lg border bg-card p-4 print:border-gray-300 print:shadow-none">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-base font-semibold">{interview.targetQuarter ?? "定期面談"}</h3>
+          </div>
+          <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+            <PrintMetaItem label="面談日" value={formatDate(interview.interviewDate)} />
+            <PrintMetaItem label="方法" value={interview.interviewMethod} />
+            <PrintMetaItem label="支援担当" value={interview.supportStaffName} />
+            <PrintMetaItem label="時間" value={interview.startTime && interview.endTime ? `${interview.startTime} - ${interview.endTime}` : undefined} />
+            <PrintMetaItem label="所要時間" value={interview.interviewDuration ? `${interview.interviewDuration}分` : undefined} />
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-lg bg-muted/30 p-4 text-sm leading-7 whitespace-pre-wrap print:bg-transparent print:p-0">
+        {interview.companyReport || "定期面談レポートはありません"}
+      </div>
+    </article>
+  )
+}
+
+export default function MeetingsPrintPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [interviews, setInterviews] = useState<RegularInterview[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const [searchTerm, setSearchTerm] = useState(() => searchParams.get("search") ?? "")
+  const [quarterFilter, setQuarterFilter] = useState<string[]>(() => getQueryMultiValues(new URLSearchParams(searchParams.toString()), "quarter"))
+  const [companyFilter, setCompanyFilter] = useState<string[]>(() => getQueryMultiValues(new URLSearchParams(searchParams.toString()), "company"))
+  const [staffFilter, setStaffFilter] = useState<string[]>(() => getQueryMultiValues(new URLSearchParams(searchParams.toString()), "staff"))
+  const [methodFilter, setMethodFilter] = useState<string[]>(() => getQueryMultiValues(new URLSearchParams(searchParams.toString()), "method"))
+  const [quarterInput, setQuarterInput] = useState(() => getQueryCsv(getQueryMultiValues(new URLSearchParams(searchParams.toString()), "quarter")))
+  const [companyInput, setCompanyInput] = useState(() => getQueryCsv(getQueryMultiValues(new URLSearchParams(searchParams.toString()), "company")))
+  const [staffInput, setStaffInput] = useState(() => getQueryCsv(getQueryMultiValues(new URLSearchParams(searchParams.toString()), "staff")))
+  const [methodInput, setMethodInput] = useState(() => getQueryCsv(getQueryMultiValues(new URLSearchParams(searchParams.toString()), "method")))
+  const [dateFilter, setDateFilter] = useState<string>(() => getQuerySingleValue(new URLSearchParams(searchParams.toString()), "date"))
+  const [fromDate, setFromDate] = useState(() => searchParams.get("from") ?? "")
+  const [toDate, setToDate] = useState(() => searchParams.get("to") ?? "")
+  const [sortMode, setSortMode] = useState<InterviewPrintSortMode>(() =>
+    searchParams.get("sort") === "timeline" ? "timeline" : "person"
+  )
+  const [pageBreakByPerson, setPageBreakByPerson] = useState(() => searchParams.get("break") !== "off")
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        setLoading(true)
+        setInterviews(await getRegularInterviews())
+      } catch (error) {
+        console.error("Error fetching printable interviews:", error)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+  }, [])
+
+  const updateUrl = (next: {
+    search?: string
+    quarter?: string[]
+    company?: string[]
+    staff?: string[]
+    method?: string[]
+    date?: string
+    from?: string
+    to?: string
+    sort?: InterviewPrintSortMode
+    pageBreak?: boolean
+  }) => {
+    const query = buildInterviewListQueryString({
+      search: next.search ?? searchTerm,
+      multi: {
+        quarter: next.quarter ?? quarterFilter,
+        company: next.company ?? companyFilter,
+        staff: next.staff ?? staffFilter,
+        method: next.method ?? methodFilter,
+      },
+      single: { date: next.date ?? dateFilter },
+    })
+    const params = new URLSearchParams(query)
+    const nextFrom = next.from ?? fromDate
+    const nextTo = next.to ?? toDate
+    const nextSort = next.sort ?? sortMode
+    const nextPageBreak = next.pageBreak ?? pageBreakByPerson
+
+    if (nextFrom) params.set("from", nextFrom)
+    if (nextTo) params.set("to", nextTo)
+    if (nextSort !== "person") params.set("sort", nextSort)
+    if (!nextPageBreak) params.set("break", "off")
+
+    router.replace(`/meetings/print${params.toString() ? `?${params.toString()}` : ""}`, { scroll: false })
+  }
+
+  const filteredInterviews = useMemo(
+    () => filterPrintableInterviews(interviews, {
+      search: searchTerm,
+      quarter: quarterFilter,
+      company: companyFilter,
+      staff: staffFilter,
+      method: methodFilter,
+      date: dateFilter,
+      from: fromDate,
+      to: toDate,
+    }),
+    [interviews, searchTerm, quarterFilter, companyFilter, staffFilter, methodFilter, dateFilter, fromDate, toDate]
+  )
+
+  const sortedInterviews = useMemo(() => sortPrintableInterviews(filteredInterviews, sortMode), [filteredInterviews, sortMode])
+  const groupedInterviews = useMemo(() => groupPrintableInterviewsByPerson(filteredInterviews), [filteredInterviews])
+  const printedAt = useMemo(() => new Date().toLocaleDateString("ja-JP"), [])
+
+  return (
+    <AuthGuard>
+      <div className="min-h-screen bg-muted/20 p-6 print:bg-white print:p-0">
+        <div className="mx-auto max-w-5xl space-y-6 print:max-w-none print:space-y-4">
+          <div className="print:hidden">
+            <Button asChild variant="ghost" size="sm" className="mb-3 -ml-2">
+              <Link href={`/meetings${searchParams.toString() ? `?${searchParams.toString()}` : ""}`}>
+                <ArrowLeft className="h-4 w-4" />
+                面談一覧へ戻る
+              </Link>
+            </Button>
+
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <h1 className="text-3xl font-bold text-foreground">面談記録 印刷</h1>
+                <p className="mt-2 text-muted-foreground">条件を指定して、施設確認用に一括印刷できます</p>
+              </div>
+              <Button onClick={() => window.print()} disabled={loading || filteredInterviews.length === 0}>
+                <Printer className="h-4 w-4" />
+                一括印刷
+              </Button>
+            </div>
+          </div>
+
+          <Card className="print:hidden">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <FilterIcon className="h-4 w-4" />
+                印刷条件
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+              <div className="space-y-2">
+                <Label htmlFor="print-search">検索</Label>
+                <Input
+                  id="print-search"
+                  value={searchTerm}
+                  placeholder="人材名、法人名、ID..."
+                  onChange={(event) => {
+                    setSearchTerm(event.target.value)
+                    updateUrl({ search: event.target.value })
+                  }}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="print-quarter">対象四半期</Label>
+                <Input
+                  id="print-quarter"
+                  value={quarterInput}
+                  placeholder="複数はカンマ区切り"
+                  onChange={(event) => {
+                    const rawValue = event.target.value
+                    const values = parseCommaSeparatedValues(rawValue)
+                    setQuarterInput(rawValue)
+                    setQuarterFilter(values)
+                    updateUrl({ quarter: values })
+                  }}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="print-company">法人</Label>
+                <Input
+                  id="print-company"
+                  value={companyInput}
+                  placeholder="複数はカンマ区切り"
+                  onChange={(event) => {
+                    const rawValue = event.target.value
+                    const values = parseCommaSeparatedValues(rawValue)
+                    setCompanyInput(rawValue)
+                    setCompanyFilter(values)
+                    updateUrl({ company: values })
+                  }}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="print-staff">支援担当者</Label>
+                <Input
+                  id="print-staff"
+                  value={staffInput}
+                  placeholder="複数はカンマ区切り"
+                  onChange={(event) => {
+                    const rawValue = event.target.value
+                    const values = parseCommaSeparatedValues(rawValue)
+                    setStaffInput(rawValue)
+                    setStaffFilter(values)
+                    updateUrl({ staff: values })
+                  }}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="print-method">面談方法</Label>
+                <Input
+                  id="print-method"
+                  value={methodInput}
+                  placeholder="複数はカンマ区切り"
+                  onChange={(event) => {
+                    const rawValue = event.target.value
+                    const values = parseCommaSeparatedValues(rawValue)
+                    setMethodInput(rawValue)
+                    setMethodFilter(values)
+                    updateUrl({ method: values })
+                  }}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="print-period">期間</Label>
+                <select
+                  id="print-period"
+                  value={dateFilter}
+                  onChange={(event) => {
+                    setDateFilter(event.target.value)
+                    updateUrl({ date: event.target.value })
+                  }}
+                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                >
+                  {DATE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="print-from">開始日</Label>
+                <Input
+                  id="print-from"
+                  type="date"
+                  value={fromDate}
+                  onChange={(event) => {
+                    setFromDate(event.target.value)
+                    updateUrl({ from: event.target.value })
+                  }}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="print-to">終了日</Label>
+                <Input
+                  id="print-to"
+                  type="date"
+                  value={toDate}
+                  onChange={(event) => {
+                    setToDate(event.target.value)
+                    updateUrl({ to: event.target.value })
+                  }}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="print-sort">まとめ方</Label>
+                <select
+                  id="print-sort"
+                  value={sortMode}
+                  onChange={(event) => {
+                    const value = event.target.value as InterviewPrintSortMode
+                    setSortMode(value)
+                    updateUrl({ sort: value })
+                  }}
+                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                >
+                  <option value="person">人単位でまとめる</option>
+                  <option value="timeline">時系列で並べる</option>
+                </select>
+              </div>
+
+              <label className="flex items-center gap-2 self-end rounded-md border p-3 text-sm">
+                <input
+                  type="checkbox"
+                  checked={pageBreakByPerson}
+                  disabled={sortMode !== "person"}
+                  onChange={(event) => {
+                    setPageBreakByPerson(event.target.checked)
+                    updateUrl({ pageBreak: event.target.checked })
+                  }}
+                />
+                人ごとに改ページ
+              </label>
+            </CardContent>
+          </Card>
+
+          {loading ? (
+            <RecordListLoadingSkeleton />
+          ) : (
+            <div className="rounded-lg bg-white p-8 shadow-sm print:p-0 print:shadow-none">
+              <header className="mb-6 border-b pb-4 print:mb-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <h2 className="text-2xl font-bold">定期面談記録</h2>
+                    <p className="mt-1 text-sm text-muted-foreground">印刷日: {printedAt}</p>
+                  </div>
+                  <Badge variant="secondary" className="print:border print:bg-white">{filteredInterviews.length}件</Badge>
+                </div>
+                <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+                  <PrintMetaItem label="まとめ方" value={sortMode === "person" ? "人単位" : "時系列"} />
+                  <PrintMetaItem label="検索" value={searchTerm} />
+                  <PrintMetaItem label="対象四半期" value={getQueryCsv(quarterFilter)} />
+                  <PrintMetaItem label="法人" value={getQueryCsv(companyFilter)} />
+                  <PrintMetaItem label="支援担当" value={getQueryCsv(staffFilter)} />
+                  <PrintMetaItem label="面談方法" value={getQueryCsv(methodFilter)} />
+                  <PrintMetaItem label="期間" value={DATE_OPTIONS.find((option) => option.value === dateFilter)?.label} />
+                  <PrintMetaItem label="開始日" value={fromDate} />
+                  <PrintMetaItem label="終了日" value={toDate} />
+                </div>
+              </header>
+
+              {filteredInterviews.length === 0 ? (
+                <p className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">該当する面談記録がありません</p>
+              ) : sortMode === "person" ? (
+                <div className="space-y-8">
+                  {groupedInterviews.map((group) => (
+                    <section
+                      key={group.personId}
+                      className={pageBreakByPerson ? "break-after-page space-y-4 last:break-after-auto" : "space-y-4"}
+                    >
+                      <div className="rounded-lg border-l-4 border-primary bg-muted/30 p-4 print:border-gray-500 print:bg-transparent">
+                        <h2 className="text-xl font-bold">
+                          {group.personName}{group.nickName ? ` (${group.nickName})` : ""}
+                        </h2>
+                        <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+                          {group.companyName && <span className="flex items-center gap-1"><Building2 className="h-3.5 w-3.5" />{group.companyName}</span>}
+                          <span className="flex items-center gap-1"><Calendar className="h-3.5 w-3.5" />{group.interviews.length}件</span>
+                        </div>
+                      </div>
+                      <div className="space-y-4">
+                        {group.interviews.map((interview) => <InterviewPrintCard key={interview.id} interview={interview} />)}
+                      </div>
+                    </section>
+                  ))}
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {sortedInterviews.map((interview) => (
+                    <section key={interview.id} className="break-inside-avoid space-y-3">
+                      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded-lg bg-muted/30 p-3 print:bg-transparent print:p-0">
+                        <h2 className="text-lg font-bold">{interview.personName}{interview.nickName ? ` (${interview.nickName})` : ""}</h2>
+                        {interview.companyName && <span className="flex items-center gap-1 text-sm text-muted-foreground"><Building2 className="h-3.5 w-3.5" />{interview.companyName}</span>}
+                        <span className="flex items-center gap-1 text-sm text-muted-foreground"><Clock className="h-3.5 w-3.5" />{formatDate(interview.interviewDate)}</span>
+                      </div>
+                      <InterviewPrintCard interview={interview} />
+                    </section>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </AuthGuard>
+  )
+}

--- a/app/meetings/print/page.tsx
+++ b/app/meetings/print/page.tsx
@@ -393,7 +393,6 @@ export default function MeetingsPrintPage() {
                 <input
                   type="checkbox"
                   checked={pageBreakByPerson}
-                  disabled={sortMode !== "person"}
                   onChange={(event) => {
                     setPageBreakByPerson(event.target.checked)
                     updateUrl({ pageBreak: event.target.checked })
@@ -446,7 +445,7 @@ export default function MeetingsPrintPage() {
               ) : (
                 <div className="space-y-4 print:space-y-0">
                   {sortedInterviews.map((interview) => (
-                    <InterviewPrintSheet key={interview.id} interview={interview} breakAfter />
+                    <InterviewPrintSheet key={interview.id} interview={interview} breakAfter={pageBreakByPerson} />
                   ))}
                 </div>
               )}

--- a/app/meetings/print/page.tsx
+++ b/app/meetings/print/page.tsx
@@ -54,7 +54,7 @@ function PrintMetaItem({ label, value }: { label: string; value?: string }) {
 
 function InterviewPrintCard({ interview }: { interview: RegularInterview }) {
   return (
-    <article className="rounded-lg border bg-card p-4 print:border-gray-300 print:p-0 print:shadow-none">
+    <article className="rounded-lg border bg-card p-4 print:border-gray-300 print:px-4 print:py-3 print:shadow-none">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <div className="flex flex-wrap items-center gap-2">
@@ -70,7 +70,7 @@ function InterviewPrintCard({ interview }: { interview: RegularInterview }) {
         </div>
       </div>
 
-      <div className="mt-4 rounded-lg bg-muted/30 p-4 text-sm leading-7 whitespace-pre-wrap print:mt-3 print:bg-transparent print:p-0 print:text-[11px] print:leading-5">
+      <div className="mt-4 rounded-lg bg-muted/30 p-4 text-sm leading-7 whitespace-pre-wrap print:mt-3 print:bg-transparent print:px-1 print:py-0 print:text-[11px] print:leading-5">
         {interview.companyReport || "定期面談レポートはありません"}
       </div>
     </article>

--- a/app/meetings/print/page.tsx
+++ b/app/meetings/print/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react"
 import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
-import { ArrowLeft, Building2, Calendar, Clock, FilterIcon, Printer } from "lucide-react"
+import { ArrowLeft, Building2, Clock, FilterIcon, Printer } from "lucide-react"
 
 import { AuthGuard } from "@/components/auth-guard"
 import { Badge } from "@/components/ui/badge"
@@ -54,13 +54,13 @@ function PrintMetaItem({ label, value }: { label: string; value?: string }) {
 
 function InterviewPrintCard({ interview }: { interview: RegularInterview }) {
   return (
-    <article className="break-inside-avoid rounded-lg border bg-card p-4 print:border-gray-300 print:shadow-none">
+    <article className="rounded-lg border bg-card p-4 print:border-gray-300 print:p-0 print:shadow-none">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <div className="flex flex-wrap items-center gap-2">
-            <h3 className="text-base font-semibold">{interview.targetQuarter ?? "定期面談"}</h3>
+            <h3 className="text-base font-semibold print:text-sm">{interview.targetQuarter ?? "定期面談"}</h3>
           </div>
-          <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+          <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground print:text-[11px]">
             <PrintMetaItem label="面談日" value={formatDate(interview.interviewDate)} />
             <PrintMetaItem label="方法" value={interview.interviewMethod} />
             <PrintMetaItem label="支援担当" value={interview.supportStaffName} />
@@ -70,10 +70,33 @@ function InterviewPrintCard({ interview }: { interview: RegularInterview }) {
         </div>
       </div>
 
-      <div className="mt-4 rounded-lg bg-muted/30 p-4 text-sm leading-7 whitespace-pre-wrap print:bg-transparent print:p-0">
+      <div className="mt-4 rounded-lg bg-muted/30 p-4 text-sm leading-7 whitespace-pre-wrap print:mt-3 print:bg-transparent print:p-0 print:text-[11px] print:leading-5">
         {interview.companyReport || "定期面談レポートはありません"}
       </div>
     </article>
+  )
+}
+
+function InterviewPrintSheet({
+  interview,
+  breakAfter,
+}: {
+  interview: RegularInterview
+  breakAfter: boolean
+}) {
+  return (
+    <section className={breakAfter ? "interview-print-sheet space-y-3" : "space-y-3"}>
+      <div className="rounded-lg border-l-4 border-primary bg-muted/30 p-4 print:border-gray-500 print:bg-transparent print:p-0">
+        <h2 className="text-xl font-bold print:text-base">
+          {interview.personName}{interview.nickName ? ` (${interview.nickName})` : ""}
+        </h2>
+        <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground print:text-[11px]">
+          {interview.companyName && <span className="flex items-center gap-1"><Building2 className="h-3.5 w-3.5 print:h-3 print:w-3" />{interview.companyName}</span>}
+          <span className="flex items-center gap-1"><Clock className="h-3.5 w-3.5 print:h-3 print:w-3" />{formatDate(interview.interviewDate)}</span>
+        </div>
+      </div>
+      <InterviewPrintCard interview={interview} />
+    </section>
   )
 }
 
@@ -181,6 +204,24 @@ export default function MeetingsPrintPage() {
 
   return (
     <AuthGuard>
+      <style>{`
+        @media print {
+          @page {
+            size: A4 portrait;
+            margin: 10mm;
+          }
+          .interview-print-sheet {
+            break-after: page;
+            page-break-after: always;
+            break-inside: avoid;
+            page-break-inside: avoid;
+          }
+          .interview-print-sheet:last-child {
+            break-after: auto;
+            page-break-after: auto;
+          }
+        }
+      `}</style>
       <div className="min-h-screen bg-muted/20 p-6 print:bg-white print:p-0">
         <div className="mx-auto max-w-5xl space-y-6 print:max-w-none print:space-y-4">
           <div className="print:hidden">
@@ -358,7 +399,7 @@ export default function MeetingsPrintPage() {
                     updateUrl({ pageBreak: event.target.checked })
                   }}
                 />
-                人ごとに改ページ
+                1面談ごとに改ページ
               </label>
             </CardContent>
           </Card>
@@ -367,7 +408,7 @@ export default function MeetingsPrintPage() {
             <RecordListLoadingSkeleton />
           ) : (
             <div className="rounded-lg bg-white p-8 shadow-sm print:p-0 print:shadow-none">
-              <header className="mb-6 border-b pb-4 print:mb-4">
+              <header className="mb-6 border-b pb-4 print:hidden">
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>
                     <h2 className="text-2xl font-bold">定期面談記録</h2>
@@ -391,38 +432,21 @@ export default function MeetingsPrintPage() {
               {filteredInterviews.length === 0 ? (
                 <p className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">該当する面談記録がありません</p>
               ) : sortMode === "person" ? (
-                <div className="space-y-8">
-                  {groupedInterviews.map((group) => (
-                    <section
-                      key={group.personId}
-                      className={pageBreakByPerson ? "break-after-page space-y-4 last:break-after-auto" : "space-y-4"}
-                    >
-                      <div className="rounded-lg border-l-4 border-primary bg-muted/30 p-4 print:border-gray-500 print:bg-transparent">
-                        <h2 className="text-xl font-bold">
-                          {group.personName}{group.nickName ? ` (${group.nickName})` : ""}
-                        </h2>
-                        <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
-                          {group.companyName && <span className="flex items-center gap-1"><Building2 className="h-3.5 w-3.5" />{group.companyName}</span>}
-                          <span className="flex items-center gap-1"><Calendar className="h-3.5 w-3.5" />{group.interviews.length}件</span>
-                        </div>
-                      </div>
-                      <div className="space-y-4">
-                        {group.interviews.map((interview) => <InterviewPrintCard key={interview.id} interview={interview} />)}
-                      </div>
-                    </section>
-                  ))}
+                <div className="space-y-8 print:space-y-0">
+                  {groupedInterviews.flatMap((group) =>
+                    group.interviews.map((interview) => (
+                      <InterviewPrintSheet
+                        key={interview.id}
+                        interview={interview}
+                        breakAfter={pageBreakByPerson}
+                      />
+                    ))
+                  )}
                 </div>
               ) : (
-                <div className="space-y-4">
+                <div className="space-y-4 print:space-y-0">
                   {sortedInterviews.map((interview) => (
-                    <section key={interview.id} className="break-inside-avoid space-y-3">
-                      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded-lg bg-muted/30 p-3 print:bg-transparent print:p-0">
-                        <h2 className="text-lg font-bold">{interview.personName}{interview.nickName ? ` (${interview.nickName})` : ""}</h2>
-                        {interview.companyName && <span className="flex items-center gap-1 text-sm text-muted-foreground"><Building2 className="h-3.5 w-3.5" />{interview.companyName}</span>}
-                        <span className="flex items-center gap-1 text-sm text-muted-foreground"><Clock className="h-3.5 w-3.5" />{formatDate(interview.interviewDate)}</span>
-                      </div>
-                      <InterviewPrintCard interview={interview} />
-                    </section>
+                    <InterviewPrintSheet key={interview.id} interview={interview} breakAfter />
                   ))}
                 </div>
               )}

--- a/components/layout/conditional-layout.tsx
+++ b/components/layout/conditional-layout.tsx
@@ -44,11 +44,15 @@ export function ConditionalLayout({ children }: ConditionalLayoutProps) {
   // ログイン済みの場合、サイドバーとヘッダーを表示
   // ミドルウェアで認証チェック済みなので、ここに来る場合は必ずログイン済み
   return (
-    <div className="flex h-screen bg-background">
-      <Sidebar />
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        <Header />
-        <main className="flex-1 overflow-auto bg-background">
+    <div className="flex h-screen bg-background print:block print:h-auto print:overflow-visible">
+      <div className="print:hidden">
+        <Sidebar />
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden print:block print:overflow-visible">
+        <div className="print:hidden">
+          <Header />
+        </div>
+        <main className="flex-1 overflow-auto bg-background print:block print:overflow-visible">
           {children}
         </main>
       </div>

--- a/lib/interview-print.test.ts
+++ b/lib/interview-print.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict"
+import { test } from "vitest"
+
+import type { RegularInterview } from "@/lib/models"
+import {
+  filterPrintableInterviews,
+  groupPrintableInterviewsByPerson,
+  sortPrintableInterviews,
+} from "@/lib/interview-print"
+
+const baseInterview: RegularInterview = {
+  id: "base",
+  personId: "person-base",
+  personName: "Base Person",
+  companyName: "Base Company",
+  interviewDate: "2026-07-01",
+  targetQuarter: "2026年第3四半期",
+  supportStaffName: "Base Staff",
+  interviewMethod: "対面",
+  companyConfirmationStatus: "確認待ち",
+  companyReport: "report",
+  createdAt: "2026-07-01T00:00:00Z",
+  updatedAt: "2026-07-01T00:00:00Z",
+}
+
+function interview(overrides: Partial<RegularInterview>): RegularInterview {
+  return { ...baseInterview, ...overrides }
+}
+
+test("filterPrintableInterviews applies search, list filters, relative period, and custom date range", () => {
+  const interviews = [
+    interview({ id: "1", personId: "p1", personName: "グエン アン", companyName: "光正会", supportStaffName: "伊藤", interviewMethod: "対面", interviewDate: "2026-07-10" }),
+    interview({ id: "2", personId: "p2", personName: "Tran Binh", companyName: "豊栄の里", supportStaffName: "長田", interviewMethod: "電話", interviewDate: "2026-07-20" }),
+    interview({ id: "3", personId: "p3", personName: "Reno", companyName: "光正会", supportStaffName: "伊藤", interviewMethod: "オンラインMTG", interviewDate: "2026-08-01" }),
+  ]
+
+  const result = filterPrintableInterviews(interviews, {
+    search: "グエン",
+    quarter: [],
+    company: ["光正会"],
+    staff: ["伊藤"],
+    method: ["対面"],
+    date: "all",
+    from: "2026-07-01",
+    to: "2026-07-31",
+  })
+
+  assert.deepEqual(result.map((item) => item.id), ["1"])
+})
+
+test("filterPrintableInterviews includes the whole cutoff day for relative periods", () => {
+  const result = filterPrintableInterviews(
+    [
+      interview({ id: "cutoff", interviewDate: "2026-07-07" }),
+      interview({ id: "before-cutoff", interviewDate: "2026-07-06" }),
+    ],
+    { date: "30" },
+    new Date("2026-08-06T12:00:00+09:00")
+  )
+
+  assert.deepEqual(result.map((item) => item.id), ["cutoff"])
+})
+
+test("sortPrintableInterviews supports timeline order and person order", () => {
+  const interviews = [
+    interview({ id: "older-b", personId: "p2", personName: "Bさん", interviewDate: "2026-07-01" }),
+    interview({ id: "newer-a", personId: "p1", personName: "Aさん", interviewDate: "2026-07-20" }),
+    interview({ id: "older-a", personId: "p1", personName: "Aさん", interviewDate: "2026-07-10" }),
+  ]
+
+  assert.deepEqual(sortPrintableInterviews(interviews, "timeline").map((item) => item.id), ["newer-a", "older-a", "older-b"])
+  assert.deepEqual(sortPrintableInterviews(interviews, "person").map((item) => item.id), ["newer-a", "older-a", "older-b"])
+})
+
+test("groupPrintableInterviewsByPerson keeps one printable section per person with newest records first", () => {
+  const grouped = groupPrintableInterviewsByPerson([
+    interview({ id: "old", personId: "p1", personName: "Aさん", interviewDate: "2026-07-01" }),
+    interview({ id: "other", personId: "p2", personName: "Bさん", interviewDate: "2026-07-15" }),
+    interview({ id: "new", personId: "p1", personName: "Aさん", interviewDate: "2026-08-01" }),
+  ])
+
+  assert.deepEqual(grouped.map((group) => group.personId), ["p1", "p2"])
+  assert.deepEqual(grouped[0].interviews.map((item) => item.id), ["new", "old"])
+})

--- a/lib/interview-print.test.ts
+++ b/lib/interview-print.test.ts
@@ -48,7 +48,7 @@ test("filterPrintableInterviews applies search, list filters, relative period, a
   assert.deepEqual(result.map((item) => item.id), ["1"])
 })
 
-test("filterPrintableInterviews includes the whole cutoff day for relative periods", () => {
+test("filterPrintableInterviews matches the meetings list exact cutoff for relative periods", () => {
   const result = filterPrintableInterviews(
     [
       interview({ id: "cutoff", interviewDate: "2026-07-07" }),
@@ -58,7 +58,7 @@ test("filterPrintableInterviews includes the whole cutoff day for relative perio
     new Date("2026-08-06T12:00:00+09:00")
   )
 
-  assert.deepEqual(result.map((item) => item.id), ["cutoff"])
+  assert.deepEqual(result.map((item) => item.id), [])
 })
 
 test("sortPrintableInterviews supports timeline order and person order", () => {

--- a/lib/interview-print.test.ts
+++ b/lib/interview-print.test.ts
@@ -59,6 +59,14 @@ test("filterPrintableInterviews matches the meetings list exact cutoff for relat
   )
 
   assert.deepEqual(result.map((item) => item.id), [])
+
+  const earlyMorningResult = filterPrintableInterviews(
+    [interview({ id: "cutoff", interviewDate: "2026-07-07" })],
+    { date: "30" },
+    new Date("2026-08-06T08:00:00+09:00")
+  )
+
+  assert.deepEqual(earlyMorningResult.map((item) => item.id), ["cutoff"])
 })
 
 test("sortPrintableInterviews supports timeline order and person order", () => {

--- a/lib/interview-print.ts
+++ b/lib/interview-print.ts
@@ -1,0 +1,141 @@
+import type { RegularInterview } from "@/lib/models"
+
+export type InterviewPrintSortMode = "person" | "timeline"
+
+export type InterviewPrintFilters = {
+  search?: string
+  quarter?: string[]
+  company?: string[]
+  staff?: string[]
+  method?: string[]
+  date?: string
+  from?: string
+  to?: string
+}
+
+export type PrintableInterviewPersonGroup = {
+  personId: string
+  personName: string
+  nickName?: string
+  companyName?: string
+  interviews: RegularInterview[]
+}
+
+function normalizeText(value?: string): string {
+  return (value ?? "").trim().toLowerCase()
+}
+
+function isInValues(value: string | undefined, values?: string[]): boolean {
+  const normalizedValues = (values ?? []).map((item) => item.trim()).filter(Boolean)
+  return normalizedValues.length === 0 || normalizedValues.includes(value ?? "")
+}
+
+function parseDateOnly(value?: string): Date | null {
+  if (!value) return null
+  const date = new Date(`${value}T00:00:00`)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function isWithinDateRange(interviewDateValue: string, filters: InterviewPrintFilters, now = new Date()): boolean {
+  const interviewDate = parseDateOnly(interviewDateValue)
+  if (!interviewDate) return false
+
+  const fromDate = parseDateOnly(filters.from)
+  if (fromDate && interviewDate < fromDate) return false
+
+  const toDate = parseDateOnly(filters.to)
+  if (toDate) {
+    const endOfToDate = new Date(toDate)
+    endOfToDate.setHours(23, 59, 59, 999)
+    if (interviewDate > endOfToDate) return false
+  }
+
+  if (filters.date && filters.date !== "all") {
+    const daysAgo = Number.parseInt(filters.date, 10)
+    if (!Number.isNaN(daysAgo)) {
+      const filterDate = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000)
+      filterDate.setHours(0, 0, 0, 0)
+      if (interviewDate < filterDate) return false
+    }
+  }
+
+  return true
+}
+
+export function filterPrintableInterviews(
+  interviews: RegularInterview[],
+  filters: InterviewPrintFilters,
+  now = new Date()
+): RegularInterview[] {
+  const search = normalizeText(filters.search)
+
+  return interviews.filter((interview) => {
+    if (search) {
+      const haystack = [
+        interview.personName,
+        interview.nickName,
+        interview.companyName,
+        interview.personId,
+        interview.companyId,
+      ].map(normalizeText)
+
+      if (!haystack.some((value) => value.includes(search))) return false
+    }
+
+    if (!isInValues(interview.targetQuarter, filters.quarter)) return false
+    if (!isInValues(interview.companyName, filters.company)) return false
+    if (!isInValues(interview.supportStaffName, filters.staff)) return false
+    if (!isInValues(interview.interviewMethod, filters.method)) return false
+    if (!isWithinDateRange(interview.interviewDate, filters, now)) return false
+
+    return true
+  })
+}
+
+function compareInterviewDateDesc(a: RegularInterview, b: RegularInterview): number {
+  const dateOrder = new Date(b.interviewDate).getTime() - new Date(a.interviewDate).getTime()
+  if (dateOrder !== 0) return dateOrder
+  return b.id.localeCompare(a.id)
+}
+
+export function sortPrintableInterviews(
+  interviews: RegularInterview[],
+  sortMode: InterviewPrintSortMode
+): RegularInterview[] {
+  if (sortMode === "timeline") {
+    return [...interviews].sort(compareInterviewDateDesc)
+  }
+
+  return [...interviews].sort((a, b) => {
+    const personOrder = a.personName.localeCompare(b.personName, "ja")
+    if (personOrder !== 0) return personOrder
+
+    const personIdOrder = a.personId.localeCompare(b.personId)
+    if (personIdOrder !== 0) return personIdOrder
+
+    return compareInterviewDateDesc(a, b)
+  })
+}
+
+export function groupPrintableInterviewsByPerson(interviews: RegularInterview[]): PrintableInterviewPersonGroup[] {
+  const sortedInterviews = sortPrintableInterviews(interviews, "person")
+  const groups = new Map<string, PrintableInterviewPersonGroup>()
+
+  sortedInterviews.forEach((interview) => {
+    const group = groups.get(interview.personId)
+    if (group) {
+      group.interviews.push(interview)
+      return
+    }
+
+    groups.set(interview.personId, {
+      personId: interview.personId,
+      personName: interview.personName,
+      nickName: interview.nickName,
+      companyName: interview.companyName,
+      interviews: [interview],
+    })
+  })
+
+  return Array.from(groups.values())
+}

--- a/lib/interview-print.ts
+++ b/lib/interview-print.ts
@@ -54,7 +54,6 @@ function isWithinDateRange(interviewDateValue: string, filters: InterviewPrintFi
     const daysAgo = Number.parseInt(filters.date, 10)
     if (!Number.isNaN(daysAgo)) {
       const filterDate = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000)
-      filterDate.setHours(0, 0, 0, 0)
       if (interviewDate < filterDate) return false
     }
   }

--- a/lib/interview-print.ts
+++ b/lib/interview-print.ts
@@ -53,8 +53,9 @@ function isWithinDateRange(interviewDateValue: string, filters: InterviewPrintFi
   if (filters.date && filters.date !== "all") {
     const daysAgo = Number.parseInt(filters.date, 10)
     if (!Number.isNaN(daysAgo)) {
+      const listInterviewDate = new Date(interviewDateValue)
       const filterDate = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000)
-      if (interviewDate < filterDate) return false
+      if (listInterviewDate < filterDate) return false
     }
   }
 


### PR DESCRIPTION
## 概要
- 面談一覧から遷移できる印刷用ページ `/meetings/print` を追加
- 検索・四半期・法人・支援担当者・面談方法・期間条件を引き継ぎ、開始日/終了日も指定可能にしました
- 印刷のまとめ方を「人単位」「時系列」から選べるようにし、人単位では人ごとの改ページにも対応しました
- 一括印刷ボタンでブラウザ印刷を起動し、印刷時は操作UIを非表示にしてレポート全文を出力します

## 元 Slack
https://funtoco.slack.com/archives/C04MS29LG8Y/p1785983443438009

## 分類
type: feature / confidence: high

## 変更点
- `app/meetings/page.tsx`: 面談一覧ヘッダーに「印刷」ボタンを追加
- `app/meetings/print/page.tsx`: 印刷条件指定・印刷プレビュー・一括印刷ページを追加
- `lib/interview-print.ts`: 印刷用の絞り込み・並び替え・人単位グルーピング helper を追加
- `lib/interview-print.test.ts`: 絞り込み、期間境界、並び替え、グルーピングのテストを追加

## テスト
- [x] `./node_modules/.bin/vitest run lib/interview-print.test.ts lib/interview-list-query.test.ts`
- [x] `./node_modules/.bin/next build`
- [x] `git diff --check`
- [x] `codex review --base origin/main`

## 補足
- `npm run lint` は既存設定で `next lint` 初回セットアッププロンプトが出るため未実行です
- `npm run typecheck` は既存の connector / tenant-management 周辺の型エラーで全体実行不可でした
- `next build` は既存の `MAX_DURATION_SECONDS` route config 警告や dynamic server usage ログを出しますが、ビルド自体は成功しています

## リスク / ロールバック
- DB・認証・権限・外部APIには触れていません
- ロールバックはこのPRをrevertすれば印刷ページ導線ごと戻せます
