### PR TITLE
feat(portal): ビザ案件に「その他ファイル」の複数アップロードを追加

### DIFF
--- a/__tests__/portal-case-files.test.ts
+++ b/__tests__/portal-case-files.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  appendCaseFiles,
+  listCaseFiles,
+  readCaseFile,
+  OTHER_FILES_FIELD_CODE,
+} from '@/lib/portal/kintone-sync/case-files'
+import {
+  KintoneApiError,
+  type KintoneReadRecord,
+  type KintoneWriteClient,
+} from '@/lib/portal/kintone-sync/kintone-write-client'
+
+/** kintone 添付ファイルフィールドの1要素（size は文字列で返る）。 */
+function attachment(fileKey: string, name = `${fileKey}.pdf`) {
+  return { fileKey, name, contentType: 'application/pdf', size: '1024' }
+}
+
+/** app296 の1レコード。other_files を指定しなければフィールド未設定扱い。 */
+function record(params: {
+  revision?: string
+  files?: ReturnType<typeof attachment>[] | null
+}): KintoneReadRecord {
+  const rec: KintoneReadRecord = {
+    $id: { value: '5' },
+    $revision: { value: params.revision ?? '3' },
+  }
+  if (params.files !== null && params.files !== undefined) {
+    rec[OTHER_FILES_FIELD_CODE] = { value: params.files }
+  }
+  return rec
+}
+
+/** getRecords が呼ばれるたびに順番にレコードを返すモック。 */
+function mockClient(params: {
+  reads: KintoneReadRecord[][]
+  update?: KintoneWriteClient['updateRecord']
+}) {
+  let readIndex = 0
+  const getRecords = vi.fn(async () => {
+    const result = params.reads[Math.min(readIndex, params.reads.length - 1)]
+    readIndex += 1
+    return result
+  })
+  const updateRecord = vi.fn(
+    params.update ?? (async () => ({ revision: '4' }))
+  )
+  return {
+    getRecords,
+    updateRecord,
+    createRecord: vi.fn(),
+    updateRecordStatus: vi.fn(),
+    getRecordComments: vi.fn(),
+    postRecordComment: vi.fn(),
+    uploadFile: vi.fn(),
+    downloadFile: vi.fn(),
+  } as unknown as KintoneWriteClient & {
+    getRecords: ReturnType<typeof vi.fn>
+    updateRecord: ReturnType<typeof vi.fn>
+  }
+}
+
+/** updateRecord に渡された other_files の fileKey 配列を取り出す。 */
+function sentFileKeys(updateRecord: ReturnType<typeof vi.fn>, callIndex = 0): string[] {
+  const record = updateRecord.mock.calls[callIndex][2] as {
+    [code: string]: { value: Array<{ fileKey: string }> }
+  }
+  return record[OTHER_FILES_FIELD_CODE].value.map((f) => f.fileKey)
+}
+
+describe('listCaseFiles', () => {
+  it('添付ファイルフィールドを CaseFile[] に変換する（size は数値）', async () => {
+    const client = mockClient({
+      reads: [[record({ files: [attachment('k1', '住民票.pdf')] })]],
+    })
+    const files = await listCaseFiles(client, '5')
+    expect(files).toEqual([
+      {
+        fileKey: 'k1',
+        name: '住民票.pdf',
+        contentType: 'application/pdf',
+        size: 1024,
+      },
+    ])
+  })
+
+  it('フィールド未設定・空配列・レコード無しはいずれも空配列', async () => {
+    const noField = mockClient({ reads: [[record({ files: null })]] })
+    expect(await listCaseFiles(noField, '5')).toEqual([])
+
+    const empty = mockClient({ reads: [[record({ files: [] })]] })
+    expect(await listCaseFiles(empty, '5')).toEqual([])
+
+    const noRecord = mockClient({ reads: [[]] })
+    expect(await listCaseFiles(noRecord, '5')).toEqual([])
+  })
+})
+
+describe('appendCaseFiles', () => {
+  it('既存ファイルを保持したまま新規 fileKey を末尾に追加する', async () => {
+    const client = mockClient({
+      reads: [[record({ files: [attachment('k1'), attachment('k2')] })]],
+    })
+
+    await appendCaseFiles(client, '5', ['new1', 'new2'])
+
+    expect(client.updateRecord).toHaveBeenCalledTimes(1)
+    expect(sentFileKeys(client.updateRecord)).toEqual(['k1', 'k2', 'new1', 'new2'])
+  })
+
+  it('読み取った revision を指定して楽観ロックする', async () => {
+    const client = mockClient({
+      reads: [[record({ revision: '7', files: [attachment('k1')] })]],
+    })
+
+    await appendCaseFiles(client, '5', ['new1'])
+
+    expect(client.updateRecord.mock.calls[0][3]).toEqual({ revision: '7' })
+  })
+
+  it('revision 競合(409)は読み直して1回リトライし、他者の追加分も残す', async () => {
+    // 1回目の読み取り後に他者が k2 を追加 → 409 → 読み直すと k1,k2 が見える
+    const update = vi
+      .fn()
+      .mockRejectedValueOnce(new KintoneApiError(409, 'revision mismatch'))
+      .mockResolvedValueOnce({ revision: '9' })
+    const client = mockClient({
+      reads: [
+        [record({ revision: '7', files: [attachment('k1')] })],
+        [record({ revision: '8', files: [attachment('k1'), attachment('k2')] })],
+      ],
+      update: update as unknown as KintoneWriteClient['updateRecord'],
+    })
+
+    await appendCaseFiles(client, '5', ['new1'])
+
+    expect(client.updateRecord).toHaveBeenCalledTimes(2)
+    expect(sentFileKeys(client.updateRecord, 1)).toEqual(['k1', 'k2', 'new1'])
+    expect(client.updateRecord.mock.calls[1][3]).toEqual({ revision: '8' })
+  })
+
+  it('リトライしても 409 なら例外にする（黙って上書きしない）', async () => {
+    const update = vi
+      .fn()
+      .mockRejectedValue(new KintoneApiError(409, 'revision mismatch'))
+    const client = mockClient({
+      reads: [[record({ files: [attachment('k1')] })]],
+      update: update as unknown as KintoneWriteClient['updateRecord'],
+    })
+
+    await expect(appendCaseFiles(client, '5', ['new1'])).rejects.toThrow(
+      KintoneApiError
+    )
+    expect(client.updateRecord).toHaveBeenCalledTimes(2)
+  })
+
+  it('409 以外のエラーはリトライせずそのまま投げる', async () => {
+    const update = vi.fn().mockRejectedValue(new KintoneApiError(403, 'forbidden'))
+    const client = mockClient({
+      reads: [[record({ files: [attachment('k1')] })]],
+      update: update as unknown as KintoneWriteClient['updateRecord'],
+    })
+
+    await expect(appendCaseFiles(client, '5', ['new1'])).rejects.toThrow('forbidden')
+    expect(client.updateRecord).toHaveBeenCalledTimes(1)
+  })
+
+  it('レコードが見つからなければ例外（アップロード済みファイルを孤児にしない）', async () => {
+    const client = mockClient({ reads: [[]] })
+    await expect(appendCaseFiles(client, '5', ['new1'])).rejects.toThrow()
+    expect(client.updateRecord).not.toHaveBeenCalled()
+  })
+
+  it('追加ファイルが無ければ何もしない', async () => {
+    const client = mockClient({ reads: [[record({ files: [attachment('k1')] })]] })
+    await appendCaseFiles(client, '5', [])
+    expect(client.updateRecord).not.toHaveBeenCalled()
+  })
+})
+
+describe('readCaseFile', () => {
+  function clientWith(files: ReturnType<typeof attachment>[]) {
+    const client = mockClient({ reads: [[record({ files })]] })
+    ;(client.downloadFile as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      body: Buffer.from('BODY'),
+      contentType: 'application/pdf',
+    })
+    return client as typeof client & { downloadFile: ReturnType<typeof vi.fn> }
+  }
+
+  it('案件に紐づく fileKey なら本文とファイル名を返す', async () => {
+    const client = clientWith([attachment('k1', '住民票.pdf')])
+
+    const file = await readCaseFile(client, '5', 'k1')
+
+    expect(file).toEqual({
+      name: '住民票.pdf',
+      contentType: 'application/pdf',
+      body: Buffer.from('BODY'),
+    })
+    expect(client.downloadFile).toHaveBeenCalledWith('k1')
+  })
+
+  it('案件に紐づかない fileKey は null（他案件のファイルを読ませない）', async () => {
+    const client = clientWith([attachment('k1')])
+
+    expect(await readCaseFile(client, '5', 'よその案件のfileKey')).toBeNull()
+    expect(client.downloadFile).not.toHaveBeenCalled()
+  })
+
+  it('添付が1件も無い案件でも null を返すだけで落ちない', async () => {
+    const client = clientWith([])
+    expect(await readCaseFile(client, '5', 'k1')).toBeNull()
+    expect(client.downloadFile).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/portal-comment-sync.test.ts
+++ b/__tests__/portal-comment-sync.test.ts
@@ -16,6 +16,10 @@ function mockClient(overrides: Partial<KintoneWriteClient> = {}): KintoneWriteCl
     updateRecordStatus: vi.fn().mockResolvedValue({ revision: '1' }),
     getRecordComments: vi.fn().mockResolvedValue([]),
     postRecordComment: vi.fn().mockResolvedValue({ id: 'kc99' }),
+    uploadFile: vi.fn().mockResolvedValue({ fileKey: 'fk1' }),
+    downloadFile: vi
+      .fn()
+      .mockResolvedValue({ body: Buffer.from(''), contentType: 'application/pdf' }),
     ...overrides,
   }
 }

--- a/__tests__/portal-kintone-client-methods.test.ts
+++ b/__tests__/portal-kintone-client-methods.test.ts
@@ -92,4 +92,97 @@ describe('RestKintoneWriteClient: 新メソッド', () => {
       mentions: [{ code: 'u1', type: 'USER' }],
     })
   })
+
+  it('updateRecord: revision 指定時のみ body に含める（楽観ロック）', async () => {
+    const withRevision = stubFetch({ revision: '8' })
+    await client().updateRecord('296', '5', { f: { value: 'v' } }, { revision: '7' })
+    expect(JSON.parse(callArgs(withRevision).opts.body!)).toEqual({
+      app: '296',
+      id: '5',
+      record: { f: { value: 'v' } },
+      revision: '7',
+    })
+
+    const withoutRevision = stubFetch({ revision: '8' })
+    await client().updateRecord('296', '5', { f: { value: 'v' } })
+    expect(JSON.parse(callArgs(withoutRevision).opts.body!)).toEqual({
+      app: '296',
+      id: '5',
+      record: { f: { value: 'v' } },
+    })
+  })
+})
+
+describe('RestKintoneWriteClient: ファイル', () => {
+  it('uploadFile → POST /k/v1/file.json に multipart で送り fileKey を返す', async () => {
+    const fetchMock = stubFetch({ fileKey: 'FK123' })
+    const res = await client().uploadFile({
+      fileName: '住民票.pdf',
+      contentType: 'application/pdf',
+      body: Buffer.from('PDFBODY'),
+    })
+
+    const [url, opts] = fetchMock.mock.calls[0] as [
+      string,
+      { method: string; headers: Record<string, string>; body: FormData },
+    ]
+    expect(url).toBe('https://x.cybozu.com/k/v1/file.json')
+    expect(opts.method).toBe('POST')
+    expect(opts.headers['X-Cybozu-Authorization']).toBeTruthy()
+    // boundary が壊れるため Content-Type は自前で付けない（FormData に任せる）
+    expect(opts.headers['Content-Type']).toBeUndefined()
+    expect(opts.body).toBeInstanceOf(FormData)
+
+    const sent = opts.body.get('file') as File
+    expect(sent.name).toBe('住民票.pdf')
+    expect(sent.type).toBe('application/pdf')
+    expect(await sent.text()).toBe('PDFBODY')
+
+    expect(res).toEqual({ fileKey: 'FK123' })
+  })
+
+  it('downloadFile → GET /k/v1/file.json?fileKey= で本文と Content-Type を返す', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'image/png' }),
+      arrayBuffer: async () => new TextEncoder().encode('PNGBODY').buffer,
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const res = await client().downloadFile('FK123')
+    const { url, opts } = callArgs(fetchMock)
+    expect(url).toBe('https://x.cybozu.com/k/v1/file.json?fileKey=FK123')
+    expect(opts.method).toBe('GET')
+    expect(res.contentType).toBe('image/png')
+    expect(res.body.toString('utf-8')).toBe('PNGBODY')
+  })
+
+  it('downloadFile: Content-Type 不明なら application/octet-stream', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        arrayBuffer: async () => new ArrayBuffer(0),
+      })
+    )
+    const res = await client().downloadFile('FK123')
+    expect(res.contentType).toBe('application/octet-stream')
+  })
+
+  it('エラー応答は status 付きの KintoneApiError になる', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        text: async () => '{"code":"GAIA_CO02"}',
+      })
+    )
+    await expect(
+      client().updateRecord('296', '5', {}, { revision: '1' })
+    ).rejects.toMatchObject({ name: 'KintoneApiError', status: 409 })
+  })
 })

--- a/__tests__/portal-kintone-transcribe.test.ts
+++ b/__tests__/portal-kintone-transcribe.test.ts
@@ -380,6 +380,10 @@ function makeMockClient(overrides: Partial<KintoneWriteClient> = {}): KintoneWri
     updateRecordStatus: vi.fn().mockResolvedValue({ revision: '3' }),
     getRecordComments: vi.fn().mockResolvedValue([]),
     postRecordComment: vi.fn().mockResolvedValue({ id: '1' }),
+    uploadFile: vi.fn().mockResolvedValue({ fileKey: 'fk1' }),
+    downloadFile: vi
+      .fn()
+      .mockResolvedValue({ body: Buffer.from(''), contentType: 'application/pdf' }),
     ...overrides,
   }
 }

--- a/__tests__/portal-status-sync.test.ts
+++ b/__tests__/portal-status-sync.test.ts
@@ -16,6 +16,10 @@ function mockClient(overrides: Partial<KintoneWriteClient> = {}): KintoneWriteCl
     updateRecordStatus: vi.fn().mockResolvedValue({ revision: '1' }),
     getRecordComments: vi.fn().mockResolvedValue([]),
     postRecordComment: vi.fn().mockResolvedValue({ id: '1' }),
+    uploadFile: vi.fn().mockResolvedValue({ fileKey: 'fk1' }),
+    downloadFile: vi
+      .fn()
+      .mockResolvedValue({ body: Buffer.from(''), contentType: 'application/pdf' }),
     ...overrides,
   }
 }

--- a/app/api/applications/[caseId]/files/[fileKey]/route.ts
+++ b/app/api/applications/[caseId]/files/[fileKey]/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { downloadCaseFile } from '@/lib/portal/case-files'
+
+// GET /api/applications/[caseId]/files/[fileKey]
+// 署名URLは使わず、FunBase のセッション認証を必ず通してから kintone から取得して返す。
+
+/** Content-Disposition のファイル名（日本語対応・RFC 5987）。 */
+function contentDisposition(fileName: string): string {
+  // ヘッダを壊す文字は落とし、非ASCII名は filename* で渡す。
+  const fallback = fileName.replace(/[^\x20-\x7e]/g, '_').replace(/["\\]/g, '_')
+  return `inline; filename="${fallback}"; filename*=UTF-8''${encodeURIComponent(fileName)}`
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { caseId: string; fileKey: string } }
+) {
+  try {
+    const result = await downloadCaseFile({
+      caseId: params.caseId,
+      fileKey: decodeURIComponent(params.fileKey),
+    })
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status })
+    }
+
+    const { name, contentType, body } = result.data
+    return new NextResponse(new Uint8Array(body), {
+      status: 200,
+      headers: {
+        'Content-Type': contentType,
+        'Content-Length': String(body.length),
+        'Content-Disposition': contentDisposition(name),
+        // 取得元の型を尊重させ、別の型として解釈されるのを防ぐ。
+        'X-Content-Type-Options': 'nosniff',
+        // 案件書類なので中間キャッシュには載せない。
+        'Cache-Control': 'private, no-store',
+      },
+    })
+  } catch (error) {
+    console.error('Error downloading case file:', error)
+    return NextResponse.json(
+      { error: 'ファイルの取得に失敗しました' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/applications/[caseId]/files/route.ts
+++ b/app/api/applications/[caseId]/files/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { uploadCaseFiles } from '@/lib/portal/case-files'
+
+// POST /api/applications/[caseId]/files
+// multipart/form-data の files[] を受け取り、案件の「その他ファイル」として
+// kintone 案件レコードの添付ファイルフィールドへ追記する。
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { caseId: string } }
+) {
+  try {
+    let formData: FormData
+    try {
+      formData = await request.formData()
+    } catch {
+      return NextResponse.json(
+        { error: 'ファイルの受信に失敗しました' },
+        { status: 400 }
+      )
+    }
+
+    const files = formData
+      .getAll('files')
+      .filter((entry): entry is File => entry instanceof File)
+
+    const result = await uploadCaseFiles({ caseId: params.caseId, files })
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status })
+    }
+
+    return NextResponse.json({ success: true, ...result.data })
+  } catch (error) {
+    console.error('Error uploading case files:', error)
+    return NextResponse.json(
+      { error: 'アップロードに失敗しました' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/applications/[caseId]/page.tsx
+++ b/app/applications/[caseId]/page.tsx
@@ -6,7 +6,9 @@ import { Badge } from '@/components/ui/badge'
 import { CaseProgressHeader } from '@/components/portal/case-progress-header'
 import { ChecklistTable } from '@/components/portal/checklist-table'
 import { CommentThread } from '@/components/portal/comment-thread'
+import { OtherFilesCard } from '@/components/portal/other-files-card'
 import { getCaseWithRequirements } from '@/lib/portal/applications'
+import { getCaseFilesState } from '@/lib/portal/case-files'
 import { listComments } from '@/lib/portal/comments'
 import {
   APPLICATION_CATEGORY_LABELS,
@@ -27,7 +29,10 @@ export default async function ApplicationDetailPage({
   }
 
   const { case: detail, requirements } = data
-  const comments = await listComments(detail.id)
+  const [comments, otherFiles] = await Promise.all([
+    listComments(detail.id),
+    getCaseFilesState(detail.id),
+  ])
 
   return (
     <div className="space-y-6 p-6">
@@ -82,6 +87,13 @@ export default async function ApplicationDetailPage({
       <CaseProgressHeader status={detail.status} />
 
       <ChecklistTable caseId={detail.id} requirements={requirements} />
+
+      <OtherFilesCard
+        caseId={detail.id}
+        files={otherFiles.files}
+        canUpload={otherFiles.canUpload}
+        blockedReason={otherFiles.blockedReason}
+      />
 
       <CommentThread caseId={detail.id} comments={comments} />
     </div>

--- a/components/portal/other-files-card.tsx
+++ b/components/portal/other-files-card.tsx
@@ -1,0 +1,208 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { FileText, Loader2, Paperclip, Upload } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/lib/hooks/use-toast'
+import type {
+  CaseFilesBlockedReason,
+  CaseFileUploadResult,
+} from '@/lib/portal/case-files'
+import type { CaseFile } from '@/lib/portal/kintone-sync/case-files'
+
+// 案件のチェックリストに載らない任意ファイル（その他ファイル）の一覧＋複数アップロード。
+// 実体は kintone 案件レコードの添付ファイルなので、表示・取得は API ルート経由で行う。
+
+const BLOCKED_MESSAGES: Record<CaseFilesBlockedReason, string> = {
+  no_kintone_link:
+    'この案件はまだ連携準備中のため、その他ファイルをアップロードできません。担当者にお問い合わせください。',
+  no_kintone_auth:
+    'ファイル連携が設定されていないため、その他ファイルをアップロードできません。管理者にお問い合わせください。',
+  error:
+    'その他ファイルを取得できませんでした。時間をおいてページを再読み込みしてください。',
+}
+
+/** 画像・PDF・Excel（サーバ側の許可形式と揃える）。 */
+const ACCEPT =
+  'image/png,image/jpeg,image/webp,image/heic,image/heif,application/pdf,' +
+  '.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,' +
+  '.xls,application/vnd.ms-excel'
+
+function formatSize(bytes: number): string {
+  if (!bytes) {
+    return '-'
+  }
+  if (bytes < 1024) {
+    return `${bytes} B`
+  }
+  if (bytes < 1024 * 1024) {
+    return `${Math.round(bytes / 1024)} KB`
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+export function OtherFilesCard({
+  caseId,
+  files,
+  canUpload,
+  blockedReason,
+}: {
+  caseId: string
+  files: CaseFile[]
+  canUpload: boolean
+  blockedReason?: CaseFilesBlockedReason
+}) {
+  const router = useRouter()
+  const { toast } = useToast()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(
+    null
+  )
+
+  const uploading = progress !== null
+
+  /**
+   * 選択された全ファイルを**1件ずつ**送る。まとめて送るとリクエストが巨大になるため、
+   * 既存の書類アップロードと同じサイズ感を保ちつつ、途中で失敗しても成功分は残す。
+   */
+  async function handleUpload(selected: File[]) {
+    setProgress({ done: 0, total: selected.length })
+    const failures: CaseFileUploadResult[] = []
+
+    try {
+      for (const [index, file] of selected.entries()) {
+        try {
+          const form = new FormData()
+          form.append('files', file)
+          const res = await fetch(`/api/applications/${caseId}/files`, {
+            method: 'POST',
+            body: form,
+          })
+          const result = (await res.json().catch(() => ({}))) as {
+            error?: string
+            results?: CaseFileUploadResult[]
+          }
+          if (!res.ok) {
+            failures.push({
+              name: file.name,
+              ok: false,
+              error: result.error || 'アップロードに失敗しました',
+            })
+          } else {
+            failures.push(...(result.results ?? []).filter((r) => !r.ok))
+          }
+        } catch {
+          failures.push({
+            name: file.name,
+            ok: false,
+            error: 'ネットワークエラーが発生しました',
+          })
+        }
+        setProgress({ done: index + 1, total: selected.length })
+      }
+
+      const okCount = selected.length - failures.length
+      if (failures.length === 0) {
+        toast({
+          title: 'アップロードしました',
+          description: `${okCount}件のファイルを追加しました。`,
+        })
+      } else {
+        toast({
+          variant: 'destructive',
+          title:
+            okCount > 0
+              ? `${okCount}件を追加しました（${failures.length}件は失敗）`
+              : 'アップロードに失敗しました',
+          description: failures
+            .map((f) => `${f.name}：${f.error ?? '不明なエラー'}`)
+            .join('\n'),
+        })
+      }
+      router.refresh()
+    } finally {
+      setProgress(null)
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-card shadow-sm">
+      <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-3">
+        <Paperclip className="h-4 w-4 text-muted-foreground" />
+        <h4 className="text-sm font-semibold text-foreground">その他ファイル</h4>
+        <span className="text-xs text-muted-foreground">（{files.length}件）</span>
+        <div className="ml-auto">
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            className="hidden"
+            accept={ACCEPT}
+            onChange={(e) => {
+              const selected = Array.from(e.target.files ?? [])
+              if (selected.length > 0) {
+                void handleUpload(selected)
+              }
+              e.target.value = ''
+            }}
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!canUpload || uploading}
+            onClick={() => fileInputRef.current?.click()}
+            className="gap-1"
+          >
+            {uploading ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                アップロード中… {progress.done}/{progress.total}件
+              </>
+            ) : (
+              <>
+                <Upload className="h-3.5 w-3.5" />
+                ファイルを追加
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+
+      <div className="px-4 py-4">
+        {!canUpload && blockedReason && (
+          <p className="mb-3 rounded-lg border border-border bg-muted px-3 py-2 text-xs text-muted-foreground">
+            {BLOCKED_MESSAGES[blockedReason]}
+          </p>
+        )}
+
+        {files.length === 0 ? (
+          <p className="text-center text-sm text-muted-foreground">
+            チェックリストに無い書類は、ここに何件でも追加できます。
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {files.map((file) => (
+              <li key={file.fileKey}>
+                <a
+                  href={`/api/applications/${caseId}/files/${encodeURIComponent(file.fileKey)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 transition-colors hover:bg-muted"
+                >
+                  <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+                    {file.name}
+                  </span>
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {formatSize(file.size)}
+                  </span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/docs/superpowers/specs/2026-08-05-visa-case-other-files-design.md
+++ b/docs/superpowers/specs/2026-08-05-visa-case-other-files-design.md
@@ -1,0 +1,101 @@
+# ビザ案件「その他ファイル」複数アップロード 設計
+
+作成日: 2026-08-05
+
+## 1. 目的
+
+ビザ案件（`/applications/[caseId]`）で、チェックリストに載っていない任意のファイルを
+**複数まとめて自由にアップロード**できるようにする。
+
+現状は `case_document_requirements`（チェックリストの1行）に紐付く形でしか提出できず、
+1要件＝1ファイルに固定されている。任意ファイルの置き場が無い。
+
+## 2. 保存先の決定
+
+**kintone app296「就労_ビザ案件管理」のレコード添付ファイルフィールド**を唯一の保存先とする。
+Supabase Storage には保存しない。
+
+### Google Drive ではなく kintone を選んだ理由
+
+既存の Drive ミラー（`lib/portal/drive/`）は、OP が案件ごとに `drive_folder_url` を手で貼る前提で、
+貼り忘れると `no_drive_folder` で静かに skip される。その他ファイルの主保存先としては穴が大きい。
+kintone レコード添付なら案件レコード内で完結し、URL の手貼り運用が不要になる。
+
+トレードオフとして以下を受け入れる。
+
+- kintone の契約ディスク容量を消費する（Drive は別枠だった）
+- 添付ファイルフィールドは PUT で**丸ごと置換**されるため、追記に read-modify-write が必要
+
+なお既存のチェックリスト書類の Drive ミラーは**そのまま残す**（この変更の対象外）。
+
+## 3. 全体フロー
+
+```
+[企業担当者] ファイルを複数選択
+  → POST /api/applications/{caseId}/files      セッション認証＋案件アクセス確認
+  → kintone POST /k/v1/file.json  × N          fileKey を取得
+  → app296 レコードの other_files を「既存 + 新規」で PUT（revision 楽観ロック）
+  ← 1ファイルごとの成否を返し、画面は router.refresh() で一覧を取り直す
+
+[プレビュー] GET /api/applications/{caseId}/files/{fileKey}
+  → アクセス確認 → kintone GET /k/v1/file.json → Content-Type 付きでストリーム返却
+  → 新規タブで PDF・画像がそのまま開く
+```
+
+API ルートは1リクエストで複数ファイル（`files[]`、最大10件）を受け付けるが、
+**画面は1ファイルずつ順番に送る**。まとめて送るとリクエストが巨大になり、既存の書類
+アップロード（1件10MBまで）で実績のあるサイズ感を超えるため。副次的に、途中で失敗しても
+成功分は保存され、`2/5件` のような進捗も出せる。
+
+## 4. kintone 側の前提（OP 作業）
+
+app296 に**添付ファイルフィールドを1つ追加**する。フィールドコードは `other_files`。
+API トークンは既存のもの（app296 のレコード閲覧・編集権限）をそのまま使う。
+
+フィールドが存在しない／API トークン未設定／案件が kintone 未連携（`kintone_record_id` が null）の
+いずれでも、UI はカードを表示したうえでアップロードを無効化し、理由を明示する（fail-closed）。
+
+## 5. コンポーネント
+
+| ファイル | 責務 |
+|---|---|
+| `lib/portal/kintone-sync/kintone-write-client.ts` | `uploadFile()` / `downloadFile()` を I/F と REST 実装に追加。`KintoneApiError`（`status` 付き）を導入 |
+| `lib/portal/kintone-sync/case-files.ts`（新規） | `listCaseFiles()` / `appendCaseFiles()`。添付フィールドの読み取りと**追記**ロジック |
+| `lib/portal/case-files.ts`（新規） | 案件アクセス確認（RLS）＋ファイル検証を通す server-mediated 層 |
+| `app/api/applications/[caseId]/files/route.ts`（新規） | 複数ファイル受信・検証・アップロード |
+| `app/api/applications/[caseId]/files/[fileKey]/route.ts`（新規） | ダウンロード／プレビューのプロキシ |
+| `components/portal/other-files-card.tsx`（新規） | 一覧＋「ファイルを追加」（複数選択可） |
+| `app/applications/[caseId]/page.tsx` | カードを差し込み、初期一覧を渡す |
+
+## 6. 追記ロジック（最重要）
+
+kintone の添付ファイルフィールドは PUT で**丸ごと置換**される。既存ファイルを消さないため
+`appendCaseFiles` は以下の手順を取る。
+
+1. レコードを `$revision` 込みで読む
+2. 既存の `fileKey` 配列に新規 `fileKey` を append
+3. `revision` を指定して PUT（楽観ロック）
+4. 409（`GAIA_CO02` = revision 不一致）なら**読み直して1回だけリトライ**
+
+リトライしても 409 なら例外にする（黙って上書きしない）。
+
+## 7. 決定事項
+
+- **ファイル名**: 元のファイル名をそのまま使う。レコード内に置くので案件名の付与は不要
+- **形式・サイズ**: 現状のまま（PDF・画像・Excel、10MB）。既存 `validateUploadFile` を流用
+- **削除**: 実装しない（追加のみ）。誤アップロードは OP が kintone 側で削除する
+- **プレビュー**: 署名 URL は使わず、FunBase のセッション認証を必ず通るプロキシ方式にする
+
+## 8. テスト
+
+`__tests__/portal-case-files.test.ts`
+
+- 既存ファイルが保持されたまま新規が append されること
+- revision 競合（409）で読み直して1回リトライすること
+- リトライしても 409 なら例外になること
+- 添付フィールドが空／未設定でもパースが壊れないこと
+
+`__tests__/portal-kintone-client-methods.test.ts`（追記）
+
+- `uploadFile` が `POST /k/v1/file.json` に multipart で送り `fileKey` を返すこと
+- `downloadFile` が `GET /k/v1/file.json?fileKey=` を叩き本文と Content-Type を返すこと

--- a/lib/portal/case-files.ts
+++ b/lib/portal/case-files.ts
@@ -1,0 +1,238 @@
+import { createClient } from '@/lib/supabase/server'
+import type { ActionResult } from './documents'
+import { validateUploadFile } from './storage'
+import {
+  createKintoneWriteClientFromEnv,
+  type KintoneWriteClient,
+} from './kintone-sync/kintone-write-client'
+import {
+  appendCaseFiles,
+  listCaseFiles,
+  readCaseFile,
+  type CaseFile,
+} from './kintone-sync/case-files'
+
+// 案件の「その他ファイル」の server-mediated 層。
+// アクセス確認はユーザーセッション（RLS）で行い、確認後の kintone 操作は
+// サーバ側の API トークンで行う（クライアントに kintone 認証を渡さない）。
+
+/**
+ * その他ファイルが使えない理由。UI にそのまま出す文言へ変換する。
+ * - no_kintone_link: 案件がまだ kintone と紐付いていない
+ * - no_kintone_auth: kintone 認証が未設定（環境変数）
+ * - error: 一時的な取得失敗（kintone 障害・フィールド未作成・権限不足など）
+ */
+export type CaseFilesBlockedReason = 'no_kintone_link' | 'no_kintone_auth' | 'error'
+
+export interface CaseFilesState {
+  files: CaseFile[]
+  /** アップロード可能なら true。false のとき blockedReason に理由が入る。 */
+  canUpload: boolean
+  blockedReason?: CaseFilesBlockedReason
+}
+
+/** 1ファイルごとのアップロード結果（部分失敗を画面に出すため）。 */
+export interface CaseFileUploadResult {
+  name: string
+  ok: boolean
+  error?: string
+}
+
+/** 1リクエストで受け付ける最大ファイル数（暴走リクエスト対策）。 */
+export const MAX_FILES_PER_REQUEST = 10
+
+type CaseAccess =
+  | { ok: true; kintoneCaseId: string | null }
+  | { ok: false; status: number; error: string }
+
+/**
+ * 案件をユーザーセッション（RLS）で読む。行が返れば「この案件へのアクセス権あり」。
+ * 併せて kintone レコード番号（未連携なら null）を返す。
+ */
+async function loadCaseAccess(caseId: string): Promise<CaseAccess> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return { ok: false, status: 401, error: 'ログインが必要です' }
+  }
+
+  const { data, error } = await supabase
+    .from('visa_application_cases')
+    .select('id, kintone_record_id')
+    .eq('id', caseId)
+    .maybeSingle()
+
+  if (error) {
+    console.error('case access check error:', error)
+    return { ok: false, status: 500, error: 'アクセス確認に失敗しました' }
+  }
+  if (!data) {
+    return { ok: false, status: 404, error: '案件が見つかりません' }
+  }
+
+  const kintoneCaseId = (data as { kintone_record_id: string | null })
+    .kintone_record_id
+  return { ok: true, kintoneCaseId: kintoneCaseId || null }
+}
+
+/** kintone 認証と案件連携が揃っているかを判定する。 */
+function resolveClient(
+  kintoneCaseId: string | null
+):
+  | { ok: true; client: KintoneWriteClient; kintoneCaseId: string }
+  | { ok: false; blockedReason: 'no_kintone_link' | 'no_kintone_auth' } {
+  if (!kintoneCaseId) {
+    return { ok: false, blockedReason: 'no_kintone_link' }
+  }
+  const client = createKintoneWriteClientFromEnv()
+  if (!client) {
+    return { ok: false, blockedReason: 'no_kintone_auth' }
+  }
+  return { ok: true, client, kintoneCaseId }
+}
+
+/**
+ * 案件詳細の初期表示用。アクセス不可・未連携・認証未設定でも throw せず、
+ * 「アップロード不可」の状態として返す（画面には理由を出す）。
+ */
+export async function getCaseFilesState(caseId: string): Promise<CaseFilesState> {
+  const access = await loadCaseAccess(caseId)
+  if (!access.ok) {
+    return { files: [], canUpload: false, blockedReason: 'error' }
+  }
+
+  const resolved = resolveClient(access.kintoneCaseId)
+  if (!resolved.ok) {
+    return { files: [], canUpload: false, blockedReason: resolved.blockedReason }
+  }
+
+  try {
+    const files = await listCaseFiles(resolved.client, resolved.kintoneCaseId)
+    return { files, canUpload: true }
+  } catch (error) {
+    // kintone 障害・添付フィールド未作成・トークン権限不足。ページ全体は壊さない。
+    console.error('listCaseFiles failed:', error)
+    return { files: [], canUpload: false, blockedReason: 'error' }
+  }
+}
+
+/**
+ * その他ファイルを複数アップロードする。
+ * 検証・アップロードは1件ずつ行い、成功した fileKey だけをまとめて案件レコードへ追記する。
+ */
+export async function uploadCaseFiles(params: {
+  caseId: string
+  files: File[]
+}): Promise<ActionResult<{ results: CaseFileUploadResult[] }>> {
+  const { caseId, files } = params
+
+  if (files.length === 0) {
+    return { ok: false, status: 400, error: 'ファイルが指定されていません' }
+  }
+  if (files.length > MAX_FILES_PER_REQUEST) {
+    return {
+      ok: false,
+      status: 400,
+      error: `一度にアップロードできるのは${MAX_FILES_PER_REQUEST}件までです`,
+    }
+  }
+
+  const access = await loadCaseAccess(caseId)
+  if (!access.ok) {
+    return { ok: false, status: access.status, error: access.error }
+  }
+
+  const resolved = resolveClient(access.kintoneCaseId)
+  if (!resolved.ok) {
+    return {
+      ok: false,
+      status: 409,
+      error:
+        resolved.blockedReason === 'no_kintone_link'
+          ? 'この案件はまだ連携されていないため、ファイルをアップロードできません'
+          : 'ファイル連携が設定されていません。管理者にお問い合わせください',
+    }
+  }
+  const { client, kintoneCaseId } = resolved
+
+  const results: CaseFileUploadResult[] = []
+  const fileKeys: string[] = []
+
+  for (const file of files) {
+    const validationError = validateUploadFile({ size: file.size, type: file.type })
+    if (validationError) {
+      results.push({ name: file.name, ok: false, error: validationError })
+      continue
+    }
+    try {
+      const { fileKey } = await client.uploadFile({
+        fileName: file.name,
+        contentType: file.type,
+        body: Buffer.from(await file.arrayBuffer()),
+      })
+      fileKeys.push(fileKey)
+      results.push({ name: file.name, ok: true })
+    } catch (error) {
+      console.error('kintone uploadFile failed:', error)
+      results.push({
+        name: file.name,
+        ok: false,
+        error: 'アップロードに失敗しました',
+      })
+    }
+  }
+
+  if (fileKeys.length > 0) {
+    try {
+      await appendCaseFiles(client, kintoneCaseId, fileKeys)
+    } catch (error) {
+      // レコードへの紐付けに失敗＝どのファイルも保存されていない。成功扱いにしない。
+      console.error('appendCaseFiles failed:', error)
+      return {
+        ok: false,
+        status: 500,
+        error: 'ファイルの保存に失敗しました。時間をおいて再度お試しください',
+      }
+    }
+  }
+
+  // 更新後の一覧は返さない。画面は router.refresh() で
+  // getCaseFilesState を通して取り直すため、ここで取ると二重取得になる。
+  return { ok: true, data: { results } }
+}
+
+/**
+ * その他ファイル1件の本文を返す（プレビュー・ダウンロード用）。
+ * 案件へのアクセス権と「その fileKey がこの案件のものであること」の両方を確認する。
+ */
+export async function downloadCaseFile(params: {
+  caseId: string
+  fileKey: string
+}): Promise<ActionResult<{ name: string; contentType: string; body: Buffer }>> {
+  const access = await loadCaseAccess(params.caseId)
+  if (!access.ok) {
+    return { ok: false, status: access.status, error: access.error }
+  }
+
+  const resolved = resolveClient(access.kintoneCaseId)
+  if (!resolved.ok) {
+    return { ok: false, status: 404, error: 'ファイルが見つかりません' }
+  }
+
+  try {
+    const file = await readCaseFile(
+      resolved.client,
+      resolved.kintoneCaseId,
+      params.fileKey
+    )
+    if (!file) {
+      return { ok: false, status: 404, error: 'ファイルが見つかりません' }
+    }
+    return { ok: true, data: file }
+  } catch (error) {
+    console.error('readCaseFile failed:', error)
+    return { ok: false, status: 500, error: 'ファイルの取得に失敗しました' }
+  }
+}

--- a/lib/portal/kintone-sync/case-files.ts
+++ b/lib/portal/kintone-sync/case-files.ts
@@ -1,0 +1,141 @@
+import {
+  KintoneApiError,
+  type KintoneFileValue,
+  type KintoneReadRecord,
+  type KintoneWriteClient,
+} from './kintone-write-client'
+import { CASE_HUB_APP_ID } from './case-hub'
+
+// 案件の「その他ファイル」＝ app296（就労_ビザ案件管理）レコードの添付ファイルフィールド。
+// チェックリストに載らない任意ファイルの置き場で、Supabase Storage は経由しない。
+//
+// 添付ファイルフィールドは PUT で**丸ごと置換**されるため、追加は必ず
+// 「読む → 既存に append → revision 付きで PUT」で行う（既存ファイルの消失を防ぐ）。
+
+/** app296 に OP が用意する添付ファイルフィールドのコード。 */
+export const OTHER_FILES_FIELD_CODE = 'other_files'
+
+/** 画面に出す1ファイル分。 */
+export interface CaseFile {
+  fileKey: string
+  name: string
+  contentType: string
+  /** バイト数。 */
+  size: number
+}
+
+/** kintone クエリの文字列リテラル用エスケープ（case-hub.ts と同じ規約）。 */
+function quote(value: string): string {
+  return `"${value.replace(/"/g, '\\"')}"`
+}
+
+/** app296 の1レコードを取得する。見つからなければ null。 */
+async function loadRecord(
+  client: KintoneWriteClient,
+  kintoneCaseId: string
+): Promise<KintoneReadRecord | null> {
+  const records = await client.getRecords(
+    CASE_HUB_APP_ID,
+    `$id = ${quote(kintoneCaseId)}`
+  )
+  return records[0] ?? null
+}
+
+/** レコードから添付ファイルフィールドを取り出す。未設定・非配列は空配列。 */
+function readAttachments(record: KintoneReadRecord): KintoneFileValue[] {
+  const value = (record[OTHER_FILES_FIELD_CODE] as { value: unknown } | undefined)
+    ?.value
+  return Array.isArray(value) ? (value as KintoneFileValue[]) : []
+}
+
+/** レコードの $revision。取れなければ undefined（楽観ロック無しで更新する）。 */
+function readRevision(record: KintoneReadRecord): string | undefined {
+  const value = (record.$revision as { value: unknown } | undefined)?.value
+  return value === undefined || value === null || value === ''
+    ? undefined
+    : String(value)
+}
+
+/** 案件に紐づく「その他ファイル」の一覧を返す。レコードが無ければ空配列。 */
+export async function listCaseFiles(
+  client: KintoneWriteClient,
+  kintoneCaseId: string
+): Promise<CaseFile[]> {
+  const record = await loadRecord(client, kintoneCaseId)
+  if (!record) {
+    return []
+  }
+  return readAttachments(record).map((file) => ({
+    fileKey: file.fileKey,
+    name: file.name,
+    contentType: file.contentType,
+    size: Number(file.size) || 0,
+  }))
+}
+
+/**
+ * 案件に紐づく1ファイルの本文を取得する。
+ * **その案件の添付フィールドに載っている fileKey でなければ null**（fileKey を推測して
+ * 他案件のファイルを読むのを防ぐ）。
+ */
+export async function readCaseFile(
+  client: KintoneWriteClient,
+  kintoneCaseId: string,
+  fileKey: string
+): Promise<{ name: string; contentType: string; body: Buffer } | null> {
+  const files = await listCaseFiles(client, kintoneCaseId)
+  const target = files.find((file) => file.fileKey === fileKey)
+  if (!target) {
+    return null
+  }
+  const downloaded = await client.downloadFile(fileKey)
+  return {
+    name: target.name,
+    // 本文の Content-Type を優先し、取れなければレコード側の値を使う。
+    contentType: downloaded.contentType || target.contentType,
+    body: downloaded.body,
+  }
+}
+
+/**
+ * アップロード済みの fileKey を案件レコードの添付フィールドへ**追記**する。
+ * revision で楽観ロックし、競合（409）したら読み直して1回だけリトライする。
+ * リトライしても競合するなら、既存ファイルを消さないために例外にする。
+ */
+export async function appendCaseFiles(
+  client: KintoneWriteClient,
+  kintoneCaseId: string,
+  fileKeys: string[]
+): Promise<void> {
+  if (fileKeys.length === 0) {
+    return
+  }
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const record = await loadRecord(client, kintoneCaseId)
+    if (!record) {
+      throw new Error(`案件レコードが見つかりません（app296 #${kintoneCaseId}）`)
+    }
+
+    const merged = [
+      ...readAttachments(record).map((file) => ({ fileKey: file.fileKey })),
+      ...fileKeys.map((fileKey) => ({ fileKey })),
+    ]
+
+    try {
+      await client.updateRecord(
+        CASE_HUB_APP_ID,
+        kintoneCaseId,
+        { [OTHER_FILES_FIELD_CODE]: { value: merged } },
+        { revision: readRevision(record) }
+      )
+      return
+    } catch (error) {
+      // 409 = revision 不一致（他者が先に更新）。読み直せば追記できる可能性が高い。
+      const isConflict = error instanceof KintoneApiError && error.status === 409
+      if (!isConflict || attempt === 1) {
+        throw error
+      }
+    }
+  }
+}

--- a/lib/portal/kintone-sync/kintone-write-client.ts
+++ b/lib/portal/kintone-sync/kintone-write-client.ts
@@ -16,6 +16,29 @@ export interface KintoneReadRecord {
   [fieldCode: string]: { value: unknown }
 }
 
+/**
+ * kintone API がエラーを返したことを表す例外。HTTP ステータスで分岐したい呼び出し側
+ * （revision 競合=409 のリトライなど）のために status を保持する。
+ */
+export class KintoneApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string
+  ) {
+    super(`kintone API error: ${status} ${message}`)
+    this.name = 'KintoneApiError'
+  }
+}
+
+/** レコード添付ファイルフィールドの1要素（GET したときの形）。 */
+export interface KintoneFileValue {
+  fileKey: string
+  name: string
+  contentType: string
+  /** kintone は文字列で返す。 */
+  size: string
+}
+
 /** kintone レコードコメント1件（GET /k/v1/record/comments.json）。 */
 export interface KintoneRecordComment {
   id: string
@@ -37,11 +60,24 @@ export interface KintoneWriteClient {
     appId: string,
     record: KintoneRecordPayload
   ): Promise<{ id: string; revision: string }>
+  /**
+   * レコードを更新する。opts.revision を渡すと楽観ロックになり、
+   * 他者が先に更新していれば 409（KintoneApiError）になる。
+   */
   updateRecord(
     appId: string,
     id: string,
-    record: KintoneRecordPayload
+    record: KintoneRecordPayload,
+    opts?: { revision?: string }
   ): Promise<{ revision: string }>
+  /** ファイルをアップロードして fileKey を得る（POST /k/v1/file.json）。 */
+  uploadFile(params: {
+    fileName: string
+    contentType: string
+    body: Buffer
+  }): Promise<{ fileKey: string }>
+  /** fileKey でファイル本体を取得する（GET /k/v1/file.json）。 */
+  downloadFile(fileKey: string): Promise<{ body: Buffer; contentType: string }>
   /** プロセス管理のステータスを「アクション名」で進める（PUT /k/v1/record/status.json）。 */
   updateRecordStatus(
     appId: string,
@@ -131,7 +167,7 @@ export class RestKintoneWriteClient implements KintoneWriteClient {
     })
     if (!response.ok) {
       const text = await response.text()
-      throw new Error(`kintone API error: ${response.status} ${text}`)
+      throw new KintoneApiError(response.status, text)
     }
     return (await response.json()) as T
   }
@@ -161,12 +197,58 @@ export class RestKintoneWriteClient implements KintoneWriteClient {
   async updateRecord(
     appId: string,
     id: string,
-    record: KintoneRecordPayload
+    record: KintoneRecordPayload,
+    opts?: { revision?: string }
   ): Promise<{ revision: string }> {
+    const body: Record<string, unknown> = { app: appId, id, record }
+    if (opts?.revision) {
+      body.revision = opts.revision
+    }
     return this.request<{ revision: string }>('/k/v1/record.json', {
       method: 'PUT',
-      body: { app: appId, id, record },
+      body,
     })
+  }
+
+  async uploadFile(params: {
+    fileName: string
+    contentType: string
+    body: Buffer
+  }): Promise<{ fileKey: string }> {
+    // multipart の組み立ては FormData に任せる。Content-Type を自前で付けると boundary が壊れる。
+    const form = new FormData()
+    form.append(
+      'file',
+      new Blob([new Uint8Array(params.body)], { type: params.contentType }),
+      params.fileName
+    )
+    const response = await fetch(`${this.baseUrl}/k/v1/file.json`, {
+      method: 'POST',
+      headers: { ...this.authHeaders },
+      body: form,
+    })
+    if (!response.ok) {
+      throw new KintoneApiError(response.status, await response.text())
+    }
+    return (await response.json()) as { fileKey: string }
+  }
+
+  async downloadFile(
+    fileKey: string
+  ): Promise<{ body: Buffer; contentType: string }> {
+    const params = new URLSearchParams({ fileKey })
+    const response = await fetch(
+      `${this.baseUrl}/k/v1/file.json?${params.toString()}`,
+      { method: 'GET', headers: { ...this.authHeaders } }
+    )
+    if (!response.ok) {
+      throw new KintoneApiError(response.status, await response.text())
+    }
+    return {
+      body: Buffer.from(await response.arrayBuffer()),
+      contentType:
+        response.headers.get('content-type') ?? 'application/octet-stream',
+    }
   }
 
   async updateRecordStatus(

--- a/lib/portal/kintone-sync/types.ts
+++ b/lib/portal/kintone-sync/types.ts
@@ -33,9 +33,17 @@ export interface KintoneSubtableRow {
   value: Record<string, { value: string | number }>
 }
 
-/** kintone レコードの1フィールド値（スカラ or SUBTABLE 行配列）。 */
+/**
+ * 添付ファイルフィールドの1要素（書込時）。アップロード済みの fileKey だけを送る。
+ * 送信した配列でフィールドが**置換**されるので、追記時は既存分も必ず含める。
+ */
+export interface KintoneFileRef {
+  fileKey: string
+}
+
+/** kintone レコードの1フィールド値（スカラ / SUBTABLE 行配列 / 添付ファイル配列）。 */
 export interface KintoneFieldValue {
-  value: KintoneCellValue | KintoneSubtableRow[]
+  value: KintoneCellValue | KintoneSubtableRow[] | KintoneFileRef[]
 }
 
 /** kintone レコード payload（`{ fieldCode: { value } }`）。空フィールドはキー自体を含めない。 */


### PR DESCRIPTION
## 概要

ビザ案件管理で、チェックリストに載らない任意のファイルを**何件でも自由にアップロード**できるようにしました。保存先は kintone app296「就労_ビザ案件管理」のレコード添付ファイルフィールドです。

## なぜ Google Drive ではなく kintone か

既存の Drive ミラーは OP が案件ごとに `drive_folder_url` を手で貼る前提で、貼り忘れると `no_drive_folder` で静かに skip されます。その他ファイルの主保存先としては穴が大きいため、案件レコード内で完結する kintone 添付を選びました。

トレードオフとして kintone の契約ディスク容量を消費します。既存チェックリスト書類の Drive ミラーは変更していません。

## 変更点

| ファイル | 内容 |
|---|---|
| `lib/portal/kintone-sync/kintone-write-client.ts` | `uploadFile()` / `downloadFile()` を追加。`updateRecord` に revision（楽観ロック）オプション、`KintoneApiError`（status 付き）を導入 |
| `lib/portal/kintone-sync/case-files.ts` | 新規。`listCaseFiles` / `appendCaseFiles` / `readCaseFile` |
| `lib/portal/case-files.ts` | 新規。案件アクセス確認（RLS）＋ファイル検証を通す server-mediated 層 |
| `app/api/applications/[caseId]/files/route.ts` | 新規。アップロード |
| `app/api/applications/[caseId]/files/[fileKey]/route.ts` | 新規。プレビュー／ダウンロードのプロキシ |
| `components/portal/other-files-card.tsx` | 新規。一覧＋複数選択アップロード |
| `app/applications/[caseId]/page.tsx` | カードを差し込み |

## レビューで見てほしい点

**既存ファイルを消さないこと** — kintone の添付フィールドは PUT で丸ごと置換されます。`appendCaseFiles` は「revision 込みで読む → 既存に append → revision 指定で PUT → 409 なら読み直して1回リトライ」とし、リトライしても競合するなら黙って上書きせず例外にします。「他者が同時に追加した分も残ること」をテストで固めています。

**他案件のファイルを覗けないこと** — `readCaseFile` は fileKey がその案件の添付一覧に載っているか確認してからダウンロードします。fileKey を推測されても弾きます。プレビューは署名URLではなく、FunBase のセッション認証を必ず通るプロキシ方式です。

**1ファイルずつ送信していること** — API は1リクエストで最大10件受け付けますが、画面は1件ずつ順に送ります。既存の書類アップロード（1件10MB）と同じリクエストサイズに収まり、途中で失敗しても成功分は保存され、`2/5件` の進捗も出せます。

## マージ前に必要な kintone 側の作業

app296 に **添付ファイルフィールド（フィールドコード `other_files`）を1つ追加**してください。API トークンは既存のもの（app296 のレコード閲覧・編集権限）をそのまま使います。

フィールド未作成／未連携案件／トークン未設定のときは、カードは表示されますがアップロードは無効化され、理由が画面に出ます（ページ全体は壊れません）。

## 決めたこと

- ファイル名は元のまま（レコード内なので案件名の付与は不要）
- 形式・サイズは現状維持（PDF・画像・Excel、10MB）。既存 `validateUploadFile` を流用
- 削除は未実装（追加のみ）。誤アップロードは OP が kintone 側で削除

設計は `docs/superpowers/specs/2026-08-05-visa-case-other-files-design.md` に置いています。

## 検証

- `npx vitest run` — **281件すべて成功 / 失敗0**（今回追加15件）
- `npx tsc --noEmit` — エラー183件で**変更前と同数**、変更したファイルにはエラー0件（既存の未解消エラーのみ）
- `npx next build` — Compiled successfully、新ルート2本とも動的ルートとして登録

🤖 Generated with [Claude Code](https://claude.com/claude-code)
