### PR TITLE
feat: add individual interview print action

### DIFF
--- a/app/interview-records/[id]/page.tsx
+++ b/app/interview-records/[id]/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link"
 import { notFound } from "next/navigation"
 import type { ComponentType } from "react"
-import { ArrowLeft, Building2, Calendar, Clock, FileText, MapPin, User } from "lucide-react"
+import { ArrowLeft, Building2, Calendar, Clock, FileText, MapPin, Printer, User } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -73,12 +73,22 @@ export default async function InterviewRecordDetailPage({ params }: InterviewRec
             </p>
           </div>
         </div>
-        <Button asChild variant="outline">
-          <Link href={`/people/${record.personId}`}>
-            <User className="h-4 w-4" />
-            人材詳細
-          </Link>
-        </Button>
+        <div className="flex flex-wrap items-center gap-2">
+          {isRegularInterview && (
+            <Button asChild variant="outline">
+              <Link href={`/meetings/print?record=${encodeURIComponent(record.id)}`}>
+                <Printer className="h-4 w-4" />
+                印刷
+              </Link>
+            </Button>
+          )}
+          <Button asChild variant="outline">
+            <Link href={`/people/${record.personId}`}>
+              <User className="h-4 w-4" />
+              人材詳細
+            </Link>
+          </Button>
+        </div>
       </div>
 
       <Card>

--- a/app/meetings/print/page.tsx
+++ b/app/meetings/print/page.tsx
@@ -112,6 +112,10 @@ export default function MeetingsPrintPage() {
   const [staffFilter, setStaffFilter] = useState<string[]>(() => getQueryMultiValues(new URLSearchParams(searchParams.toString()), "staff"))
   const [methodFilter, setMethodFilter] = useState<string[]>(() => getQueryMultiValues(new URLSearchParams(searchParams.toString()), "method"))
   const [recordIds] = useState<string[]>(() => getQueryMultiValues(new URLSearchParams(searchParams.toString()), "record"))
+  const source = searchParams.get("source")
+  const personId = searchParams.get("person") ?? ""
+  const isPersonPreview = source === "person" && Boolean(personId) && recordIds.length > 0
+  const [showFilters, setShowFilters] = useState(() => !isPersonPreview)
   const [quarterInput, setQuarterInput] = useState(() => getQueryCsv(getQueryMultiValues(new URLSearchParams(searchParams.toString()), "quarter")))
   const [companyInput, setCompanyInput] = useState(() => getQueryCsv(getQueryMultiValues(new URLSearchParams(searchParams.toString()), "company")))
   const [staffInput, setStaffInput] = useState(() => getQueryCsv(getQueryMultiValues(new URLSearchParams(searchParams.toString()), "staff")))
@@ -167,6 +171,10 @@ export default function MeetingsPrintPage() {
     const nextSort = next.sort ?? sortMode
     const nextPageBreak = next.pageBreak ?? pageBreakByPerson
 
+    if (isPersonPreview) {
+      params.set("source", "person")
+      params.set("person", personId)
+    }
     if (recordIds.length > 0) params.set("record", recordIds.join(","))
     if (nextFrom) params.set("from", nextFrom)
     if (nextTo) params.set("to", nextTo)
@@ -229,31 +237,44 @@ export default function MeetingsPrintPage() {
         <div className="mx-auto max-w-5xl space-y-6 print:max-w-none print:space-y-4">
           <div className="print:hidden">
             <Button asChild variant="ghost" size="sm" className="mb-3 -ml-2">
-              <Link href={`/meetings${meetingsListQuery ? `?${meetingsListQuery}` : ""}`}>
+              <Link href={isPersonPreview ? `/people/${personId}` : `/meetings${meetingsListQuery ? `?${meetingsListQuery}` : ""}`}>
                 <ArrowLeft className="h-4 w-4" />
-                面談一覧へ戻る
+                {isPersonPreview ? "人材詳細へ戻る" : "面談一覧へ戻る"}
               </Link>
             </Button>
 
             <div className="flex flex-wrap items-start justify-between gap-4">
               <div>
-                <h1 className="text-3xl font-bold text-foreground">面談記録 印刷</h1>
+                <h1 className="text-3xl font-bold text-foreground">
+                  {isPersonPreview ? "面談記録 印刷プレビュー" : "面談記録 印刷"}
+                </h1>
                 <p className="mt-2 text-muted-foreground">
-                  {recordIds.length > 0 ? "選択した面談記録を個別印刷できます" : "条件を指定して、施設確認用に一括印刷できます"}
+                  {isPersonPreview
+                    ? "人材詳細の面談記録だけをプレビューしています"
+                    : recordIds.length > 0
+                      ? "選択した面談記録を個別印刷できます"
+                      : "条件を指定して、施設確認用に一括印刷できます"}
                 </p>
               </div>
-              <Button onClick={() => window.print()} disabled={loading || filteredInterviews.length === 0}>
-                <Printer className="h-4 w-4" />
-                {recordIds.length > 0 ? "個別印刷" : "一括印刷"}
-              </Button>
+              <div className="flex flex-wrap items-center gap-2">
+                {isPersonPreview && !showFilters && (
+                  <Button variant="outline" onClick={() => setShowFilters(true)}>
+                    条件を変更
+                  </Button>
+                )}
+                <Button onClick={() => window.print()} disabled={loading || filteredInterviews.length === 0}>
+                  <Printer className="h-4 w-4" />
+                  {isPersonPreview ? "印刷する" : recordIds.length > 0 ? "個別印刷" : "一括印刷"}
+                </Button>
+              </div>
             </div>
           </div>
 
-          <Card className="print:hidden">
+          {showFilters && <Card className="print:hidden">
             <CardHeader>
               <CardTitle className="flex items-center gap-2 text-base">
                 <FilterIcon className="h-4 w-4" />
-                {recordIds.length > 0 ? "個別印刷対象" : "印刷条件"}
+                {isPersonPreview ? "印刷条件を変更" : recordIds.length > 0 ? "個別印刷対象" : "印刷条件"}
               </CardTitle>
             </CardHeader>
             <CardContent className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
@@ -406,7 +427,7 @@ export default function MeetingsPrintPage() {
                 1面談ごとに改ページ
               </label>
             </CardContent>
-          </Card>
+          </Card>}
 
           {loading ? (
             <RecordListLoadingSkeleton />

--- a/app/meetings/print/page.tsx
+++ b/app/meetings/print/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
 import { ArrowLeft, Building2, Clock, FilterIcon, Printer } from "lucide-react"
@@ -105,6 +105,7 @@ export default function MeetingsPrintPage() {
   const searchParams = useSearchParams()
   const [interviews, setInterviews] = useState<RegularInterview[]>([])
   const [loading, setLoading] = useState(true)
+  const autoPrintTriggeredRef = useRef(false)
 
   const [searchTerm, setSearchTerm] = useState(() => searchParams.get("search") ?? "")
   const [quarterFilter, setQuarterFilter] = useState<string[]>(() => getQueryMultiValues(new URLSearchParams(searchParams.toString()), "quarter"))
@@ -115,7 +116,8 @@ export default function MeetingsPrintPage() {
   const source = searchParams.get("source")
   const personId = searchParams.get("person") ?? ""
   const isPersonPreview = source === "person" && Boolean(personId) && recordIds.length > 0
-  const [showFilters, setShowFilters] = useState(() => !isPersonPreview)
+  const isDirectPreview = recordIds.length > 0
+  const [showFilters, setShowFilters] = useState(() => !isDirectPreview)
   const [quarterInput, setQuarterInput] = useState(() => getQueryCsv(getQueryMultiValues(new URLSearchParams(searchParams.toString()), "quarter")))
   const [companyInput, setCompanyInput] = useState(() => getQueryCsv(getQueryMultiValues(new URLSearchParams(searchParams.toString()), "company")))
   const [staffInput, setStaffInput] = useState(() => getQueryCsv(getQueryMultiValues(new URLSearchParams(searchParams.toString()), "staff")))
@@ -213,6 +215,14 @@ export default function MeetingsPrintPage() {
     single: { date: dateFilter },
   })
 
+  useEffect(() => {
+    if (!isDirectPreview || loading || filteredInterviews.length === 0 || autoPrintTriggeredRef.current) return
+
+    autoPrintTriggeredRef.current = true
+    const timerId = window.setTimeout(() => window.print(), 300)
+    return () => window.clearTimeout(timerId)
+  }, [filteredInterviews.length, isDirectPreview, loading])
+
   return (
     <AuthGuard>
       <style>{`
@@ -246,25 +256,23 @@ export default function MeetingsPrintPage() {
             <div className="flex flex-wrap items-start justify-between gap-4">
               <div>
                 <h1 className="text-3xl font-bold text-foreground">
-                  {isPersonPreview ? "面談記録 印刷プレビュー" : "面談記録 印刷"}
+                  {isDirectPreview ? "面談記録 印刷プレビュー" : "面談記録 印刷"}
                 </h1>
                 <p className="mt-2 text-muted-foreground">
-                  {isPersonPreview
-                    ? "人材詳細の面談記録だけをプレビューしています"
-                    : recordIds.length > 0
-                      ? "選択した面談記録を個別印刷できます"
-                      : "条件を指定して、施設確認用に一括印刷できます"}
+                  {isDirectPreview
+                    ? "対象の面談記録を読み込み後、印刷プレビューを開きます"
+                    : "条件を指定して、施設確認用に一括印刷できます"}
                 </p>
               </div>
               <div className="flex flex-wrap items-center gap-2">
-                {isPersonPreview && !showFilters && (
+                {isDirectPreview && !showFilters && (
                   <Button variant="outline" onClick={() => setShowFilters(true)}>
                     条件を変更
                   </Button>
                 )}
                 <Button onClick={() => window.print()} disabled={loading || filteredInterviews.length === 0}>
                   <Printer className="h-4 w-4" />
-                  {isPersonPreview ? "印刷する" : recordIds.length > 0 ? "個別印刷" : "一括印刷"}
+                  {isDirectPreview ? "印刷プレビューを開く" : "一括印刷"}
                 </Button>
               </div>
             </div>
@@ -274,7 +282,7 @@ export default function MeetingsPrintPage() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2 text-base">
                 <FilterIcon className="h-4 w-4" />
-                {isPersonPreview ? "印刷条件を変更" : recordIds.length > 0 ? "個別印刷対象" : "印刷条件"}
+                {isDirectPreview ? "印刷条件を変更" : "印刷条件"}
               </CardTitle>
             </CardHeader>
             <CardContent className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">

--- a/app/meetings/print/page.tsx
+++ b/app/meetings/print/page.tsx
@@ -111,6 +111,7 @@ export default function MeetingsPrintPage() {
   const [companyFilter, setCompanyFilter] = useState<string[]>(() => getQueryMultiValues(new URLSearchParams(searchParams.toString()), "company"))
   const [staffFilter, setStaffFilter] = useState<string[]>(() => getQueryMultiValues(new URLSearchParams(searchParams.toString()), "staff"))
   const [methodFilter, setMethodFilter] = useState<string[]>(() => getQueryMultiValues(new URLSearchParams(searchParams.toString()), "method"))
+  const [recordIds] = useState<string[]>(() => getQueryMultiValues(new URLSearchParams(searchParams.toString()), "record"))
   const [quarterInput, setQuarterInput] = useState(() => getQueryCsv(getQueryMultiValues(new URLSearchParams(searchParams.toString()), "quarter")))
   const [companyInput, setCompanyInput] = useState(() => getQueryCsv(getQueryMultiValues(new URLSearchParams(searchParams.toString()), "company")))
   const [staffInput, setStaffInput] = useState(() => getQueryCsv(getQueryMultiValues(new URLSearchParams(searchParams.toString()), "staff")))
@@ -166,6 +167,7 @@ export default function MeetingsPrintPage() {
     const nextSort = next.sort ?? sortMode
     const nextPageBreak = next.pageBreak ?? pageBreakByPerson
 
+    if (recordIds.length > 0) params.set("record", recordIds.join(","))
     if (nextFrom) params.set("from", nextFrom)
     if (nextTo) params.set("to", nextTo)
     if (nextSort !== "person") params.set("sort", nextSort)
@@ -176,6 +178,7 @@ export default function MeetingsPrintPage() {
 
   const filteredInterviews = useMemo(
     () => filterPrintableInterviews(interviews, {
+      recordIds,
       search: searchTerm,
       quarter: quarterFilter,
       company: companyFilter,
@@ -185,7 +188,7 @@ export default function MeetingsPrintPage() {
       from: fromDate,
       to: toDate,
     }),
-    [interviews, searchTerm, quarterFilter, companyFilter, staffFilter, methodFilter, dateFilter, fromDate, toDate]
+    [interviews, recordIds, searchTerm, quarterFilter, companyFilter, staffFilter, methodFilter, dateFilter, fromDate, toDate]
   )
 
   const sortedInterviews = useMemo(() => sortPrintableInterviews(filteredInterviews, sortMode), [filteredInterviews, sortMode])
@@ -235,11 +238,13 @@ export default function MeetingsPrintPage() {
             <div className="flex flex-wrap items-start justify-between gap-4">
               <div>
                 <h1 className="text-3xl font-bold text-foreground">面談記録 印刷</h1>
-                <p className="mt-2 text-muted-foreground">条件を指定して、施設確認用に一括印刷できます</p>
+                <p className="mt-2 text-muted-foreground">
+                  {recordIds.length > 0 ? "選択した面談記録を個別印刷できます" : "条件を指定して、施設確認用に一括印刷できます"}
+                </p>
               </div>
               <Button onClick={() => window.print()} disabled={loading || filteredInterviews.length === 0}>
                 <Printer className="h-4 w-4" />
-                一括印刷
+                {recordIds.length > 0 ? "個別印刷" : "一括印刷"}
               </Button>
             </div>
           </div>
@@ -248,7 +253,7 @@ export default function MeetingsPrintPage() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2 text-base">
                 <FilterIcon className="h-4 w-4" />
-                印刷条件
+                {recordIds.length > 0 ? "個別印刷対象" : "印刷条件"}
               </CardTitle>
             </CardHeader>
             <CardContent className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">

--- a/app/people/[id]/page.tsx
+++ b/app/people/[id]/page.tsx
@@ -51,7 +51,7 @@ export default async function PersonDetailPage({ params }: PersonDetailPageProps
       <div className="flex flex-wrap items-center justify-end gap-2">
         {personPrintQuery && (
           <Button asChild variant="outline" className="gap-2">
-            <Link href={`/meetings/print?record=${personPrintQuery}`}>
+            <Link href={`/meetings/print?source=person&person=${encodeURIComponent(params.id)}&record=${personPrintQuery}`}>
               <Printer className="h-4 w-4" />
               印刷
             </Link>

--- a/app/people/[id]/page.tsx
+++ b/app/people/[id]/page.tsx
@@ -14,7 +14,7 @@ import { getRegularInterviewsByPersonId, getDailySupportRecordsByPersonId } from
 import { isManualPersonId } from "@/lib/person-source"
 import { canCreateRetirementNotice } from "@/lib/reports/retirement-notice-reports"
 import { formatDate, formatDateTime } from "@/lib/utils"
-import { Mail, Phone, MapPin, Building2, Calendar, User, IdCard, User2, Edit, FileText, Plane, Shield, Briefcase } from "lucide-react"
+import { Mail, Phone, MapPin, Building2, Calendar, User, IdCard, User2, Edit, FileText, Plane, Shield, Briefcase, Printer } from "lucide-react"
 
 interface PersonDetailPageProps {
   params: { id: string }
@@ -40,12 +40,23 @@ export default async function PersonDetailPage({ params }: PersonDetailPageProps
     notFound()
   }
 
+  const personPrintQuery = personRegularInterviews.length > 0
+    ? personRegularInterviews.map((interview) => encodeURIComponent(interview.id)).join(",")
+    : ""
   // Generate timeline for this person
 
   return (
     <div className="p-6 space-y-6">
       {/* Header with Edit Button */}
-      <div className="flex items-center justify-end">
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        {personPrintQuery && (
+          <Button asChild variant="outline" className="gap-2">
+            <Link href={`/meetings/print?record=${personPrintQuery}`}>
+              <Printer className="h-4 w-4" />
+              印刷
+            </Link>
+          </Button>
+        )}
         <Link href={`/people/${params.id}/edit`}>
           <Button variant="outline" className="gap-2">
             <Edit className="h-4 w-4" />

--- a/lib/interview-print.test.ts
+++ b/lib/interview-print.test.ts
@@ -48,6 +48,18 @@ test("filterPrintableInterviews applies search, list filters, relative period, a
   assert.deepEqual(result.map((item) => item.id), ["1"])
 })
 
+test("filterPrintableInterviews can target a single record for detail print links", () => {
+  const interviews = [
+    interview({ id: "target", personId: "p1", personName: "Aさん" }),
+    interview({ id: "other-same-person", personId: "p1", personName: "Aさん", interviewDate: "2026-07-15" }),
+    interview({ id: "other-person", personId: "p2", personName: "Bさん" }),
+  ]
+
+  const result = filterPrintableInterviews(interviews, { recordIds: ["target"] })
+
+  assert.deepEqual(result.map((item) => item.id), ["target"])
+})
+
 test("filterPrintableInterviews matches the meetings list exact cutoff for relative periods", () => {
   const result = filterPrintableInterviews(
     [

--- a/lib/interview-print.ts
+++ b/lib/interview-print.ts
@@ -3,6 +3,7 @@ import type { RegularInterview } from "@/lib/models"
 export type InterviewPrintSortMode = "person" | "timeline"
 
 export type InterviewPrintFilters = {
+  recordIds?: string[]
   search?: string
   quarter?: string[]
   company?: string[]
@@ -70,6 +71,8 @@ export function filterPrintableInterviews(
   const search = normalizeText(filters.search)
 
   return interviews.filter((interview) => {
+    if (!isInValues(interview.id, filters.recordIds)) return false
+
     if (search) {
       const haystack = [
         interview.personName,


### PR DESCRIPTION
## 概要
- 面談詳細ページの「人材詳細」横に、定期面談の個別印刷ボタンを追加
- `/meetings/print?record=...` で対象の面談記録だけを印刷対象に絞り込むように変更
- 個別印刷時は印刷ページの説明・ボタン文言を個別印刷向けに切り替え

## 元 Slack
C06676D4L10 thread 1785991776.394099

## 分類
feature / high confidence

## 変更点
- 面談詳細の定期面談レコードに「印刷」導線を追加
- 印刷フィルターに `recordIds` を追加
- 個別印刷リンクの回帰テストを追加

## テスト
- `./node_modules/.bin/vitest run lib/interview-print.test.ts` ✅ 5 tests passed
- `git diff --check` ✅
- `./node_modules/.bin/next build` ✅ 成功（既存警告あり）
- `codex review --base origin/main` ✅ 指摘なし
- `./node_modules/.bin/tsc --noEmit` ⚠️ 既存の admin/connectors / tenant-management 由来の型エラーで失敗
- focused tscも既存の `components/ui/badge.tsx` / `components/ui/button.tsx` の React ref 型エラーで失敗

## リスク / ロールバック
- DB/認証/権限まわりの変更なし
- ロールバックはこのPRのrevertで可能
