### PR TITLE
feat(skill): マイグレーション採番をマージ前に確認するスキルを追加

### DIFF
--- a/.claude/skills/migration-numbering/SKILL.md
+++ b/.claude/skills/migration-numbering/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: migration-numbering
+description: >-
+  fun-base-infra（supabase サブモジュール）のマイグレーション採番を、マージ直前に確認して
+  必要ならリネームする。以下のときは必ず使うこと：
+  infra の PR をマージしようとしている／マイグレーションを新規に作った／
+  「マイグレが適用されない」「テーブルや列が無い」「PGRST204」「schema cache に無い」を調べている／
+  db-migrate-production ワークフローが failure になった／supabase db push の結果を確認したい。
+  マイグレーション・採番・db push・infra の PR という話題なら、明示的に頼まれなくても発動する。
+---
+
+# マイグレーション採番チェック
+
+## なぜ必要か
+
+`supabase db push` は **適用済みの最新より古い採番のマイグレーションを、警告もエラーも出さずスキップする**。
+
+スキップされても push は成功扱いで終わる。気づけるのは main マージ後に走る
+`db-migrate-production` の parity チェックが落ちたときで、そこまで進むと
+「採番し直して再マージ」しか手がない。
+
+実際に 2026-08 だけで #67 / #74 / #75 の3本がこれを踏んでいる。#75 に至っては
+`kintone_assignee_codes` 列が入らないまま本番に出て、Webhook が叩かれるたびに
+`PGRST204 Could not find the column ... in the schema cache` を出し続けていた。
+
+並行開発中は採番がぶつかりやすい。**マージ直前に必ず確認する。**
+
+## 手順
+
+### 1. 基準になる2つの数字を取る
+
+判定の基準は次の大きい方。
+
+| | 取り方 |
+|---|---|
+| main の最新採番 | `git ls-tree --name-only origin/main migrations/` の最大 |
+| 本番の適用済み最新 | Supabase MCP で fun-studio（`xnntfgsfcvhdvelfpbvz`）に SQL |
+
+```sql
+SELECT max(version) FROM supabase_migrations.schema_migrations;
+```
+
+main にまだ未適用のマイグレーションが積まれていることがあるので、**両方を見る**。
+片方だけだと取りこぼす。
+
+### 2. チェックする
+
+スクリプトはこのスキル配下にあるが、**カレントディレクトリは supabase サブモジュール**で実行する
+（`migrations/` を git で見るため）。
+
+```bash
+cd <リポジトリルート>/supabase
+git fetch origin <対象ブランチ>
+bash ../.claude/skills/migration-numbering/scripts/check-numbering.sh \
+  origin/main FETCH_HEAD <適用済み最新>
+```
+
+worktree の場合はリポジトリルートが worktree のパスになる。`git rev-parse --show-toplevel`
+で確かめてから実行する。
+
+終了コードは 0=問題なし / 1=要リネーム。問題があれば `RENAME:` 行で
+「今のパス → 推奨パス」を出すので、そのとおりに `git mv` する。
+
+### 3. リネームする
+
+```bash
+git mv migrations/<旧>.sql migrations/<新>.sql
+git commit -m "fix: マイグレを再採番する"
+git push origin <ブランチ>
+```
+
+**SQL の中身は変えない。** ファイル名だけ。
+
+コミットメッセージには「なぜ再採番したか」を書く。後から見て
+「同じ内容のファイルがなぜ改名されているのか」が分からなくなるため。
+
+### 4. マージして、適用を確認する
+
+マージ後 `db-migrate-production` が走る。**success を確認するまでが作業**。
+
+```bash
+gh run list --repo funtoco/fun-base-infra --workflow db-migrate-production.yml --limit 1
+```
+
+そのうえで、狙った列やテーブルが実際に増えたかを SQL で確かめる。
+ワークフローが success でも、スキップされていれば何も増えていない。
+
+## 絶対にやってはいけないこと
+
+**適用済みのマイグレーションを採番し直さない。**
+
+`schema_migrations` に記録された version とファイル名が食い違い、parity チェックが
+永久に落ちる。リネームしてよいのは**まだどの環境にも適用されていないもの**だけ。
+
+適用済みかどうかは必ず SQL で確認する。ファイル名や git 履歴からは分からない。
+
+```sql
+SELECT version FROM supabase_migrations.schema_migrations ORDER BY version DESC LIMIT 5;
+```
+
+## 複数のPRをまとめて直さない
+
+提案採番は「基準の翌日」から作るので、**基準が動かないうちに複数PRを直すと同じ番号になる**。
+
+1本ずつ、マージ直前にやる。1本マージすれば main の最新が動き、次の提案も自然にずれる。
+
+## 落とし穴
+
+- **リネームは `git diff --diff-filter=A` に映らない**。採番し直し自体がリネーム(R)なので、
+  差分を見るときは `AR` を使う。`A` だけだと採番ミスを見逃す
+- **`db push --dry-run` はスキップを教えてくれない**。「適用するものが無い」と
+  「適用対象を飛ばした」を区別しない
+- **`--include-all` を使えば古い採番でも適用できる**が、履歴が順不同のまま残る。
+  一度使うと以後ずっと必要になるので、採番し直す方を選ぶ
+- **`migration-replay` の CI は通る**。あれは `db reset` でゼロから再生するだけで、
+  本番の適用状況とは無関係。緑でも安心材料にならない
+
+## 参考
+
+- 本番プロジェクト: fun-studio / `xnntfgsfcvhdvelfpbvz`
+- 適用ワークフロー: `.github/workflows/db-migrate-production.yml`（main の `migrations/**` 変更で発火）
+- ブランチ保護: `main` は `migration-replay` 必須・`strict: true`（マージ前に最新化が必要）

--- a/.claude/skills/migration-numbering/scripts/check-numbering.sh
+++ b/.claude/skills/migration-numbering/scripts/check-numbering.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# fun-base-infra のマイグレーション採番が安全かを判定する。
+#
+# 使い方（supabase サブモジュール内で実行）:
+#   check-numbering.sh <base-ref> <head-ref> [applied-max]
+#     base-ref    比較元。通常 origin/main
+#     head-ref    対象ブランチ。通常 HEAD や FETCH_HEAD
+#     applied-max 本番の schema_migrations の最大 version（任意・分かるなら渡す）
+#
+# 出力: 問題があれば「現ファイル名 → 推奨ファイル名」を1行ずつ出す（rename 指示）。
+# 終了コード: 0=問題なし / 1=要リネーム / 2=使い方エラー
+#
+# 提案採番は「基準の翌日」から作る。基準が動かないと提案も動かないので、
+# 複数PRを同時に採番し直すと同じ番号がぶつかる。必ず1本ずつ、マージ直前に実行すること。
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+HEAD_REF="${2:-HEAD}"
+APPLIED_MAX="${3:-0}"
+
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  echo "base-ref '$BASE_REF' が見つかりません。git fetch origin を先に実行してください。" >&2
+  exit 2
+fi
+
+version_of() { basename "$1" | cut -d_ -f1; }
+
+# base 側（通常 main）にある最新の採番
+base_max=0
+while read -r f; do
+  [ -n "$f" ] || continue
+  v="$(version_of "$f")"
+  [[ "$v" =~ ^[0-9]{14}$ ]] || continue
+  [ "$v" -gt "$base_max" ] && base_max="$v"
+done < <(git ls-tree --name-only "$BASE_REF" migrations/ 2>/dev/null || true)
+
+# 基準は「main の最新」と「本番に適用済みの最新」の大きい方。
+# db push は適用済み最新より古い採番を無警告でスキップするため、両方を超える必要がある。
+baseline="$base_max"
+if [[ "$APPLIED_MAX" =~ ^[0-9]{14}$ ]] && [ "$APPLIED_MAX" -gt "$baseline" ]; then
+  baseline="$APPLIED_MAX"
+fi
+
+echo "main の最新採番:       $base_max"
+echo "本番の適用済み最新:     ${APPLIED_MAX:-未指定}"
+echo "基準（これより後ろが必要）: $baseline"
+echo
+
+# このブランチが追加(A)またはリネーム(R)したマイグレーション
+changed="$(git diff --name-only --diff-filter=AR "$BASE_REF...$HEAD_REF" -- 'migrations/*.sql' || true)"
+if [ -z "$changed" ]; then
+  echo "追加・改名されたマイグレーションはありません。"
+  exit 0
+fi
+
+# 提案する採番は基準の「翌日 00:00:00」を起点に、1件ずつ1時間ずらす。
+# 現在時刻を使うと複数PRが同じ分に集中して衝突しやすいため、基準からの相対で決める。
+# 月末（例 20260831 の翌日）を正しく扱うため日付計算は python3 に任せる。
+next_base="$(python3 -c "
+import datetime, sys
+d = datetime.datetime.strptime('${baseline:0:8}', '%Y%m%d').date() + datetime.timedelta(days=1)
+print(d.strftime('%Y%m%d') + '000000')
+")"
+
+need_rename=0
+i=0
+while read -r f; do
+  [ -n "$f" ] || continue
+  v="$(version_of "$f")"
+  name="${f#migrations/}"
+  suffix="${name#*_}"
+
+  if ! [[ "$v" =~ ^[0-9]{14}$ ]]; then
+    echo "NG  $name"
+    echo "    先頭が14桁のタイムスタンプではありません。"
+    need_rename=1
+    continue
+  fi
+
+  if [ "$v" -le "$baseline" ]; then
+    proposed="$(( next_base + i * 10000 ))"
+    echo "NG  $name"
+    echo "    採番 $v は基準 $baseline 以前です。db push に無警告でスキップされます。"
+    echo "    RENAME: migrations/$name -> migrations/${proposed}_${suffix}"
+    need_rename=1
+    i=$(( i + 1 ))
+  else
+    echo "OK  $name ($v > $baseline)"
+  fi
+done <<< "$changed"
+
+exit "$need_rename"


### PR DESCRIPTION
## 背景

`supabase db push` は **適用済みの最新より古い採番のマイグレーションを、警告もエラーも出さずスキップします**。push 自体は成功で終わります。

気づけるのは main マージ後の `db-migrate-production` の parity チェックが落ちたときで、そこまで進むと再採番して作り直すしかありません。2026-08 だけで #67 / #74 / #75 の3本が踏んでいます。#75 は `kintone_assignee_codes` 列が入らないまま本番に出て、Webhook のたびに `PGRST204` を出し続けていました。

一度 CI ゲート（fun-base-infra#78）で塞ぎましたが、**CI ではなくマージ直前に Claude 側で確認・リネームする運用**に変更する方針になったため、そちらを revert して本スキルを用意します。

- fun-base-infra#79（#78 の revert）
- 先行してリネームしていた infra #72 / #65 も元の採番へ戻し済み

## 変更内容

`.claude/skills/migration-numbering/` を追加します。

- **SKILL.md** — 発動条件、手順、やってはいけないこと
- **scripts/check-numbering.sh** — 採番判定とリネーム先の提案

### 判定基準

**main の最新採番** と **本番の適用済み最新** の**大きい方**を基準にします。片方だけだと取りこぼします（main に未適用のものが積まれている場合がある）。

### 明記した落とし穴

実際に踏んだものだけを書いています。

- **適用済みのマイグレーションは絶対に採番し直さない**。`schema_migrations` と食い違って parity が永久に落ちる
- **複数PRをまとめて直さない**。提案採番は基準の翌日から作るので、基準が動かないうちに直すと同じ番号になる。1本ずつマージ直前に
- **リネームは `--diff-filter=A` に映らない**。採番し直し自体がリネーム(R)なので `AR` で見る
- **`db push --dry-run` はスキップを教えない**
- **`migration-replay` の CI が緑でも安心材料にならない**。`db reset` でゼロから再生するだけで本番の適用状況とは無関係

## 検証

実ブランチに対して手順どおり流して確認しました。

```
$ cd supabase
$ bash ../.claude/skills/migration-numbering/scripts/check-numbering.sh origin/main FETCH_HEAD 20260806010000
main の最新採番:       20260806010000
本番の適用済み最新:     20260806010000
基準（これより後ろが必要）: 20260806010000

NG  20260804165701_allow_empty_office_scope_tenant_wide.sql
    採番 20260804165701 は基準 20260806010000 以前です。db push に無警告でスキップされます。
    RENAME: ... -> migrations/20260807000000_allow_empty_office_scope_tenant_wide.sql
=> exit=1
```

- 採番が正しいブランチでは exit=0
- 月末境界（`20260831` の翌日 → `20260901000000`）も確認済み。日付計算は python3 に任せています
- SKILL.md に書いたコマンドをそのまま実行して動くことを確認しました（当初スクリプトのパスを間違えて書いていたので修正済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)