### PR TITLE
feat(portal): kintoneコメントを作業者あてのメンション付きで投稿する

### DIFF
--- a/__tests__/portal-assignee-sync.test.ts
+++ b/__tests__/portal-assignee-sync.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  KINTONE_MENTION_LIMIT,
+  extractKintoneAssigneeCodes,
+  buildAssigneeMentions,
+  applyKintoneAssigneesToCase,
+} from '@/lib/portal/kintone-sync/assignee-sync'
+
+/** visa_application_cases の update(...).eq(...).select(...) を捉える最小モック。 */
+function mockService(opts: { rows?: unknown[]; error?: unknown } = {}) {
+  const updates: unknown[] = []
+  const service = {
+    from: () => ({
+      update: (row: unknown) => {
+        updates.push(row)
+        return {
+          eq: () => ({
+            select: async () => ({
+              data: opts.error ? null : (opts.rows ?? [{ id: 'case-1' }]),
+              error: opts.error ?? null,
+            }),
+          }),
+        }
+      },
+    }),
+    updates,
+  }
+  return service
+}
+
+describe('extractKintoneAssigneeCodes', () => {
+  it('作業者(STATUS_ASSIGNEE)の value からログイン名を取り出す', () => {
+    const record = {
+      作業者: { value: [{ code: 'sato', name: '佐藤　昇' }, { code: 'kato', name: '加藤　美咲' }] },
+    }
+    expect(extractKintoneAssigneeCodes(record)).toEqual(['sato', 'kato'])
+  })
+
+  it('作業者が未設定（空配列）なら空配列（＝キャッシュを消す）', () => {
+    expect(extractKintoneAssigneeCodes({ 作業者: { value: [] } })).toEqual([])
+  })
+
+  it('作業者フィールドが payload に無ければ null（＝キャッシュに触らない）', () => {
+    expect(extractKintoneAssigneeCodes({})).toBeNull()
+    expect(extractKintoneAssigneeCodes({ 作業者: { value: null } })).toBeNull()
+  })
+
+  it('重複コード・空コードは除き、宛先上限(10)で切る', () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({ code: `u${i}`, name: `u${i}` }))
+    const record = {
+      作業者: { value: [{ code: 'sato' }, { code: 'sato' }, { code: '' }, ...many] },
+    }
+    const codes = extractKintoneAssigneeCodes(record)
+    expect(codes).toHaveLength(KINTONE_MENTION_LIMIT)
+    expect(codes!.slice(0, 3)).toEqual(['sato', 'u0', 'u1'])
+  })
+})
+
+describe('buildAssigneeMentions', () => {
+  it('ログイン名を USER 宛先へ変換する', () => {
+    expect(buildAssigneeMentions(['sato', 'kato'])).toEqual([
+      { code: 'sato', type: 'USER' },
+      { code: 'kato', type: 'USER' },
+    ])
+  })
+
+  it('空なら空配列', () => {
+    expect(buildAssigneeMentions([])).toEqual([])
+  })
+})
+
+describe('applyKintoneAssigneesToCase', () => {
+  it('kintone_record_id 一致の案件へ作業者コードを書き込む', async () => {
+    const service = mockService()
+    const res = await applyKintoneAssigneesToCase(service as never, '5', ['sato'])
+    expect(res.updated).toBe(true)
+    expect(service.updates).toEqual([{ kintone_assignee_codes: ['sato'] }])
+  })
+
+  it('未ミラー案件（0件更新）は updated:false', async () => {
+    const service = mockService({ rows: [] })
+    const res = await applyKintoneAssigneesToCase(service as never, '5', ['sato'])
+    expect(res.updated).toBe(false)
+  })
+
+  it('DB エラーは握り潰して updated:false（Webhook を落とさない）', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const service = mockService({ error: { message: 'boom' } })
+    const res = await applyKintoneAssigneesToCase(service as never, '5', ['sato'])
+    expect(res.updated).toBe(false)
+    spy.mockRestore()
+  })
+})

--- a/__tests__/portal-comment-sync.test.ts
+++ b/__tests__/portal-comment-sync.test.ts
@@ -5,6 +5,7 @@ import {
   isFunbaseOriginText,
   pushCommentToKintone,
   importKintoneComment,
+  resolveKintoneCommentTarget,
 } from '@/lib/portal/kintone-sync/comment-sync'
 import type { KintoneWriteClient } from '@/lib/portal/kintone-sync/kintone-write-client'
 
@@ -53,10 +54,17 @@ describe('comment-sync: 純粋ヘルパ', () => {
     expect(isFunbaseOriginText('   [FunBase]: hi')).toBe(true)
     expect(isFunbaseOriginText('普通のコメント')).toBe(false)
   })
+
+  it('isFunbaseOriginText: メンション付きで投稿した echo（宛先名が先頭行に入る）も true', () => {
+    // 取得APIは宛先つきコメントを「宛先名 + 改行 + 本文」で返す（@ は削除される）。
+    expect(isFunbaseOriginText('佐藤　昇 \n[FunBase] 山田: hi')).toBe(true)
+    expect(isFunbaseOriginText('佐藤　昇 \n\n[FunBase] 山田: hi')).toBe(true)
+    expect(isFunbaseOriginText('佐藤　昇 \nkintone から普通の返信')).toBe(false)
+  })
 })
 
 describe('pushCommentToKintone', () => {
-  it('接頭辞つき本文で postRecordComment を呼び id を返す', async () => {
+  it('接頭辞つき本文で postRecordComment を呼び id を返す（作業者なし＝宛先省略）', async () => {
     const client = mockClient()
     const res = await pushCommentToKintone({
       client,
@@ -64,8 +72,116 @@ describe('pushCommentToKintone', () => {
       authorLabel: '山田',
       body: 'hi',
     })
-    expect(client.postRecordComment).toHaveBeenCalledWith('296', '5', '[FunBase] 山田: hi')
+    expect(client.postRecordComment).toHaveBeenCalledWith(
+      '296',
+      '5',
+      '[FunBase] 山田: hi',
+      undefined
+    )
     expect(res).toEqual({ kintoneCommentId: 'kc99' })
+  })
+
+  it('作業者コードを USER 宛先に変換して postRecordComment に渡す', async () => {
+    const client = mockClient()
+    await pushCommentToKintone({
+      client,
+      kintoneRecordId: '5',
+      authorLabel: '山田',
+      body: 'hi',
+      assigneeCodes: ['sato', 'kato'],
+    })
+    expect(client.postRecordComment).toHaveBeenCalledWith('296', '5', '[FunBase] 山田: hi', [
+      { code: 'sato', type: 'USER' },
+      { code: 'kato', type: 'USER' },
+    ])
+  })
+
+  it('キャッシュありなら kintone を読まない', async () => {
+    const client = mockClient()
+    await pushCommentToKintone({
+      client,
+      kintoneRecordId: '5',
+      authorLabel: '山田',
+      body: 'hi',
+      assigneeCodes: ['sato'],
+    })
+    expect(client.getRecords).not.toHaveBeenCalled()
+  })
+
+  it('キャッシュ未同期（空）なら kintone を1回読んで作業者を宛先にする', async () => {
+    const client = mockClient({
+      getRecords: vi.fn().mockResolvedValue([
+        { $id: { value: '5' }, 作業者: { value: [{ code: 'sato', name: '佐藤　昇' }] } },
+      ]),
+    })
+    await pushCommentToKintone({
+      client,
+      kintoneRecordId: '5',
+      authorLabel: '山田',
+      body: 'hi',
+      assigneeCodes: [],
+    })
+    expect(client.getRecords).toHaveBeenCalledWith('296', '$id = "5"')
+    expect(client.postRecordComment).toHaveBeenCalledWith('296', '5', '[FunBase] 山田: hi', [
+      { code: 'sato', type: 'USER' },
+    ])
+  })
+
+  it('フォールバックの読み取りが失敗しても宛先なしで投稿する', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const client = mockClient({
+      getRecords: vi.fn().mockRejectedValue(new Error('boom')),
+    })
+    const res = await pushCommentToKintone({
+      client,
+      kintoneRecordId: '5',
+      authorLabel: '山田',
+      body: 'hi',
+    })
+    expect(res).toEqual({ kintoneCommentId: 'kc99' })
+    expect(client.postRecordComment).toHaveBeenCalledWith(
+      '296',
+      '5',
+      '[FunBase] 山田: hi',
+      undefined
+    )
+    spy.mockRestore()
+  })
+})
+
+describe('resolveKintoneCommentTarget', () => {
+  function mockCaseService(row: unknown) {
+    return {
+      from: () => ({
+        select: () => ({
+          eq: () => ({ maybeSingle: async () => ({ data: row }) }),
+        }),
+      }),
+    }
+  }
+
+  it('レコード番号と作業者キャッシュを返す', async () => {
+    const service = mockCaseService({
+      kintone_record_id: '5',
+      kintone_assignee_codes: ['sato'],
+    })
+    expect(await resolveKintoneCommentTarget(service as never, 'case-1')).toEqual({
+      kintoneRecordId: '5',
+      assigneeCodes: ['sato'],
+    })
+  })
+
+  it('作業者キャッシュが null/未設定でも空配列で返す', async () => {
+    const service = mockCaseService({ kintone_record_id: '5', kintone_assignee_codes: null })
+    expect(await resolveKintoneCommentTarget(service as never, 'case-1')).toEqual({
+      kintoneRecordId: '5',
+      assigneeCodes: [],
+    })
+  })
+
+  it('kintone 未紐付けの案件は null', async () => {
+    const service = mockCaseService({ kintone_record_id: null, kintone_assignee_codes: [] })
+    expect(await resolveKintoneCommentTarget(service as never, 'case-1')).toBeNull()
   })
 })
 

--- a/app/api/kintone/webhook/route.ts
+++ b/app/api/kintone/webhook/route.ts
@@ -15,14 +15,37 @@ import {
 } from '@/lib/portal/kintone-sync/office-doc-sync'
 import { listFilledOfficeDocCodes } from '@/lib/portal/kintone-sync/office-doc-status'
 import { createKintoneWriteClientFromEnv } from '@/lib/portal/kintone-sync/kintone-write-client'
+import {
+  extractKintoneAssigneeCodes,
+  applyKintoneAssigneesToCase,
+} from '@/lib/portal/kintone-sync/assignee-sync'
 import { getServiceClient } from '@/lib/portal/storage'
+import type { KintoneWebhookEvent } from '@/lib/portal/kintone-sync/webhook'
+
+/**
+ * app296 プロセス管理の作業者を案件行へキャッシュする（kintone コメントのメンション宛先）。
+ * payload に作業者フィールドが無いイベントでは何もしない（宛先を黙って消さない）。
+ * 失敗しても Webhook 全体は落とさない。
+ */
+async function cacheAssignees(event: KintoneWebhookEvent): Promise<void> {
+  const codes = extractKintoneAssigneeCodes(event.record)
+  if (codes === null) {
+    return
+  }
+  try {
+    await applyKintoneAssigneesToCase(getServiceClient(), event.recordId, codes)
+  } catch (error) {
+    console.error('kintone assignee cache failed:', error)
+  }
+}
 
 export const runtime = 'nodejs'
 
 // POST /api/kintone/webhook?secret=...
 // kintone「就労_ビザ案件管理」(app296) の Webhook 受信口。
 // 共有シークレット(?secret=)を検証し、レコード追加/更新/削除を FunBase 案件へミラーする。
-// ステータス変更(UPDATE_STATUS)・コメント(ADD_RECORD_COMMENT)は Phase5/6 で処理（当面は受けて no-op）。
+// ステータス変更(UPDATE_STATUS)・コメント(ADD_RECORD_COMMENT)は Phase5/6 で処理する。
+// あわせて、削除以外のイベントで作業者(プロセス管理)を案件行へキャッシュする（コメントのメンション宛先）。
 // kintone Webhook はリトライが弱く30sタイムアウトのため、極力軽く 200 を返す。
 export async function POST(request: NextRequest) {
   // 共有シークレット検証（URL クエリ）。
@@ -50,9 +73,12 @@ export async function POST(request: NextRequest) {
       case 'UPDATE_RECORD':
       case 'DELETE_RECORD': {
         const result = await mirrorCaseFromKintone(event)
+        // DELETE と未解決（tenant/office 不明）は案件行が無いのでここで終わり。
         if (!result.caseId) {
           return NextResponse.json({ ok: true, event: event.type, ...result })
         }
+        // 案件行が出来た後にキャッシュする（ADD_RECORD は upsert 前だと 0 件更新になる）。
+        await cacheAssignees(event)
         // 事業所書類ステータス（doc_status_*）: kintone が正。
         // まず OP の変更を FunBase へ反映し、次に kintone 側が空欄の書類だけ初期化する。
         // 初期化で発火する Webhook は2周目に空欄が無くなるため停止する。
@@ -76,6 +102,8 @@ export async function POST(request: NextRequest) {
       }
       // Phase5: ステータス変更を Supabase に反映（kintone へは再送しない＝ループ防止）。
       case 'UPDATE_STATUS': {
+        // 作業者が変わるのはプロセス管理の操作時＝このイベント。ステータス不明でも先に拾う。
+        await cacheAssignees(event)
         const label = extractKintoneStatusLabel(event.record)
         if (!label) {
           return NextResponse.json({ ok: true, event: 'UPDATE_STATUS', skipped: 'no_status' })

--- a/lib/portal/comments.ts
+++ b/lib/portal/comments.ts
@@ -5,7 +5,7 @@ import { getServiceClient } from './storage'
 import { createKintoneWriteClientFromEnv } from './kintone-sync/kintone-write-client'
 import {
   pushCommentToKintone,
-  resolveKintoneRecordId,
+  resolveKintoneCommentTarget,
 } from './kintone-sync/comment-sync'
 
 type CommentRow = {
@@ -150,18 +150,20 @@ export async function addComment(params: {
 
   // kintone（app296）へ push（紐付け＋認証があれば・ベストエフォート）。
   // 接頭辞 [FunBase] を付けて出すため、戻ってくる Webhook は取り込み側でループ除外される。
+  // 宛先は Webhook でキャッシュした作業者（app296 プロセス管理）。未同期なら宛先なしで投稿する。
   const insertedRow = inserted as CommentRow
   try {
     const client = createKintoneWriteClientFromEnv()
     if (client) {
       const service = getServiceClient()
-      const kintoneRecordId = await resolveKintoneRecordId(service, c.id)
-      if (kintoneRecordId) {
+      const target = await resolveKintoneCommentTarget(service, c.id)
+      if (target) {
         const { kintoneCommentId } = await pushCommentToKintone({
           client,
-          kintoneRecordId,
+          kintoneRecordId: target.kintoneRecordId,
           authorLabel,
           body,
+          assigneeCodes: target.assigneeCodes,
         })
         await service
           .from('case_comments')

--- a/lib/portal/kintone-sync/assignee-sync.ts
+++ b/lib/portal/kintone-sync/assignee-sync.ts
@@ -1,0 +1,71 @@
+import { getServiceClient } from '../storage'
+import type { KintoneCommentMention } from './kintone-write-client'
+
+// Phase6: kintone コメントのメンション宛先＝app296 プロセス管理の「作業者」。
+// 作業者は Webhook(ADD_RECORD / UPDATE_RECORD / UPDATE_STATUS)の record に載ってくるので、
+// 受信のたびに案件行へキャッシュし、コメント投稿時は追加の kintone 読み取り無しで宛先に使う。
+// kintone の宛先は「表示名」ではなく「ログイン名(code)」で解決される点に注意。
+
+type ServiceClient = ReturnType<typeof getServiceClient>
+
+/** app296 の作業者フィールド（STATUS_ASSIGNEE）のフィールドコード。 */
+export const KINTONE_ASSIGNEE_FIELD = '作業者'
+
+/** kintone のコメント宛先の上限（1コメントあたり10件）。超えると API がエラーになる。 */
+export const KINTONE_MENTION_LIMIT = 10
+
+/**
+ * Webhook payload(record) から作業者のログイン名を取り出す。
+ * STATUS_ASSIGNEE の value は `[{ code, name }]`。
+ * @returns 作業者コードの配列。空配列は「作業者が未設定」＝キャッシュを空にする。
+ *   フィールド自体が payload に無い場合は null を返し、呼び出し側はキャッシュに触らない
+ *   （作業者を載せない payload でキャッシュを消してしまうと、宛先が黙って消える）。
+ */
+export function extractKintoneAssigneeCodes(
+  record: Record<string, { value: unknown } | undefined>
+): string[] | null {
+  const raw = record[KINTONE_ASSIGNEE_FIELD]?.value
+  if (!Array.isArray(raw)) {
+    return null
+  }
+  const codes: string[] = []
+  for (const entry of raw) {
+    const code = (entry as { code?: unknown } | null)?.code
+    if (typeof code !== 'string' || code === '' || codes.includes(code)) {
+      continue
+    }
+    codes.push(code)
+    if (codes.length >= KINTONE_MENTION_LIMIT) {
+      break
+    }
+  }
+  return codes
+}
+
+/** 作業者コード → コメント宛先（`comment.mentions[]`）。 */
+export function buildAssigneeMentions(codes: string[]): KintoneCommentMention[] {
+  return codes
+    .slice(0, KINTONE_MENTION_LIMIT)
+    .map((code) => ({ code, type: 'USER' as const }))
+}
+
+/**
+ * 作業者キャッシュを案件行へ書き込む（service-role）。
+ * 未ミラー案件（該当行なし）は 0 件更新の no-op。失敗しても Webhook 全体は落とさない。
+ */
+export async function applyKintoneAssigneesToCase(
+  service: ServiceClient,
+  kintoneRecordId: string,
+  codes: string[]
+): Promise<{ updated: boolean }> {
+  const { data, error } = await service
+    .from('visa_application_cases')
+    .update({ kintone_assignee_codes: codes })
+    .eq('kintone_record_id', kintoneRecordId)
+    .select('id')
+  if (error) {
+    console.error('Error caching kintone assignees:', error)
+    return { updated: false }
+  }
+  return { updated: Array.isArray(data) && data.length > 0 }
+}

--- a/lib/portal/kintone-sync/comment-sync.ts
+++ b/lib/portal/kintone-sync/comment-sync.ts
@@ -1,4 +1,8 @@
 import { getServiceClient } from '../storage'
+import {
+  buildAssigneeMentions,
+  extractKintoneAssigneeCodes,
+} from './assignee-sync'
 import { CASE_HUB_APP_ID } from './case-hub'
 import type { KintoneWriteClient } from './kintone-write-client'
 
@@ -18,41 +22,99 @@ export function buildKintoneCommentText(
   return `${FUNBASE_COMMENT_PREFIX}${who}: ${body}`
 }
 
-/** 受信時、自分（FunBase）が出したコメントの echo かどうか（ループ防止）。 */
+/**
+ * 受信時、自分（FunBase）が出したコメントの echo かどうか（ループ防止）。
+ * 宛先（メンション）つきで投稿したコメントは、取得API/Webhook では
+ * 「宛先名 + 改行 + 本文」の形で返る（`@` は削除される）ため、先頭行だけでなく
+ * 各行の行頭で接頭辞を探す。
+ */
 export function isFunbaseOriginText(text: string): boolean {
-  return text.trimStart().startsWith(FUNBASE_COMMENT_PREFIX)
+  return text
+    .split('\n')
+    .some((line) => line.trimStart().startsWith(FUNBASE_COMMENT_PREFIX))
 }
 
-/** FunBase→kintone: app296 レコードへコメント投稿。返り id を保存に使う。 */
+/**
+ * 作業者キャッシュが空のときに kintone から直接読み直す（ベストエフォート）。
+ * Webhook が一度も来ていない既存案件では案件行が空のままのため、ここで取りに行く。
+ * 読み取り失敗でコメント投稿ごと落とさない（宛先なしで投稿する）。
+ */
+async function fetchAssigneeCodes(
+  client: KintoneWriteClient,
+  kintoneRecordId: string
+): Promise<string[]> {
+  try {
+    const records = await client.getRecords(
+      CASE_HUB_APP_ID,
+      `$id = "${kintoneRecordId}"`
+    )
+    if (records.length === 0) {
+      return []
+    }
+    return extractKintoneAssigneeCodes(records[0]) ?? []
+  } catch (error) {
+    console.error('Error reading kintone assignees for mention:', error)
+    return []
+  }
+}
+
+/**
+ * FunBase→kintone: app296 レコードへコメント投稿。返り id を保存に使う。
+ * assigneeCodes（app296 プロセス管理の作業者のログイン名）を渡すと、その全員宛の
+ * メンションつきで投稿する。kintone は本文中の `@名前` では通知しないため、
+ * 宛先は必ず `comment.mentions` で渡す。
+ * 空（＝Webhook 未受信でキャッシュが無い）のときだけ kintone を読んで補う。
+ */
 export async function pushCommentToKintone(args: {
   client: KintoneWriteClient
   kintoneRecordId: string
   authorLabel: string | null
   body: string
+  assigneeCodes?: string[]
 }): Promise<{ kintoneCommentId: string }> {
   const text = buildKintoneCommentText(args.authorLabel, args.body)
+  const codes =
+    args.assigneeCodes && args.assigneeCodes.length > 0
+      ? args.assigneeCodes
+      : await fetchAssigneeCodes(args.client, args.kintoneRecordId)
+  const mentions = buildAssigneeMentions(codes)
   const res = await args.client.postRecordComment(
     CASE_HUB_APP_ID,
     args.kintoneRecordId,
-    text
+    text,
+    mentions.length > 0 ? mentions : undefined
   )
   return { kintoneCommentId: res.id }
 }
 
-/** caseId → app296 レコード番号（未紐付けは null）。 */
-export async function resolveKintoneRecordId(
+/** コメント投稿先（app296 レコード番号＋メンション宛先の作業者コード）。 */
+export interface KintoneCommentTarget {
+  kintoneRecordId: string
+  /** Webhook 受信時にキャッシュした作業者のログイン名。未同期・未設定なら空。 */
+  assigneeCodes: string[]
+}
+
+/** caseId → コメント投稿先（未紐付けは null）。 */
+export async function resolveKintoneCommentTarget(
   service: ServiceClient,
   caseId: string
-): Promise<string | null> {
+): Promise<KintoneCommentTarget | null> {
   const { data } = await service
     .from('visa_application_cases')
-    .select('kintone_record_id')
+    .select('kintone_record_id, kintone_assignee_codes')
     .eq('id', caseId)
     .maybeSingle()
-  return (
-    (data as { kintone_record_id?: string | null } | null)?.kintone_record_id ??
-    null
-  )
+  const row = data as {
+    kintone_record_id?: string | null
+    kintone_assignee_codes?: string[] | null
+  } | null
+  if (!row?.kintone_record_id) {
+    return null
+  }
+  return {
+    kintoneRecordId: row.kintone_record_id,
+    assigneeCodes: row.kintone_assignee_codes ?? [],
+  }
 }
 
 export interface CaseKey {


### PR DESCRIPTION
## 概要

FunBase のコメントを kintone に連携するとき、**app296「就労_ビザ案件管理」の作業者あてにメンションを付けて投稿する**ようにします。

kintone のコメントは**本文中の `@名前` では通知されません**。`POST /k/v1/record/comment.json` の `comment.mentions[].code` に**ログイン名**を渡すのが唯一の方法です（[API ドキュメント](https://cybozu.dev/ja/kintone/docs/rest-api/records/add-comment/)）。

## 依存

- **funtoco/fun-base-infra#75**（`kintone_assignee_codes` 列の追加）が先にマージされている必要があります
- マージ後、`supabase` サブモジュールのポインタ更新が必要です

## 実装

### 作業者の受信・キャッシュ（新規 `lib/portal/kintone-sync/assignee-sync.ts`）

宛先に使う「作業者」はプロセス管理の `STATUS_ASSIGNEE` フィールドで、Webhook の `record` に載ってきます。

- `extractKintoneAssigneeCodes()` — `record['作業者'].value[].code` を抽出。重複除去、kintone の宛先上限10件で切る
- `buildAssigneeMentions()` — `[{ code, type: 'USER' }]` に変換
- `applyKintoneAssigneesToCase()` — `kintone_record_id` 一致の案件行へ書き込み

Webhook 側は `ADD_RECORD` / `UPDATE_RECORD`（案件行が出来た後）と `UPDATE_STATUS`（作業者が変わるのはプロセス管理の操作時＝このイベント）でキャッシュします。

### コメント投稿

`resolveKintoneRecordId` を `resolveKintoneCommentTarget` に置き換え、レコード番号と作業者コードを1クエリで取得して `postRecordComment` に渡します。**通常は追加の kintone API コールはゼロ**です。

Webhook を一度も受けていない既存案件のために、キャッシュが空のときだけレコードを1回読むフォールバックを持たせています。読み取りが失敗しても宛先なしで投稿は続行します（メンション取得の失敗でコメント自体を落とさない）。

## あわせて直したもの: ループ防止の破れ

宛先つきコメントは、取得API/Webhook では **「宛先名 + 改行 + 本文」** の形で返ります（`@` は削除される）。つまり `[FunBase] 山田: hi` が `"高橋 しおり \n[FunBase] 山田: hi"` になり、`isFunbaseOriginText` の先頭一致判定が効かなくなって、**自分の投稿が FunBase に逆輸入されます**。各行の行頭で接頭辞を探す形に変更しました。

## 設計上の判断

**作業者フィールドが payload に無いイベントではキャッシュに触りません**（`extractKintoneAssigneeCodes` が `null` を返す）。空配列で上書きすると宛先が黙って消えるためです。作業者が明示的に外された（`value: []`）ときだけクリアします。

## テスト

```bash
npm run test
```

308 passed。`__tests__/portal-assignee-sync.test.ts`（9件）と `__tests__/portal-comment-sync.test.ts`（+9件）を追加しています。

`lib/**/*.test.ts` の4スイートが失敗しますが、これは node:test 形式で vitest が拾えないためで、**このブランチの変更前から同じ**です。`npm run typecheck` も変更ファイルにエラーはありません（既存エラーは `tenant-management/` のみ）。

## 動作確認時の注意

`KINTONE_API_TOKEN_APP34` を使う経路では**投稿者が「Administrator」になり**、かつそのトークンに app296 のレコード閲覧権限が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)